### PR TITLE
[Bounty #78] Add user activity logs

### DIFF
--- a/middleware/activityLogger.js
+++ b/middleware/activityLogger.js
@@ -1,0 +1,3 @@
+const { activityLogger } = require('../services/activityLogService');
+
+module.exports = activityLogger;

--- a/models/ActivityLog.js
+++ b/models/ActivityLog.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const ActivityLogSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null, index: true },
+    action: { type: String, required: true, trim: true, index: true },
+    timestamp: { type: Date, default: Date.now, index: true },
+    ip: { type: String, default: null },
+    userAgent: { type: String, default: null },
+    method: { type: String, default: null },
+    path: { type: String, default: null, index: true },
+    statusCode: { type: Number, default: null, index: true },
+    resourceType: { type: String, default: null, index: true },
+    resourceId: { type: mongoose.Schema.Types.Mixed, default: null, index: true },
+    metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  },
+  { timestamps: true }
+);
+
+ActivityLogSchema.index({ user: 1, timestamp: -1 });
+ActivityLogSchema.index({ action: 1, timestamp: -1 });
+ActivityLogSchema.index({ resourceType: 1, resourceId: 1, timestamp: -1 });
+
+module.exports = mongoose.model('ActivityLog', ActivityLogSchema);

--- a/models/index.js
+++ b/models/index.js
@@ -8,4 +8,5 @@ module.exports = {
   Transaction: require('./Transaction'),
   Review: require('./Review'),
   WebhookLog: require('./WebhookLog'),
+  ActivityLog: require('./ActivityLog'),
 };

--- a/routes/activity.js
+++ b/routes/activity.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const ActivityLogService = require('../services/activityLogService');
+
+const router = express.Router();
+const adminRouter = express.Router();
+
+function requireAdmin(req, res, next) {
+  if (req.user?.role === 'admin') return next();
+
+  return res.status(403).json({
+    success: false,
+    error: 'Admin privileges required',
+  });
+}
+
+router.get('/me', auth, async (req, res) => {
+  try {
+    const logs = await ActivityLogService.listActivities(req.query, req.user._id);
+    res.json({ success: true, data: logs });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+router.post('/logout', auth, async (req, res) => {
+  try {
+    const log = await ActivityLogService.recordActivity({
+      user: req.user._id,
+      action: 'logout',
+      ip: req.ip,
+      userAgent: req.get('User-Agent') || null,
+      method: req.method,
+      path: req.originalUrl?.split('?')[0] || req.path,
+      statusCode: 200,
+      resourceType: 'auth',
+      metadata: { success: true },
+    });
+
+    res.json({
+      success: true,
+      data: { id: log._id, action: log.action, timestamp: log.timestamp },
+    });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+adminRouter.get('/', auth, requireAdmin, async (req, res) => {
+  try {
+    const logs = await ActivityLogService.listActivities(req.query);
+    res.json({ success: true, data: logs });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+module.exports = router;
+module.exports.adminRouter = adminRouter;

--- a/server.js
+++ b/server.js
@@ -16,6 +16,9 @@ app.use(morgan('dev'));
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
+const activityLogger = require('./middleware/activityLogger');
+app.use(activityLogger());
+
 // ===== DATABASE =====
 mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/myzubster', {
   useNewUrlParser: true,
@@ -63,6 +66,11 @@ app.use('/api/users', userRoutes);
 // Webhook verification routes
 const webhookRoutes = require('./routes/webhook');
 app.use('/api/webhook', webhookRoutes);
+
+// Activity audit log routes
+const activityRoutes = require('./routes/activity');
+app.use('/api/activity', activityRoutes);
+app.use('/api/admin/activity', activityRoutes.adminRouter);
 
 // ===== ERROR HANDLER =====
 app.use((err, req, res, next) => {

--- a/services/activityLogService.js
+++ b/services/activityLogService.js
@@ -1,0 +1,183 @@
+const jwt = require('jsonwebtoken');
+const ActivityLog = require('../models/ActivityLog');
+
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'token',
+  'accesstoken',
+  'refreshtoken',
+  'authorization',
+  'secret',
+  'privateKey',
+  'seed',
+]);
+
+function redact(value, depth = 0) {
+  if (value === null || value === undefined) return value;
+  if (depth > 4) return '[Truncated]';
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 25).map((item) => redact(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value).reduce((safe, [key, item]) => {
+      safe[key] = SENSITIVE_KEYS.has(String(key).toLowerCase()) ? '[Redacted]' : redact(item, depth + 1);
+      return safe;
+    }, {});
+  }
+
+  if (typeof value === 'string' && value.length > 500) {
+    return `${value.slice(0, 500)}...`;
+  }
+
+  return value;
+}
+
+function getTokenPayload(req) {
+  const header = req.get?.('Authorization') || req.headers?.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return null;
+
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET);
+  } catch (error) {
+    return jwt.decode(token);
+  }
+}
+
+function getUserId(req, responseBody) {
+  return (
+    req.user?._id ||
+    req.user?.id ||
+    responseBody?.user?.id ||
+    responseBody?.user?._id ||
+    req.body?.userId ||
+    req.body?.user_id ||
+    getTokenPayload(req)?.id ||
+    null
+  );
+}
+
+function classifyRequest(req) {
+  const method = req.method.toUpperCase();
+  const path = req.originalUrl?.split('?')[0] || req.path || '';
+
+  if (method === 'POST' && path === '/api/auth/login') {
+    return { action: 'login', resourceType: 'auth' };
+  }
+
+  if (method === 'POST' && path === '/api/auth/logout') {
+    return { action: 'logout', resourceType: 'auth' };
+  }
+
+  if (method === 'POST' && path === '/api/orders') {
+    return { action: 'order_creation', resourceType: 'order' };
+  }
+
+  if (
+    method === 'POST' &&
+    (path.startsWith('/api/payments') ||
+      path === '/api/monero/generate-subaddress' ||
+      path.includes('/payment'))
+  ) {
+    return { action: 'payment_initiation', resourceType: 'payment' };
+  }
+
+  if (method === 'POST' && path.startsWith('/api/webhook')) {
+    return { action: 'webhook_event', resourceType: 'webhook' };
+  }
+
+  return null;
+}
+
+function buildFilter(query = {}, forcedUserId = null) {
+  const filter = {};
+
+  if (forcedUserId) filter.user = forcedUserId;
+  if (query.userId && !forcedUserId) filter.user = query.userId;
+  if (query.action) filter.action = query.action;
+  if (query.statusCode) filter.statusCode = Number(query.statusCode);
+  if (query.method) filter.method = String(query.method).toUpperCase();
+  if (query.path) filter.path = query.path;
+
+  if (query.since || query.until) {
+    filter.timestamp = {};
+    if (query.since) filter.timestamp.$gte = new Date(query.since);
+    if (query.until) filter.timestamp.$lte = new Date(query.until);
+  }
+
+  return filter;
+}
+
+async function recordActivity(activity) {
+  return ActivityLog.create({
+    ...activity,
+    metadata: redact(activity.metadata || {}),
+    timestamp: activity.timestamp || new Date(),
+  });
+}
+
+async function listActivities(query = {}, forcedUserId = null) {
+  const limit = Math.min(Number(query.limit) || 50, 200);
+  return ActivityLog.find(buildFilter(query, forcedUserId))
+    .sort({ timestamp: -1 })
+    .limit(limit);
+}
+
+function captureResponseBody(res) {
+  const originalJson = res.json;
+
+  res.json = function patchedJson(body) {
+    res.locals.activityResponseBody = body;
+    return originalJson.call(this, body);
+  };
+}
+
+function activityLogger() {
+  return (req, res, next) => {
+    captureResponseBody(res);
+
+    res.on('finish', () => {
+      const classification = classifyRequest(req);
+      if (!classification) return;
+
+      recordActivity({
+        user: getUserId(req, res.locals.activityResponseBody),
+        action: classification.action,
+        ip: req.ip,
+        userAgent: req.get('User-Agent') || null,
+        method: req.method,
+        path: req.originalUrl?.split('?')[0] || req.path,
+        statusCode: res.statusCode,
+        resourceType: classification.resourceType,
+        resourceId:
+          req.body?.orderId ||
+          req.body?.order_id ||
+          req.body?.paymentId ||
+          req.body?.payment_id ||
+          req.body?.webhookId ||
+          null,
+        metadata: {
+          query: req.query,
+          body: req.body,
+          success: res.statusCode < 400,
+        },
+      }).catch((error) => {
+        console.error('Activity logging failed:', error.message);
+      });
+    });
+
+    next();
+  };
+}
+
+module.exports = {
+  activityLogger,
+  buildFilter,
+  classifyRequest,
+  getUserId,
+  listActivities,
+  recordActivity,
+  redact,
+};

--- a/tests/activityLog.test.js
+++ b/tests/activityLog.test.js
@@ -1,0 +1,88 @@
+const express = require('express');
+const request = require('supertest');
+
+const createdLogs = [];
+
+jest.mock('../models/ActivityLog', () => ({
+  create: jest.fn(async (document) => {
+    const log = {
+      _id: `activity-${createdLogs.length + 1}`,
+      ...document,
+    };
+    createdLogs.push(log);
+    return log;
+  }),
+  find: jest.fn(() => ({
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn(async () => createdLogs),
+  })),
+}));
+
+const ActivityLog = require('../models/ActivityLog');
+const ActivityLogService = require('../services/activityLogService');
+
+describe('Activity logging', () => {
+  beforeEach(() => {
+    createdLogs.length = 0;
+    jest.clearAllMocks();
+  });
+
+  it('classifies login, order, payment, and webhook requests', () => {
+    expect(ActivityLogService.classifyRequest({
+      method: 'POST',
+      originalUrl: '/api/auth/login',
+    }).action).toBe('login');
+
+    expect(ActivityLogService.classifyRequest({
+      method: 'POST',
+      originalUrl: '/api/orders',
+    }).action).toBe('order_creation');
+
+    expect(ActivityLogService.classifyRequest({
+      method: 'POST',
+      originalUrl: '/api/monero/generate-subaddress',
+    }).action).toBe('payment_initiation');
+
+    expect(ActivityLogService.classifyRequest({
+      method: 'POST',
+      originalUrl: '/api/webhook/delivery',
+    }).action).toBe('webhook_event');
+  });
+
+  it('redacts sensitive metadata before writing logs', async () => {
+    await ActivityLogService.recordActivity({
+      action: 'login',
+      metadata: {
+        email: 'user@example.com',
+        password: 'secret',
+        nested: { token: 'jwt' },
+      },
+    });
+
+    expect(createdLogs[0].metadata.password).toBe('[Redacted]');
+    expect(createdLogs[0].metadata.nested.token).toBe('[Redacted]');
+  });
+
+  it('records key requests without blocking the response', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(ActivityLogService.activityLogger());
+    app.post('/api/auth/login', (req, res) => {
+      res.json({ success: true, user: { id: '64b000000000000000000001' } });
+    });
+
+    await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@example.com', password: 'secret' })
+      .expect(200);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(ActivityLog.create).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'login',
+      path: '/api/auth/login',
+      statusCode: 200,
+    }));
+    expect(createdLogs[0].metadata.body.password).toBe('[Redacted]');
+  });
+});


### PR DESCRIPTION
Closes #78

## What changed
- Added an `ActivityLog` MongoDB model for user, action, timestamp, IP address, user agent, route, status code, resource, and sanitized metadata.
- Added a reusable activity logging service and middleware that records login, logout, order creation, payment initiation, and webhook events without blocking the request path.
- Added `GET /api/activity/me` for users to view their own logs and `GET /api/admin/activity` for admins to filter all logs.
- Added `POST /api/activity/logout` to explicitly record logout events for clients that do not already have a logout route.
- Added focused tests for request classification, sensitive metadata redaction, and non-blocking request logging.

## Why
The gateway needs an audit trail for sensitive marketplace actions so users can review their own activity and admins can investigate order, payment, and webhook flows.

## Validation
- `node --check models/ActivityLog.js`
- `node --check services/activityLogService.js`
- `node --check middleware/activityLogger.js`
- `node --check routes/activity.js`
- `node --check models/index.js`
- `node --check server.js`
- `node --check tests/activityLog.test.js`

Note: this Windows checkout cannot fully materialize the repository because the base tree contains filenames invalid on Windows, so I used the same sparse/plumbing workflow as PR #74 and validated the touched files directly.

## Bounty payout
Payout Address: 45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8