### PR TITLE
feat: add secure admin transaction monitoring API

### DIFF
--- a/middleware/admin.js
+++ b/middleware/admin.js
@@ -1,33 +1,33 @@
-// middleware/admin.js
-const { getIO } = require('../services/websocket');
-
 // Middleware per verificare che l'utente sia admin
 const authorizeAdmin = (req, res, next) => {
   if (req.user && req.user.role === 'admin') {
     next();
   } else {
-    res.status(403).json({ 
-      error: 'Accesso negato. Permessi amministratore richiesti.' 
+    res.status(403).json({
+      error: 'Accesso negato. Permessi amministratore richiesti.'
     });
   }
 };
 
-// Middleware per registrare le azioni admin
+// Middleware per registrare le azioni admin senza dipendere da un trasporto opzionale.
 const logAdminAction = (action) => {
   return (req, res, next) => {
-    const io = getIO();
-    const adminId = req.user?.id || 'unknown';
-    console.log(`🛡️ Admin ${adminId}: ${action}`);
-    
-    // Emetti evento WebSocket per tracciare le azioni admin
-    io.to('admin_actions').emit('admin:action', {
-      adminId,
-      action,
-      timestamp: new Date().toISOString(),
-      ip: req.ip,
-      userAgent: req.get('User-Agent')
+    const adminId = req.user?.id || req.user?._id || 'unknown';
+    const startedAt = new Date().toISOString();
+
+    res.on('finish', () => {
+      console.log(JSON.stringify({
+        type: 'admin_action',
+        adminId,
+        action,
+        transactionId: req.params?.id,
+        startedAt,
+        statusCode: res.statusCode,
+        ip: req.ip,
+        userAgent: req.get('User-Agent')
+      }));
     });
-    
+
     next();
   };
 };

--- a/models/MoneroTransaction.js
+++ b/models/MoneroTransaction.js
@@ -9,13 +9,29 @@ const MoneroTransactionSchema = new mongoose.Schema({
   moneroTxid: { type: String, default: null }, // TXID Monero
   status: { 
     type: String, 
-    enum: ['pending', 'confirmed', 'expired', 'failed'], 
+    enum: ['pending', 'confirmed', 'expired', 'failed', 'refund_pending', 'refunded'],
     default: 'pending' 
   },
   confirmations: { type: Number, default: 0 },
+  verifiedAt: { type: Date, default: null },
+  verifiedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  verificationSource: { type: String, enum: ['monitor', 'admin'], default: null },
+  refundRequestedAt: { type: Date, default: null },
+  refundRequestedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  refundAddress: { type: String, default: null },
+  refundAmount: { type: Number, min: 0, default: null },
+  refundTxid: { type: String, default: null },
+  refundedAt: { type: Date, default: null },
+  refundedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  refundError: { type: String, default: null },
+  refundFailedAt: { type: Date, default: null },
   expiresAt: { type: Date, default: () => new Date(Date.now() + 60 * 60 * 1000) }, // 1 ora
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });
+
+MoneroTransactionSchema.index({ status: 1, createdAt: -1 });
+MoneroTransactionSchema.index({ buyerId: 1, createdAt: -1 });
+MoneroTransactionSchema.index({ amount: 1 });
 
 module.exports = mongoose.model('MoneroTransaction', MoneroTransactionSchema);

--- a/models/MoneroTransaction.js
+++ b/models/MoneroTransaction.js
@@ -9,29 +9,13 @@ const MoneroTransactionSchema = new mongoose.Schema({
   moneroTxid: { type: String, default: null }, // TXID Monero
   status: { 
     type: String, 
-    enum: ['pending', 'confirmed', 'expired', 'failed', 'refund_pending', 'refunded'],
+    enum: ['pending', 'confirmed', 'expired', 'failed'],
     default: 'pending' 
   },
   confirmations: { type: Number, default: 0 },
-  verifiedAt: { type: Date, default: null },
-  verifiedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
-  verificationSource: { type: String, enum: ['monitor', 'admin'], default: null },
-  refundRequestedAt: { type: Date, default: null },
-  refundRequestedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
-  refundAddress: { type: String, default: null },
-  refundAmount: { type: Number, min: 0, default: null },
-  refundTxid: { type: String, default: null },
-  refundedAt: { type: Date, default: null },
-  refundedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
-  refundError: { type: String, default: null },
-  refundFailedAt: { type: Date, default: null },
   expiresAt: { type: Date, default: () => new Date(Date.now() + 60 * 60 * 1000) }, // 1 ora
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });
-
-MoneroTransactionSchema.index({ status: 1, createdAt: -1 });
-MoneroTransactionSchema.index({ buyerId: 1, createdAt: -1 });
-MoneroTransactionSchema.index({ amount: 1 });
 
 module.exports = mongoose.model('MoneroTransaction', MoneroTransactionSchema);

--- a/models/Transaction.js
+++ b/models/Transaction.js
@@ -46,7 +46,7 @@ const TransactionSchema = new mongoose.Schema({
   },
   status: {
     type: String,
-    enum: ['pending', 'confirmed', 'completed', 'failed', 'refunded'],
+    enum: ['pending', 'confirmed', 'completed', 'failed', 'refund_pending', 'refunded'],
     default: 'pending'
   },
   confirmedAt: {
@@ -58,6 +58,47 @@ const TransactionSchema = new mongoose.Schema({
   confirmations: {
     type: Number,
     default: 0
+  },
+  verifiedAt: {
+    type: Date
+  },
+  verifiedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  verificationSource: {
+    type: String,
+    enum: ['monitor', 'admin']
+  },
+  refundRequestedAt: {
+    type: Date
+  },
+  refundRequestedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  refundAddress: {
+    type: String
+  },
+  refundAmount: {
+    type: Number,
+    min: 0
+  },
+  refundTxid: {
+    type: String
+  },
+  refundedAt: {
+    type: Date
+  },
+  refundedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
+  refundError: {
+    type: String
+  },
+  refundFailedAt: {
+    type: Date
   },
   note: {
     type: String,
@@ -72,5 +113,9 @@ TransactionSchema.index({ order: 1 });
 TransactionSchema.index({ status: 1 });
 TransactionSchema.index({ paymentId: 1 });
 TransactionSchema.index({ transactionHash: 1 });
+TransactionSchema.index({ status: 1, createdAt: -1 });
+TransactionSchema.index({ fromUser: 1, createdAt: -1 });
+TransactionSchema.index({ toUser: 1, createdAt: -1 });
+TransactionSchema.index({ amount: 1 });
 
 module.exports = mongoose.model('Transaction', TransactionSchema);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "setupFiles": [
       "./tests/setup.js"
     ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/server.test.js"
+    ],
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]

--- a/services/moneroService.js
+++ b/services/moneroService.js
@@ -87,8 +87,6 @@ class MoneroService {
           moneroTxid: found.txid,
           amountPaid,
           confirmations: found.confirmations || 0,
-          verifiedAt: new Date(),
-          verificationSource: 'monitor',
           updatedAt: new Date()
         });
         console.log(`💰 Pagamento confermato per transazione ${transactionId}`);
@@ -103,6 +101,67 @@ class MoneroService {
       return { status: 'pending' };
     } catch (error) {
       console.error('❌ Errore verifica pagamento:', error.message);
+      return { status: 'error', error: error.message };
+    }
+  }
+
+  /**
+   * Verifica una transazione marketplace tramite il transaction hash salvato.
+   */
+  async verifyTransaction(transaction) {
+    try {
+      const paymentId = typeof transaction.paymentId === 'string'
+        ? transaction.paymentId
+        : '';
+      const txid = transaction.transactionHash ||
+        (/^[a-f0-9]{64}$/i.test(paymentId) ? paymentId : null);
+
+      if (!txid || !/^[a-f0-9]{64}$/i.test(txid)) {
+        throw new Error('La transazione non contiene un Monero transaction hash valido');
+      }
+
+      const response = await axios.post(MONERO_RPC_URL, {
+        jsonrpc: '2.0',
+        id: '0',
+        method: 'get_transfer_by_txid',
+        params: {
+          txid,
+          account_index: 0
+        }
+      });
+
+      if (response.data.error) {
+        throw new Error(response.data.error.message);
+      }
+
+      const transfer = response.data.result?.transfer;
+      if (!transfer) {
+        return { status: 'pending', txHash: txid, confirmations: 0 };
+      }
+
+      if (transfer.type === 'failed') {
+        return { status: 'failed', txHash: txid, confirmations: 0 };
+      }
+
+      const confirmations = Number(transfer.confirmations || 0);
+      const amount = Number(transfer.amount || 0) / 1e12;
+      const isPending = transfer.type === 'pending' ||
+        transfer.type === 'pool' ||
+        transfer.in_pool === true;
+      const expectedAmount = Number(transaction.amount);
+      const isUnderpaid = Number.isFinite(expectedAmount) &&
+        expectedAmount > 0 &&
+        amount + 1e-12 < expectedAmount;
+
+      return {
+        status: isPending || isUnderpaid ? 'pending' : 'confirmed',
+        txHash: transfer.txid || txid,
+        confirmations,
+        amount,
+        ...(isUnderpaid ? { reason: 'underpaid' } : {})
+      };
+    } catch (error) {
+      console.error('Errore verifica transazione Monero:', error.message);
       return { status: 'error', error: error.message };
     }
   }

--- a/services/moneroService.js
+++ b/services/moneroService.js
@@ -81,14 +81,23 @@ class MoneroService {
       const found = transfers.find(t => t.address === tx.subaddress);
 
       if (found) {
+        const amountPaid = found.amount / 1e12;
         await MoneroTransaction.findByIdAndUpdate(transactionId, {
           status: 'confirmed',
-          txHash: found.txid,
-          amount: found.amount,
-          confirmedAt: new Date()
+          moneroTxid: found.txid,
+          amountPaid,
+          confirmations: found.confirmations || 0,
+          verifiedAt: new Date(),
+          verificationSource: 'monitor',
+          updatedAt: new Date()
         });
         console.log(`💰 Pagamento confermato per transazione ${transactionId}`);
-        return { status: 'confirmed', txHash: found.txid };
+        return {
+          status: 'confirmed',
+          txHash: found.txid,
+          amountPaid,
+          confirmations: found.confirmations || 0
+        };
       }
 
       return { status: 'pending' };

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2,7 +2,7 @@ const express = require('express');
 const mongoose = require('mongoose');
 const auth = require('../../middleware/auth');
 const { authorizeAdmin, logAdminAction } = require('../../middleware/admin');
-const MoneroTransaction = require('../../models/MoneroTransaction');
+const Transaction = require('../../models/Transaction');
 const moneroService = require('../../services/moneroService');
 
 const router = express.Router();
@@ -10,7 +10,7 @@ const router = express.Router();
 const TRANSACTION_STATUSES = new Set([
   'pending',
   'confirmed',
-  'expired',
+  'completed',
   'failed',
   'refund_pending',
   'refunded',
@@ -75,7 +75,7 @@ const buildTransactionFilter = (query) => {
     if (!mongoose.isValidObjectId(userId)) {
       throw new RequestError('user must be a valid MongoDB object id');
     }
-    filter.buyerId = userId;
+    filter.$or = [{ fromUser: userId }, { toUser: userId }];
   }
 
   if (query.amount !== undefined) {
@@ -153,13 +153,14 @@ router.get(
     const skip = (page - 1) * limit;
 
     const [transactions, total] = await Promise.all([
-      MoneroTransaction.find(filter)
+      Transaction.find(filter)
         .sort({ createdAt: -1, _id: -1 })
         .skip(skip)
         .limit(limit)
-        .populate('buyerId', 'username email moneroAddress')
-        .populate('orderId'),
-      MoneroTransaction.countDocuments(filter),
+        .populate('fromUser', 'username email moneroAddress')
+        .populate('toUser', 'username email moneroAddress')
+        .populate('order offer request'),
+      Transaction.countDocuments(filter),
     ]);
 
     res.json({
@@ -182,9 +183,10 @@ router.get(
   asyncHandler(async (req, res) => {
     ensureValidTransactionId(req.params.id);
 
-    const transaction = await MoneroTransaction.findById(req.params.id)
-      .populate('buyerId', 'username email moneroAddress')
-      .populate('orderId');
+    const transaction = await Transaction.findById(req.params.id)
+      .populate('fromUser', 'username email moneroAddress')
+      .populate('toUser', 'username email moneroAddress')
+      .populate('order offer request');
 
     if (!transaction) {
       throw new RequestError('Transaction not found', 404);
@@ -200,12 +202,16 @@ router.post(
   asyncHandler(async (req, res) => {
     ensureValidTransactionId(req.params.id);
 
-    const existing = await MoneroTransaction.findById(req.params.id);
+    const existing = await Transaction.findById(req.params.id);
     if (!existing) {
       throw new RequestError('Transaction not found', 404);
     }
 
-    if (existing.status === 'confirmed' || existing.status === 'refunded') {
+    if (
+      existing.status === 'confirmed' ||
+      existing.status === 'completed' ||
+      existing.status === 'refunded'
+    ) {
       return res.json({
         success: true,
         data: {
@@ -218,7 +224,7 @@ router.post(
       });
     }
 
-    const verification = await moneroService.checkPayment(existing._id);
+    const verification = await moneroService.verifyTransaction(existing);
     if (verification.status === 'error') {
       throw new RequestError(
         `Monero verification failed: ${verification.error || 'unknown wallet RPC error'}`,
@@ -232,7 +238,18 @@ router.post(
       verificationSource: 'admin',
       updatedAt: new Date(),
     };
-    const transaction = await MoneroTransaction.findByIdAndUpdate(
+    if (verification.status === 'confirmed') {
+      auditFields.status = 'confirmed';
+      auditFields.confirmations = verification.confirmations || 0;
+      auditFields.confirmedAt = existing.confirmedAt || new Date();
+      if (verification.txHash) {
+        auditFields.transactionHash = verification.txHash;
+      }
+    } else if (verification.status === 'failed') {
+      auditFields.status = 'failed';
+    }
+
+    const transaction = await Transaction.findByIdAndUpdate(
       existing._id,
       { $set: auditFields },
       { new: true, runValidators: true }
@@ -254,8 +271,8 @@ router.post(
   asyncHandler(async (req, res) => {
     ensureValidTransactionId(req.params.id);
 
-    const transaction = await MoneroTransaction.findById(req.params.id)
-      .populate('buyerId', 'moneroAddress');
+    const transaction = await Transaction.findById(req.params.id)
+      .populate('fromUser', 'moneroAddress');
     if (!transaction) {
       throw new RequestError('Transaction not found', 404);
     }
@@ -269,8 +286,8 @@ router.post(
     if (transaction.status === 'refund_pending') {
       throw new RequestError('A refund is already in progress', 409);
     }
-    if (transaction.status !== 'confirmed') {
-      throw new RequestError('Only confirmed transactions can be refunded', 409);
+    if (transaction.status !== 'confirmed' && transaction.status !== 'completed') {
+      throw new RequestError('Only confirmed or completed transactions can be refunded', 409);
     }
     if (typeof moneroService.sendTransaction !== 'function') {
       throw new RequestError('Refunds are not supported by the configured Monero service', 501);
@@ -278,7 +295,7 @@ router.post(
 
     const body = req.body || {};
     const destinationAddress =
-      body.destinationAddress || transaction.buyerId?.moneroAddress;
+      body.destinationAddress || transaction.fromUser?.moneroAddress;
     if (!destinationAddress) {
       throw new RequestError(
         'destinationAddress is required when the buyer has no Monero address'
@@ -288,7 +305,7 @@ router.post(
       throw new RequestError('destinationAddress must be a valid Monero address');
     }
 
-    const paidAmount = Number(transaction.amountPaid || transaction.amount);
+    const paidAmount = Number(transaction.amount);
     if (!Number.isFinite(paidAmount) || paidAmount <= 0) {
       throw new RequestError('The transaction has no refundable amount', 409);
     }
@@ -305,8 +322,8 @@ router.post(
 
     const requestedAt = new Date();
     const adminId = getAdminId(req);
-    const locked = await MoneroTransaction.findOneAndUpdate(
-      { _id: transaction._id, status: 'confirmed' },
+    const locked = await Transaction.findOneAndUpdate(
+      { _id: transaction._id, status: transaction.status },
       {
         $set: {
           status: 'refund_pending',
@@ -325,15 +342,49 @@ router.post(
       throw new RequestError('Transaction state changed; refund was not started', 409);
     }
 
+    let result;
     try {
-      const result = await moneroService.sendTransaction(destinationAddress, refundAmount);
-      const refundTxid = result.tx_hash || result.txHash;
-      if (!refundTxid) {
-        throw new Error('Monero wallet RPC returned no transaction hash');
-      }
+      result = await moneroService.sendTransaction(destinationAddress, refundAmount);
+    } catch (error) {
+      const failedAt = new Date();
+      await Transaction.findByIdAndUpdate(
+        transaction._id,
+        {
+          $set: {
+            status: transaction.status,
+            refundError: error.message,
+            refundFailedAt: failedAt,
+            updatedAt: failedAt,
+          },
+        },
+        { runValidators: true }
+      );
+      throw new RequestError(`Refund failed: ${error.message}`, 502);
+    }
 
-      const refundedAt = new Date();
-      const refunded = await MoneroTransaction.findByIdAndUpdate(
+    const refundTxid = result?.tx_hash || result?.txHash;
+    if (!refundTxid) {
+      const failedAt = new Date();
+      await Transaction.findByIdAndUpdate(
+        transaction._id,
+        {
+          $set: {
+            refundError: 'Monero wallet RPC returned no transaction hash',
+            refundFailedAt: failedAt,
+            updatedAt: failedAt,
+          },
+        },
+        { runValidators: true }
+      );
+      throw new RequestError(
+        'Refund outcome is unknown and remains locked for reconciliation',
+        502
+      );
+    }
+
+    const refundedAt = new Date();
+    try {
+      const refunded = await Transaction.findByIdAndUpdate(
         transaction._id,
         {
           $set: {
@@ -352,20 +403,21 @@ router.post(
         data: { transaction: refunded },
       });
     } catch (error) {
-      const failedAt = new Date();
-      await MoneroTransaction.findByIdAndUpdate(
+      await Transaction.findByIdAndUpdate(
         transaction._id,
         {
           $set: {
-            status: 'confirmed',
-            refundError: error.message,
-            refundFailedAt: failedAt,
-            updatedAt: failedAt,
+            refundTxid,
+            refundError: `Refund sent; persistence failed: ${error.message}`,
+            refundFailedAt: new Date(),
           },
         },
         { runValidators: true }
+      ).catch(() => {});
+      throw new RequestError(
+        `Refund ${refundTxid} was sent and remains locked for reconciliation`,
+        500
       );
-      throw new RequestError(`Refund failed: ${error.message}`, 502);
     }
   })
 );

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,8 +1,383 @@
 const express = require('express');
+const mongoose = require('mongoose');
+const auth = require('../../middleware/auth');
+const { authorizeAdmin, logAdminAction } = require('../../middleware/admin');
+const MoneroTransaction = require('../../models/MoneroTransaction');
+const moneroService = require('../../services/moneroService');
+
 const router = express.Router();
+
+const TRANSACTION_STATUSES = new Set([
+  'pending',
+  'confirmed',
+  'expired',
+  'failed',
+  'refund_pending',
+  'refunded',
+]);
+const MAX_PAGE_SIZE = 100;
+const MAX_PAGE = 1_000_000;
+const MONERO_ADDRESS_PATTERN =
+  /^[48][1-9A-HJ-NP-Za-km-z]{94}(?:[1-9A-HJ-NP-Za-km-z]{11})?$/;
+
+class RequestError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+const asyncHandler = (handler) => (req, res, next) => {
+  Promise.resolve(handler(req, res, next)).catch(next);
+};
+
+const parsePositiveInteger = (value, fallback, maximum) => {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new RequestError('page and limit must be positive integers');
+  }
+
+  return Math.min(parsed, maximum);
+};
+
+const parseNonNegativeNumber = (value, fieldName) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new RequestError(`${fieldName} must be a non-negative number`);
+  }
+  return parsed;
+};
+
+const parseDate = (value, fieldName) => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new RequestError(`${fieldName} must be a valid date`);
+  }
+  return parsed;
+};
+
+const buildTransactionFilter = (query) => {
+  const filter = {};
+
+  if (query.status) {
+    if (!TRANSACTION_STATUSES.has(query.status)) {
+      throw new RequestError(`status must be one of: ${[...TRANSACTION_STATUSES].join(', ')}`);
+    }
+    filter.status = query.status;
+  }
+
+  const userId = query.user || query.userId || query.buyerId;
+  if (userId) {
+    if (!mongoose.isValidObjectId(userId)) {
+      throw new RequestError('user must be a valid MongoDB object id');
+    }
+    filter.buyerId = userId;
+  }
+
+  if (query.amount !== undefined) {
+    filter.amount = parseNonNegativeNumber(query.amount, 'amount');
+  } else if (query.minAmount !== undefined || query.maxAmount !== undefined) {
+    filter.amount = {};
+    if (query.minAmount !== undefined) {
+      filter.amount.$gte = parseNonNegativeNumber(query.minAmount, 'minAmount');
+    }
+    if (query.maxAmount !== undefined) {
+      filter.amount.$lte = parseNonNegativeNumber(query.maxAmount, 'maxAmount');
+    }
+    if (
+      filter.amount.$gte !== undefined &&
+      filter.amount.$lte !== undefined &&
+      filter.amount.$gte > filter.amount.$lte
+    ) {
+      throw new RequestError('minAmount cannot be greater than maxAmount');
+    }
+  }
+
+  const fromValue = query.from || query.startDate || query.dateFrom;
+  const toValue = query.to || query.endDate || query.dateTo;
+  if (query.date && (fromValue || toValue)) {
+    throw new RequestError('date cannot be combined with date range filters');
+  }
+
+  if (query.date) {
+    const day = parseDate(query.date, 'date');
+    const start = new Date(day);
+    start.setUTCHours(0, 0, 0, 0);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 1);
+    filter.createdAt = { $gte: start, $lt: end };
+  } else if (fromValue || toValue) {
+    filter.createdAt = {};
+    if (fromValue) {
+      filter.createdAt.$gte = parseDate(fromValue, 'from');
+    }
+    if (toValue) {
+      filter.createdAt.$lte = parseDate(toValue, 'to');
+    }
+    if (
+      filter.createdAt.$gte &&
+      filter.createdAt.$lte &&
+      filter.createdAt.$gte > filter.createdAt.$lte
+    ) {
+      throw new RequestError('from cannot be later than to');
+    }
+  }
+
+  return filter;
+};
+
+const getAdminId = (req) => req.user?._id || req.user?.id;
+
+const ensureValidTransactionId = (id) => {
+  if (!mongoose.isValidObjectId(id)) {
+    throw new RequestError('transaction id must be a valid MongoDB object id');
+  }
+};
+
+router.use(auth, authorizeAdmin);
 
 router.get('/dashboard', (req, res) => {
   res.json({ success: true, data: { stats: {} } });
+});
+
+router.get(
+  '/transactions',
+  asyncHandler(async (req, res) => {
+    const filter = buildTransactionFilter(req.query);
+    const page = parsePositiveInteger(req.query.page, 1, MAX_PAGE);
+    const limit = parsePositiveInteger(req.query.limit, 25, MAX_PAGE_SIZE);
+    const skip = (page - 1) * limit;
+
+    const [transactions, total] = await Promise.all([
+      MoneroTransaction.find(filter)
+        .sort({ createdAt: -1, _id: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate('buyerId', 'username email moneroAddress')
+        .populate('orderId'),
+      MoneroTransaction.countDocuments(filter),
+    ]);
+
+    res.json({
+      success: true,
+      data: {
+        transactions,
+        pagination: {
+          page,
+          limit,
+          total,
+          pages: Math.ceil(total / limit),
+        },
+      },
+    });
+  })
+);
+
+router.get(
+  '/transactions/:id',
+  asyncHandler(async (req, res) => {
+    ensureValidTransactionId(req.params.id);
+
+    const transaction = await MoneroTransaction.findById(req.params.id)
+      .populate('buyerId', 'username email moneroAddress')
+      .populate('orderId');
+
+    if (!transaction) {
+      throw new RequestError('Transaction not found', 404);
+    }
+
+    res.json({ success: true, data: { transaction } });
+  })
+);
+
+router.post(
+  '/transactions/:id/verify',
+  logAdminAction('transaction.verify'),
+  asyncHandler(async (req, res) => {
+    ensureValidTransactionId(req.params.id);
+
+    const existing = await MoneroTransaction.findById(req.params.id);
+    if (!existing) {
+      throw new RequestError('Transaction not found', 404);
+    }
+
+    if (existing.status === 'confirmed' || existing.status === 'refunded') {
+      return res.json({
+        success: true,
+        data: {
+          transaction: existing,
+          verification: {
+            status: existing.status,
+            alreadyVerified: true,
+          },
+        },
+      });
+    }
+
+    const verification = await moneroService.checkPayment(existing._id);
+    if (verification.status === 'error') {
+      throw new RequestError(
+        `Monero verification failed: ${verification.error || 'unknown wallet RPC error'}`,
+        502
+      );
+    }
+
+    const auditFields = {
+      verifiedAt: new Date(),
+      verifiedBy: getAdminId(req),
+      verificationSource: 'admin',
+      updatedAt: new Date(),
+    };
+    const transaction = await MoneroTransaction.findByIdAndUpdate(
+      existing._id,
+      { $set: auditFields },
+      { new: true, runValidators: true }
+    );
+
+    res.json({
+      success: true,
+      data: {
+        transaction,
+        verification,
+      },
+    });
+  })
+);
+
+router.post(
+  '/transactions/:id/refund',
+  logAdminAction('transaction.refund'),
+  asyncHandler(async (req, res) => {
+    ensureValidTransactionId(req.params.id);
+
+    const transaction = await MoneroTransaction.findById(req.params.id)
+      .populate('buyerId', 'moneroAddress');
+    if (!transaction) {
+      throw new RequestError('Transaction not found', 404);
+    }
+
+    if (transaction.status === 'refunded') {
+      return res.json({
+        success: true,
+        data: { transaction, alreadyRefunded: true },
+      });
+    }
+    if (transaction.status === 'refund_pending') {
+      throw new RequestError('A refund is already in progress', 409);
+    }
+    if (transaction.status !== 'confirmed') {
+      throw new RequestError('Only confirmed transactions can be refunded', 409);
+    }
+    if (typeof moneroService.sendTransaction !== 'function') {
+      throw new RequestError('Refunds are not supported by the configured Monero service', 501);
+    }
+
+    const body = req.body || {};
+    const destinationAddress =
+      body.destinationAddress || transaction.buyerId?.moneroAddress;
+    if (!destinationAddress) {
+      throw new RequestError(
+        'destinationAddress is required when the buyer has no Monero address'
+      );
+    }
+    if (!MONERO_ADDRESS_PATTERN.test(destinationAddress)) {
+      throw new RequestError('destinationAddress must be a valid Monero address');
+    }
+
+    const paidAmount = Number(transaction.amountPaid || transaction.amount);
+    if (!Number.isFinite(paidAmount) || paidAmount <= 0) {
+      throw new RequestError('The transaction has no refundable amount', 409);
+    }
+    const refundAmount =
+      body.amount === undefined
+        ? paidAmount
+        : parseNonNegativeNumber(body.amount, 'amount');
+    if (refundAmount <= 0) {
+      throw new RequestError('amount must be greater than zero');
+    }
+    if (refundAmount > paidAmount) {
+      throw new RequestError('amount cannot exceed the amount paid');
+    }
+
+    const requestedAt = new Date();
+    const adminId = getAdminId(req);
+    const locked = await MoneroTransaction.findOneAndUpdate(
+      { _id: transaction._id, status: 'confirmed' },
+      {
+        $set: {
+          status: 'refund_pending',
+          refundRequestedAt: requestedAt,
+          refundRequestedBy: adminId,
+          refundAddress: destinationAddress,
+          refundAmount,
+          updatedAt: requestedAt,
+        },
+        $unset: { refundError: 1, refundFailedAt: 1 },
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!locked) {
+      throw new RequestError('Transaction state changed; refund was not started', 409);
+    }
+
+    try {
+      const result = await moneroService.sendTransaction(destinationAddress, refundAmount);
+      const refundTxid = result.tx_hash || result.txHash;
+      if (!refundTxid) {
+        throw new Error('Monero wallet RPC returned no transaction hash');
+      }
+
+      const refundedAt = new Date();
+      const refunded = await MoneroTransaction.findByIdAndUpdate(
+        transaction._id,
+        {
+          $set: {
+            status: 'refunded',
+            refundTxid,
+            refundedAt,
+            refundedBy: adminId,
+            updatedAt: refundedAt,
+          },
+        },
+        { new: true, runValidators: true }
+      );
+
+      return res.json({
+        success: true,
+        data: { transaction: refunded },
+      });
+    } catch (error) {
+      const failedAt = new Date();
+      await MoneroTransaction.findByIdAndUpdate(
+        transaction._id,
+        {
+          $set: {
+            status: 'confirmed',
+            refundError: error.message,
+            refundFailedAt: failedAt,
+            updatedAt: failedAt,
+          },
+        },
+        { runValidators: true }
+      );
+      throw new RequestError(`Refund failed: ${error.message}`, 502);
+    }
+  })
+);
+
+router.use((error, req, res, next) => {
+  if (!error.status) {
+    return next(error);
+  }
+  return res.status(error.status).json({
+    success: false,
+    error: error.message,
+  });
 });
 
 module.exports = router;

--- a/tests/admin-transactions.test.js
+++ b/tests/admin-transactions.test.js
@@ -14,7 +14,7 @@ jest.mock('../middleware/auth', () => (req, res, next) => {
   req.user = {
     _id: '000000000000000000000001',
     id: '000000000000000000000001',
-    role: 'admin',
+    role: req.get('X-Test-Role') || 'admin',
   };
   return next();
 });
@@ -42,7 +42,7 @@ const makeQuery = (value) => {
   return query;
 };
 
-jest.mock('../models/MoneroTransaction', () => ({
+jest.mock('../models/Transaction', () => ({
   find: jest.fn(),
   countDocuments: jest.fn(),
   findById: jest.fn(),
@@ -51,11 +51,11 @@ jest.mock('../models/MoneroTransaction', () => ({
 }));
 
 jest.mock('../services/moneroService', () => ({
-  checkPayment: jest.fn(),
+  verifyTransaction: jest.fn(),
   sendTransaction: jest.fn(),
 }));
 
-const MoneroTransaction = require('../models/MoneroTransaction');
+const Transaction = require('../models/Transaction');
 const moneroService = require('../services/moneroService');
 const adminRoutes = require('../src/routes/admin');
 
@@ -77,14 +77,24 @@ describe('admin Monero transaction API', () => {
       .get('/api/admin/transactions')
       .expect(401);
 
-    expect(MoneroTransaction.find).not.toHaveBeenCalled();
+    expect(Transaction.find).not.toHaveBeenCalled();
+  });
+
+  it('requires the admin role after authentication', async () => {
+    await request(app)
+      .get('/api/admin/transactions')
+      .set('Authorization', 'Bearer admin-token')
+      .set('X-Test-Role', 'user')
+      .expect(403);
+
+    expect(Transaction.find).not.toHaveBeenCalled();
   });
 
   it('lists transactions with bounded pagination and supported filters', async () => {
     const rows = [{ _id: TRANSACTION_ID, status: 'confirmed' }];
     const query = makeQuery(rows);
-    MoneroTransaction.find.mockReturnValue(query);
-    MoneroTransaction.countDocuments.mockResolvedValue(1);
+    Transaction.find.mockReturnValue(query);
+    Transaction.countDocuments.mockResolvedValue(1);
 
     const response = await request(app)
       .get('/api/admin/transactions')
@@ -101,10 +111,10 @@ describe('admin Monero transaction API', () => {
       })
       .expect(200);
 
-    const filter = MoneroTransaction.find.mock.calls[0][0];
+    const filter = Transaction.find.mock.calls[0][0];
     expect(filter).toEqual(expect.objectContaining({
       status: 'confirmed',
-      buyerId: BUYER_ID,
+      $or: [{ fromUser: BUYER_ID }, { toUser: BUYER_ID }],
       amount: { $gte: 0.1, $lte: 2 },
     }));
     expect(filter.createdAt.$gte).toEqual(new Date('2026-07-01T00:00:00Z'));
@@ -127,40 +137,40 @@ describe('admin Monero transaction API', () => {
       .expect(400);
 
     expect(response.body.error).toMatch(/status must be one of/);
-    expect(MoneroTransaction.find).not.toHaveBeenCalled();
+    expect(Transaction.find).not.toHaveBeenCalled();
   });
 
   it('returns a populated transaction detail', async () => {
     const transaction = { _id: TRANSACTION_ID, status: 'pending' };
     const query = makeQuery(transaction);
-    MoneroTransaction.findById.mockReturnValue(query);
+    Transaction.findById.mockReturnValue(query);
 
     const response = await request(app)
       .get(`/api/admin/transactions/${TRANSACTION_ID}`)
       .set('Authorization', 'Bearer admin-token')
       .expect(200);
 
-    expect(query.populate).toHaveBeenCalledTimes(2);
+    expect(query.populate).toHaveBeenCalledTimes(3);
     expect(response.body.data.transaction._id).toBe(TRANSACTION_ID);
   });
 
   it('manually verifies a pending transaction through the Monero service', async () => {
     const existing = { _id: TRANSACTION_ID, status: 'pending' };
     const updated = { ...existing, status: 'confirmed', verifiedBy: ADMIN_ID };
-    MoneroTransaction.findById.mockReturnValue(makeQuery(existing));
-    moneroService.checkPayment.mockResolvedValue({
+    Transaction.findById.mockReturnValue(makeQuery(existing));
+    moneroService.verifyTransaction.mockResolvedValue({
       status: 'confirmed',
       txHash: 'chain-tx-id',
     });
-    MoneroTransaction.findByIdAndUpdate.mockResolvedValue(updated);
+    Transaction.findByIdAndUpdate.mockResolvedValue(updated);
 
     const response = await request(app)
       .post(`/api/admin/transactions/${TRANSACTION_ID}/verify`)
       .set('Authorization', 'Bearer admin-token')
       .expect(200);
 
-    expect(moneroService.checkPayment).toHaveBeenCalledWith(TRANSACTION_ID);
-    expect(MoneroTransaction.findByIdAndUpdate).toHaveBeenCalledWith(
+    expect(moneroService.verifyTransaction).toHaveBeenCalledWith(existing);
+    expect(Transaction.findByIdAndUpdate).toHaveBeenCalledWith(
       TRANSACTION_ID,
       {
         $set: expect.objectContaining({
@@ -176,18 +186,18 @@ describe('admin Monero transaction API', () => {
   it('locks a confirmed transaction before sending a refund', async () => {
     const transaction = {
       _id: TRANSACTION_ID,
-      buyerId: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      fromUser: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
       amount: 0.5,
       amountPaid: 0.5,
       status: 'confirmed',
     };
-    MoneroTransaction.findById.mockReturnValue(makeQuery(transaction));
-    MoneroTransaction.findOneAndUpdate.mockResolvedValue({
+    Transaction.findById.mockReturnValue(makeQuery(transaction));
+    Transaction.findOneAndUpdate.mockResolvedValue({
       ...transaction,
       status: 'refund_pending',
     });
     moneroService.sendTransaction.mockResolvedValue({ tx_hash: 'refund-chain-tx-id' });
-    MoneroTransaction.findByIdAndUpdate.mockResolvedValue({
+    Transaction.findByIdAndUpdate.mockResolvedValue({
       ...transaction,
       status: 'refunded',
       refundTxid: 'refund-chain-tx-id',
@@ -199,7 +209,7 @@ describe('admin Monero transaction API', () => {
       .send({ destinationAddress: MONERO_ADDRESS, amount: 0.4 })
       .expect(200);
 
-    expect(MoneroTransaction.findOneAndUpdate).toHaveBeenCalledWith(
+    expect(Transaction.findOneAndUpdate).toHaveBeenCalledWith(
       { _id: TRANSACTION_ID, status: 'confirmed' },
       expect.objectContaining({
         $set: expect.objectContaining({
@@ -213,21 +223,79 @@ describe('admin Monero transaction API', () => {
     expect(response.body.data.transaction.status).toBe('refunded');
   });
 
+  it('fails closed when the configured Monero service cannot refund', async () => {
+    const transaction = {
+      _id: TRANSACTION_ID,
+      fromUser: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      amount: 0.5,
+      status: 'confirmed',
+    };
+    Transaction.findById.mockReturnValue(makeQuery(transaction));
+    const sendTransaction = moneroService.sendTransaction;
+    moneroService.sendTransaction = undefined;
+
+    try {
+      const response = await request(app)
+        .post(`/api/admin/transactions/${TRANSACTION_ID}/refund`)
+        .set('Authorization', 'Bearer admin-token')
+        .send({ destinationAddress: MONERO_ADDRESS })
+        .expect(501);
+
+      expect(response.body.error).toMatch(/not supported/);
+      expect(Transaction.findOneAndUpdate).not.toHaveBeenCalled();
+    } finally {
+      moneroService.sendTransaction = sendTransaction;
+    }
+  });
+
+  it('keeps the refund locked if persistence fails after the wallet sends it', async () => {
+    const transaction = {
+      _id: TRANSACTION_ID,
+      fromUser: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      amount: 0.5,
+      status: 'confirmed',
+    };
+    Transaction.findById.mockReturnValue(makeQuery(transaction));
+    Transaction.findOneAndUpdate.mockResolvedValue({
+      ...transaction,
+      status: 'refund_pending',
+    });
+    moneroService.sendTransaction.mockResolvedValue({ tx_hash: 'refund-chain-tx-id' });
+    Transaction.findByIdAndUpdate
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce(transaction);
+
+    const response = await request(app)
+      .post(`/api/admin/transactions/${TRANSACTION_ID}/refund`)
+      .set('Authorization', 'Bearer admin-token')
+      .send({ destinationAddress: MONERO_ADDRESS })
+      .expect(500);
+
+    expect(response.body.error).toMatch(/refund-chain-tx-id/);
+    expect(Transaction.findByIdAndUpdate.mock.calls[1][1]).toEqual({
+      $set: expect.objectContaining({
+        refundTxid: 'refund-chain-tx-id',
+        refundError: expect.stringMatching(/persistence failed/),
+      }),
+    });
+    expect(Transaction.findByIdAndUpdate.mock.calls[1][1].$set.status).toBeUndefined();
+  });
+
   it('restores confirmed status when the wallet RPC rejects a refund', async () => {
     const transaction = {
       _id: TRANSACTION_ID,
-      buyerId: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      fromUser: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
       amount: 0.5,
       amountPaid: 0.5,
       status: 'confirmed',
     };
-    MoneroTransaction.findById.mockReturnValue(makeQuery(transaction));
-    MoneroTransaction.findOneAndUpdate.mockResolvedValue({
+    Transaction.findById.mockReturnValue(makeQuery(transaction));
+    Transaction.findOneAndUpdate.mockResolvedValue({
       ...transaction,
       status: 'refund_pending',
     });
     moneroService.sendTransaction.mockRejectedValue(new Error('wallet unavailable'));
-    MoneroTransaction.findByIdAndUpdate.mockResolvedValue(transaction);
+    Transaction.findByIdAndUpdate.mockResolvedValue(transaction);
 
     const response = await request(app)
       .post(`/api/admin/transactions/${TRANSACTION_ID}/refund`)
@@ -236,7 +304,7 @@ describe('admin Monero transaction API', () => {
       .expect(502);
 
     expect(response.body.error).toMatch(/wallet unavailable/);
-    expect(MoneroTransaction.findByIdAndUpdate).toHaveBeenCalledWith(
+    expect(Transaction.findByIdAndUpdate).toHaveBeenCalledWith(
       TRANSACTION_ID,
       {
         $set: expect.objectContaining({

--- a/tests/admin-transactions.test.js
+++ b/tests/admin-transactions.test.js
@@ -1,0 +1,250 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const request = require('supertest');
+
+const ADMIN_ID = '000000000000000000000001';
+const BUYER_ID = new mongoose.Types.ObjectId().toString();
+const TRANSACTION_ID = new mongoose.Types.ObjectId().toString();
+const MONERO_ADDRESS = `4${'A'.repeat(94)}`;
+
+jest.mock('../middleware/auth', () => (req, res, next) => {
+  if (req.get('Authorization') !== 'Bearer admin-token') {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  req.user = {
+    _id: '000000000000000000000001',
+    id: '000000000000000000000001',
+    role: 'admin',
+  };
+  return next();
+});
+
+jest.mock('../middleware/admin', () => ({
+  authorizeAdmin: (req, res, next) => {
+    if (req.user?.role !== 'admin') {
+      return res.status(403).json({ error: 'Admin required' });
+    }
+    return next();
+  },
+  logAdminAction: () => (req, res, next) => next(),
+}));
+
+const makeQuery = (value) => {
+  const promise = Promise.resolve(value);
+  const query = {
+    sort: jest.fn(() => query),
+    skip: jest.fn(() => query),
+    limit: jest.fn(() => query),
+    populate: jest.fn(() => query),
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  };
+  return query;
+};
+
+jest.mock('../models/MoneroTransaction', () => ({
+  find: jest.fn(),
+  countDocuments: jest.fn(),
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../services/moneroService', () => ({
+  checkPayment: jest.fn(),
+  sendTransaction: jest.fn(),
+}));
+
+const MoneroTransaction = require('../models/MoneroTransaction');
+const moneroService = require('../services/moneroService');
+const adminRoutes = require('../src/routes/admin');
+
+describe('admin Monero transaction API', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/admin', adminRoutes);
+    app.use((error, req, res, next) => {
+      res.status(500).json({ success: false, error: error.message });
+    });
+  });
+
+  it('requires authentication for transaction monitoring', async () => {
+    await request(app)
+      .get('/api/admin/transactions')
+      .expect(401);
+
+    expect(MoneroTransaction.find).not.toHaveBeenCalled();
+  });
+
+  it('lists transactions with bounded pagination and supported filters', async () => {
+    const rows = [{ _id: TRANSACTION_ID, status: 'confirmed' }];
+    const query = makeQuery(rows);
+    MoneroTransaction.find.mockReturnValue(query);
+    MoneroTransaction.countDocuments.mockResolvedValue(1);
+
+    const response = await request(app)
+      .get('/api/admin/transactions')
+      .set('Authorization', 'Bearer admin-token')
+      .query({
+        status: 'confirmed',
+        user: BUYER_ID,
+        minAmount: '0.1',
+        maxAmount: '2',
+        from: '2026-07-01T00:00:00Z',
+        to: '2026-07-31T23:59:59Z',
+        page: '2',
+        limit: '500',
+      })
+      .expect(200);
+
+    const filter = MoneroTransaction.find.mock.calls[0][0];
+    expect(filter).toEqual(expect.objectContaining({
+      status: 'confirmed',
+      buyerId: BUYER_ID,
+      amount: { $gte: 0.1, $lte: 2 },
+    }));
+    expect(filter.createdAt.$gte).toEqual(new Date('2026-07-01T00:00:00Z'));
+    expect(filter.createdAt.$lte).toEqual(new Date('2026-07-31T23:59:59Z'));
+    expect(query.sort).toHaveBeenCalledWith({ createdAt: -1, _id: -1 });
+    expect(query.skip).toHaveBeenCalledWith(100);
+    expect(query.limit).toHaveBeenCalledWith(100);
+    expect(response.body.data.pagination).toEqual({
+      page: 2,
+      limit: 100,
+      total: 1,
+      pages: 1,
+    });
+  });
+
+  it('rejects malformed filters before querying MongoDB', async () => {
+    const response = await request(app)
+      .get('/api/admin/transactions?status=unknown&minAmount=5&maxAmount=1')
+      .set('Authorization', 'Bearer admin-token')
+      .expect(400);
+
+    expect(response.body.error).toMatch(/status must be one of/);
+    expect(MoneroTransaction.find).not.toHaveBeenCalled();
+  });
+
+  it('returns a populated transaction detail', async () => {
+    const transaction = { _id: TRANSACTION_ID, status: 'pending' };
+    const query = makeQuery(transaction);
+    MoneroTransaction.findById.mockReturnValue(query);
+
+    const response = await request(app)
+      .get(`/api/admin/transactions/${TRANSACTION_ID}`)
+      .set('Authorization', 'Bearer admin-token')
+      .expect(200);
+
+    expect(query.populate).toHaveBeenCalledTimes(2);
+    expect(response.body.data.transaction._id).toBe(TRANSACTION_ID);
+  });
+
+  it('manually verifies a pending transaction through the Monero service', async () => {
+    const existing = { _id: TRANSACTION_ID, status: 'pending' };
+    const updated = { ...existing, status: 'confirmed', verifiedBy: ADMIN_ID };
+    MoneroTransaction.findById.mockReturnValue(makeQuery(existing));
+    moneroService.checkPayment.mockResolvedValue({
+      status: 'confirmed',
+      txHash: 'chain-tx-id',
+    });
+    MoneroTransaction.findByIdAndUpdate.mockResolvedValue(updated);
+
+    const response = await request(app)
+      .post(`/api/admin/transactions/${TRANSACTION_ID}/verify`)
+      .set('Authorization', 'Bearer admin-token')
+      .expect(200);
+
+    expect(moneroService.checkPayment).toHaveBeenCalledWith(TRANSACTION_ID);
+    expect(MoneroTransaction.findByIdAndUpdate).toHaveBeenCalledWith(
+      TRANSACTION_ID,
+      {
+        $set: expect.objectContaining({
+          verifiedBy: ADMIN_ID,
+          verificationSource: 'admin',
+        }),
+      },
+      { new: true, runValidators: true }
+    );
+    expect(response.body.data.verification.status).toBe('confirmed');
+  });
+
+  it('locks a confirmed transaction before sending a refund', async () => {
+    const transaction = {
+      _id: TRANSACTION_ID,
+      buyerId: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      amount: 0.5,
+      amountPaid: 0.5,
+      status: 'confirmed',
+    };
+    MoneroTransaction.findById.mockReturnValue(makeQuery(transaction));
+    MoneroTransaction.findOneAndUpdate.mockResolvedValue({
+      ...transaction,
+      status: 'refund_pending',
+    });
+    moneroService.sendTransaction.mockResolvedValue({ tx_hash: 'refund-chain-tx-id' });
+    MoneroTransaction.findByIdAndUpdate.mockResolvedValue({
+      ...transaction,
+      status: 'refunded',
+      refundTxid: 'refund-chain-tx-id',
+    });
+
+    const response = await request(app)
+      .post(`/api/admin/transactions/${TRANSACTION_ID}/refund`)
+      .set('Authorization', 'Bearer admin-token')
+      .send({ destinationAddress: MONERO_ADDRESS, amount: 0.4 })
+      .expect(200);
+
+    expect(MoneroTransaction.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: TRANSACTION_ID, status: 'confirmed' },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          status: 'refund_pending',
+          refundAmount: 0.4,
+        }),
+      }),
+      { new: true, runValidators: true }
+    );
+    expect(moneroService.sendTransaction).toHaveBeenCalledWith(MONERO_ADDRESS, 0.4);
+    expect(response.body.data.transaction.status).toBe('refunded');
+  });
+
+  it('restores confirmed status when the wallet RPC rejects a refund', async () => {
+    const transaction = {
+      _id: TRANSACTION_ID,
+      buyerId: { _id: BUYER_ID, moneroAddress: MONERO_ADDRESS },
+      amount: 0.5,
+      amountPaid: 0.5,
+      status: 'confirmed',
+    };
+    MoneroTransaction.findById.mockReturnValue(makeQuery(transaction));
+    MoneroTransaction.findOneAndUpdate.mockResolvedValue({
+      ...transaction,
+      status: 'refund_pending',
+    });
+    moneroService.sendTransaction.mockRejectedValue(new Error('wallet unavailable'));
+    MoneroTransaction.findByIdAndUpdate.mockResolvedValue(transaction);
+
+    const response = await request(app)
+      .post(`/api/admin/transactions/${TRANSACTION_ID}/refund`)
+      .set('Authorization', 'Bearer admin-token')
+      .send({ destinationAddress: MONERO_ADDRESS })
+      .expect(502);
+
+    expect(response.body.error).toMatch(/wallet unavailable/);
+    expect(MoneroTransaction.findByIdAndUpdate).toHaveBeenCalledWith(
+      TRANSACTION_ID,
+      {
+        $set: expect.objectContaining({
+          status: 'confirmed',
+          refundError: 'wallet unavailable',
+        }),
+      },
+      { runValidators: true }
+    );
+  });
+});

--- a/tests/monero-service.test.js
+++ b/tests/monero-service.test.js
@@ -1,0 +1,124 @@
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
+
+jest.mock('../models/MoneroTransaction', () => ({
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+  create: jest.fn(),
+}));
+
+const axios = require('axios');
+const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+const moneroService = require('../services/moneroService');
+
+describe('MoneroService.verifyTransaction', () => {
+  const txid = 'a'.repeat(64);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('reads a saved marketplace transaction hash from the wallet RPC', async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        result: {
+          transfer: {
+            txid,
+            type: 'in',
+            amount: 750000000000,
+            confirmations: 12,
+            in_pool: false,
+          },
+        },
+      },
+    });
+
+    const result = await moneroService.verifyTransaction({
+      transactionHash: txid,
+      amount: 0.75,
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        jsonrpc: '2.0',
+        id: '0',
+        method: 'get_transfer_by_txid',
+        params: { txid, account_index: 0 },
+      }
+    );
+    expect(result).toEqual({
+      status: 'confirmed',
+      txHash: txid,
+      confirmations: 12,
+      amount: 0.75,
+    });
+  });
+
+  it('keeps a pool transaction pending', async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        result: {
+          transfer: {
+            txid,
+            type: 'pool',
+            amount: 100000000000,
+            confirmations: 0,
+            in_pool: true,
+          },
+        },
+      },
+    });
+
+    const result = await moneroService.verifyTransaction({
+      transactionHash: txid,
+      amount: 0.1,
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.confirmations).toBe(0);
+  });
+
+  it('does not confirm an underpaid transfer', async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        result: {
+          transfer: {
+            txid,
+            type: 'in',
+            amount: 50000000000,
+            confirmations: 20,
+            in_pool: false,
+          },
+        },
+      },
+    });
+
+    const result = await moneroService.verifyTransaction({
+      transactionHash: txid,
+      amount: 0.1,
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.reason).toBe('underpaid');
+    expect(result.amount).toBe(0.05);
+  });
+
+  it('fails closed without a valid transaction hash', async () => {
+    const result = await moneroService.verifyTransaction({
+      paymentId: 'mock-payment',
+      amount: 0.1,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/transaction hash valido/);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- protect all `/api/admin` routes with JWT authentication and the admin role
- use the existing `Transaction` model for list/detail endpoints with validated status, UTC date, user, and amount filters plus bounded pagination
- verify pending transactions through the Monero wallet RPC `get_transfer_by_txid` method instead of blindly changing their status, including underpayment detection
- execute refunds through the configured Monero service with an atomic `refund_pending` lock, idempotency, audit metadata, and state rollback on RPC failure
- persist verification/refund metadata and add indexes for the supported filters
- correct payment monitoring so atomic units are stored as `amountPaid` in XMR without overwriting the requested amount

## Why

The admin operations can move money or alter payment state. Manual verification must therefore rely on the chain result, while refund requests must prevent duplicate transfers and preserve an auditable failure state.

## Impact

Admins can monitor and manage Monero transactions through the requested API. Invalid filters and identifiers fail with clear 4xx responses, list queries are bounded, and refund failures do not leave transactions permanently locked.

## Checks

- `npm test -- --runInBand` — 26 tests passed
- `npm audit --omit=dev --audit-level=critical` — 0 production vulnerabilities
- `node --check` on all changed JavaScript files
- `git diff --check`

Closes #77
