### PR TITLE
[BOUNTY #98] Add garden IoT sensor API

### DIFF
--- a/models/GardenReading.js
+++ b/models/GardenReading.js
@@ -1,0 +1,52 @@
+const mongoose = require('mongoose');
+
+const GardenReadingSchema = new mongoose.Schema(
+  {
+    owner: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    gardenId: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 80,
+      index: true,
+    },
+    ph: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 14,
+    },
+    ec: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    temperature: {
+      type: Number,
+      required: true,
+      min: -50,
+      max: 100,
+    },
+    humidity: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+    },
+    receivedAt: {
+      type: Date,
+      default: Date.now,
+      index: true,
+    },
+  },
+  { timestamps: true }
+);
+
+GardenReadingSchema.index({ owner: 1, gardenId: 1, receivedAt: -1 });
+
+module.exports = mongoose.model('GardenReading', GardenReadingSchema);

--- a/models/index.js
+++ b/models/index.js
@@ -9,4 +9,5 @@ module.exports = {
   Review: require('./Review'),
   WebhookLog: require('./WebhookLog'),
   ActivityLog: require('./ActivityLog'),
+  GardenReading: require('./GardenReading'),
 };

--- a/routes/garden.js
+++ b/routes/garden.js
@@ -1,0 +1,167 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const GardenReading = require('../models/GardenReading');
+
+const router = express.Router();
+
+const METRICS = ['ph', 'ec', 'temperature', 'humidity'];
+
+function parseMetric(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function validatePayload(body) {
+  const gardenId = typeof body.gardenId === 'string' ? body.gardenId.trim() : '';
+  const readings = {
+    ph: parseMetric(body.ph),
+    ec: parseMetric(body.ec),
+    temperature: parseMetric(body.temperature),
+    humidity: parseMetric(body.humidity),
+  };
+  const errors = [];
+
+  if (!gardenId) errors.push('gardenId is required');
+  if (gardenId.length > 80) errors.push('gardenId must be 80 characters or less');
+
+  if (readings.ph === null || readings.ph < 0 || readings.ph > 14) {
+    errors.push('ph must be a number between 0 and 14');
+  }
+  if (readings.ec === null || readings.ec < 0) {
+    errors.push('ec must be a non-negative number');
+  }
+  if (readings.temperature === null || readings.temperature < -50 || readings.temperature > 100) {
+    errors.push('temperature must be a number between -50 and 100');
+  }
+  if (readings.humidity === null || readings.humidity < 0 || readings.humidity > 100) {
+    errors.push('humidity must be a number between 0 and 100');
+  }
+
+  return { gardenId, readings, errors };
+}
+
+function toPublicReading(reading) {
+  return {
+    id: reading._id,
+    gardenId: reading.gardenId,
+    ph: reading.ph,
+    ec: reading.ec,
+    temperature: reading.temperature,
+    humidity: reading.humidity,
+    receivedAt: reading.receivedAt,
+  };
+}
+
+function summarizeReadings(readings) {
+  const summary = {
+    count: readings.length,
+    latest: readings[0] ? toPublicReading(readings[0]) : null,
+    averages: {},
+    min: {},
+    max: {},
+  };
+
+  for (const metric of METRICS) {
+    const values = readings
+      .map((reading) => Number(reading[metric]))
+      .filter((value) => Number.isFinite(value));
+
+    if (!values.length) {
+      summary.averages[metric] = null;
+      summary.min[metric] = null;
+      summary.max[metric] = null;
+      continue;
+    }
+
+    const total = values.reduce((sum, value) => sum + value, 0);
+    summary.averages[metric] = Number((total / values.length).toFixed(3));
+    summary.min[metric] = Math.min(...values);
+    summary.max[metric] = Math.max(...values);
+  }
+
+  return summary;
+}
+
+function buildDateFilter(query) {
+  const receivedAt = {};
+
+  if (query.from) {
+    const from = new Date(query.from);
+    if (Number.isNaN(from.getTime())) {
+      return { error: 'from must be a valid date' };
+    }
+    receivedAt.$gte = from;
+  }
+
+  if (query.to) {
+    const to = new Date(query.to);
+    if (Number.isNaN(to.getTime())) {
+      return { error: 'to must be a valid date' };
+    }
+    receivedAt.$lte = to;
+  }
+
+  return Object.keys(receivedAt).length ? { receivedAt } : {};
+}
+
+router.post('/data', auth, async (req, res) => {
+  try {
+    const { gardenId, readings, errors } = validatePayload(req.body || {});
+    if (errors.length) {
+      return res.status(400).json({ success: false, errors });
+    }
+
+    const reading = await GardenReading.create({
+      owner: req.user._id,
+      gardenId,
+      ...readings,
+    });
+
+    return res.status(201).json({
+      success: true,
+      data: toPublicReading(reading),
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+router.get('/:id/stats', auth, async (req, res) => {
+  try {
+    const gardenId = String(req.params.id || '').trim();
+    if (!gardenId) {
+      return res.status(400).json({ success: false, error: 'garden id is required' });
+    }
+
+    const dateFilter = buildDateFilter(req.query);
+    if (dateFilter.error) {
+      return res.status(400).json({ success: false, error: dateFilter.error });
+    }
+
+    const limit = Math.min(Math.max(Number.parseInt(req.query.limit, 10) || 100, 1), 500);
+    const filter = {
+      owner: req.user._id,
+      gardenId,
+      ...dateFilter,
+    };
+
+    const readings = await GardenReading.find(filter)
+      .sort({ receivedAt: -1 })
+      .limit(limit)
+      .lean();
+
+    return res.json({
+      success: true,
+      data: {
+        gardenId,
+        stats: summarizeReadings(readings),
+        readings: readings.map(toPublicReading),
+      },
+    });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -65,6 +65,10 @@ app.use('/api/monero', moneroRoutes);
 const userRoutes = require('./src/routes/users');
 app.use('/api/users', userRoutes);
 
+// Garden sensor routes
+const gardenRoutes = require('./routes/garden');
+app.use('/api/garden', gardenRoutes);
+
 // Webhook verification routes
 const webhookRoutes = require('./routes/webhook');
 app.use('/api/webhook', webhookRoutes);

--- a/tests/garden.test.js
+++ b/tests/garden.test.js
@@ -1,0 +1,161 @@
+const express = require('express');
+const request = require('supertest');
+
+const USER_ID = '000000000000000000000123';
+
+jest.mock('../middleware/auth', () => (req, res, next) => {
+  if (req.get('Authorization') !== 'Bearer garden-token') {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  req.user = { _id: USER_ID, id: USER_ID };
+  return next();
+});
+
+const makeFindQuery = (rows) => {
+  const query = {
+    sort: jest.fn(() => query),
+    limit: jest.fn(() => query),
+    lean: jest.fn(async () => rows),
+  };
+  return query;
+};
+
+jest.mock('../models/GardenReading', () => ({
+  create: jest.fn(async (document) => ({
+    _id: 'reading-1',
+    receivedAt: new Date('2026-07-30T11:30:00.000Z'),
+    ...document,
+  })),
+  find: jest.fn(),
+}));
+
+const GardenReading = require('../models/GardenReading');
+const gardenRoutes = require('../routes/garden');
+
+describe('garden sensor API', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/garden', gardenRoutes);
+  });
+
+  it('requires JWT authentication before accepting Arduino readings', async () => {
+    await request(app)
+      .post('/api/garden/data')
+      .send({
+        gardenId: 'garden-1',
+        ph: 6.2,
+        ec: 1.8,
+        temperature: 22.5,
+        humidity: 65,
+      })
+      .expect(401);
+
+    expect(GardenReading.create).not.toHaveBeenCalled();
+  });
+
+  it('stores a validated garden sensor reading for the authenticated garden owner', async () => {
+    const response = await request(app)
+      .post('/api/garden/data')
+      .set('Authorization', 'Bearer garden-token')
+      .send({
+        gardenId: ' garden-1 ',
+        ph: '6.2',
+        ec: 1.8,
+        temperature: 22.5,
+        humidity: 65,
+      })
+      .expect(201);
+
+    expect(GardenReading.create).toHaveBeenCalledWith({
+      owner: USER_ID,
+      gardenId: 'garden-1',
+      ph: 6.2,
+      ec: 1.8,
+      temperature: 22.5,
+      humidity: 65,
+    });
+    expect(response.body).toEqual(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({
+        gardenId: 'garden-1',
+        ph: 6.2,
+        humidity: 65,
+      }),
+    }));
+  });
+
+  it('rejects invalid sensor readings with field-level messages', async () => {
+    const response = await request(app)
+      .post('/api/garden/data')
+      .set('Authorization', 'Bearer garden-token')
+      .send({
+        gardenId: '',
+        ph: 18,
+        ec: -1,
+        temperature: 120,
+        humidity: 101,
+      })
+      .expect(400);
+
+    expect(response.body.success).toBe(false);
+    expect(response.body.errors).toEqual(expect.arrayContaining([
+      'gardenId is required',
+      'ph must be a number between 0 and 14',
+      'ec must be a non-negative number',
+    ]));
+    expect(GardenReading.create).not.toHaveBeenCalled();
+  });
+
+  it('returns historical readings and summary stats for one authenticated garden', async () => {
+    const rows = [
+      {
+        _id: 'reading-2',
+        gardenId: 'garden-1',
+        ph: 6.6,
+        ec: 2,
+        temperature: 24,
+        humidity: 70,
+        receivedAt: new Date('2026-07-30T11:35:00.000Z'),
+      },
+      {
+        _id: 'reading-1',
+        gardenId: 'garden-1',
+        ph: 6.2,
+        ec: 1.8,
+        temperature: 22,
+        humidity: 60,
+        receivedAt: new Date('2026-07-30T11:30:00.000Z'),
+      },
+    ];
+    const query = makeFindQuery(rows);
+    GardenReading.find.mockReturnValue(query);
+
+    const response = await request(app)
+      .get('/api/garden/garden-1/stats?limit=50&from=2026-07-30T00:00:00Z')
+      .set('Authorization', 'Bearer garden-token')
+      .expect(200);
+
+    expect(GardenReading.find).toHaveBeenCalledWith({
+      owner: USER_ID,
+      gardenId: 'garden-1',
+      receivedAt: { $gte: new Date('2026-07-30T00:00:00Z') },
+    });
+    expect(query.sort).toHaveBeenCalledWith({ receivedAt: -1 });
+    expect(query.limit).toHaveBeenCalledWith(50);
+    expect(response.body.data.stats).toEqual(expect.objectContaining({
+      count: 2,
+      averages: expect.objectContaining({
+        ph: 6.4,
+        ec: 1.9,
+        temperature: 23,
+        humidity: 65,
+      }),
+    }));
+    expect(response.body.data.readings).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #98

## What changed
- Added authenticated `POST /api/garden/data` for Arduino/garden sensor JSON payloads.
- Added MongoDB persistence via a new `GardenReading` model scoped to the authenticated owner and `gardenId`.
- Added `GET /api/garden/:id/stats` for recent historical readings, date filtering, bounded limits, latest reading, averages, min, and max values.
- Added validation for `gardenId`, pH, EC, temperature, and humidity ranges.
- Registered the garden API under `/api/garden` and exported the model.
- Added focused API tests for authentication, validation, persistence, and stats output.

## Notes
Issues #96 and #97 appear to describe the same Arduino IoT API scope; this PR targets #98 and covers that duplicate scope as well.

## Validation
- `npx jest tests/garden.test.js --runInBand`
- `npx jest tests/garden.test.js tests/webhook.test.js tests/activityLog.test.js --runInBand`
- `npm test -- --runInBand --forceExit` (58 tests passed)
- `git diff --check`

## Bounty payout
Payout Address: 45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8