### PR TITLE
fix: add netlify.toml for deploy preview (Fixes #178)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]  
+  command = "echo 'No build step required'"  
+  publish = "public"  


### PR DESCRIPTION
## Root Cause Analysis  Netlify Deploy Preview was failing on PRs because the repository lacked a \`netlify.toml\` configuration file.  Without explicit build settings, Netlify fell back to its default Node.js behavior: - Looking for a build script in \`package.json\` (which doesn't exist in this project) - Attempting to publish the repository root as a static site  This mismatch caused the Netlify deploy checks ("Redirect rules", "Header rules", "Pages changed") to fail with "Deploy failed".  ## Fix  Added \`netlify.toml\` with explicit configuration: - \`command = "echo 'No build step required'"\` — tells Netlify no build step is needed - \`publish = "public"\` — tells Netlify to serve the static \`dashboard.html\` from the \`public/\` directory  ## Files Changed  - \`netlify.toml\` (new file) — Netlify site configuration  ## Verification  - \`netlify.toml\` syntax validated - File successfully pushed to \`fix/netlify-deploy-preview\` branch - Ready for Netlify Deploy Preview to run on this PR  Fixes #178