### PR TITLE
feat: production-ready Dockerfile for frontend (fixes #214)

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,27 @@
+# ── Dependencies ──
+node_modules
+npm-debug.log*
+
+# ── Build output ──
+dist
+build
+
+# ── Git ──
+.git
+.gitignore
+
+# ── Environment ──
+.env
+.env.local
+.env.*.local
+!.env.production
+
+# ── Editor / OS ──
+.vscode
+.idea
+*.swp
+.DS_Store
+Thumbs.db
+
+# ── Logs ──
+*.log

--- a/frontend/DOCKER.md
+++ b/frontend/DOCKER.md
@@ -1,0 +1,88 @@
+# MyZubster Frontend — Docker Deployment
+
+Production-ready Dockerfile for the React + Vite frontend.
+
+## Features
+
+- **Multi-stage build** — `node:20-alpine` builds the bundle, `nginx:1.27-alpine` serves it. Final image is ~25 MB, no node_modules, no build toolchain.
+- **Layer caching** — `package.json` + `package-lock.json` are copied and installed before the rest of the source, so dependency layers are reused across builds.
+- **Environment variables** — Vite build args (`VITE_*`) are inlined at build time (see table below).
+- **Health checks** — `/healthz` endpoint + Docker `HEALTHCHECK` instruction.
+- **Logging** — nginx access/error logs go to stdout/stderr, so `docker logs` works out of the box.
+- **Optimization** — gzip compression, immutable caching for hashed assets, SPA history fallback.
+
+## Build
+
+```bash
+cd frontend
+
+# Minimal build (uses .env.production for VITE_* values)
+docker build -t myzubster-frontend .
+
+# With explicit build args
+docker build -t myzubster-frontend \
+  --build-arg VITE_API_URL=https://api.myzubster.example \
+  --build-arg VITE_GATEWAY_URL=https://api.myzubster.example \
+  --build-arg VITE_BACKEND_URL=https://backend.myzubster.example \
+  --build-arg VITE_ENV=production \
+  --build-arg VITE_VERSION=1.2.0 \
+  .
+```
+
+## Run
+
+```bash
+docker run -d --name myzubster-frontend -p 3000:80 myzubster-frontend
+# → http://localhost:3000
+# → health:  http://localhost:3000/healthz  (returns "ok")
+```
+
+## Docker Compose
+
+Add this service to `docker-compose.yml`:
+
+```yaml
+frontend:
+  build:
+    context: ./frontend
+    dockerfile: Dockerfile
+    args:
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:10001}
+      VITE_GATEWAY_URL: ${VITE_GATEWAY_URL:-http://localhost:10001}
+      VITE_BACKEND_URL: ${VITE_BACKEND_URL:-http://localhost:3010}
+      VITE_ENV: ${VITE_ENV:-production}
+  container_name: myzubster-frontend
+  restart: unless-stopped
+  ports:
+    - "3000:80"
+  networks:
+    - myzubster-network
+  healthcheck:
+    test: ["CMD", "wget", "-qO-", "http://127.0.0.1/healthz"]
+    interval: 30s
+    timeout: 5s
+    retries: 3
+```
+
+## Environment Variables
+
+| Variable           | Build arg        | Description                        |
+|--------------------|------------------|------------------------------------|
+| `VITE_API_URL`     | `VITE_API_URL`   | Gateway API base URL               |
+| `VITE_GATEWAY_URL` | `VITE_GATEWAY_URL` | Monero gateway URL               |
+| `VITE_BACKEND_URL` | `VITE_BACKEND_URL` | Backend API URL                  |
+| `VITE_MONERO_ADDRESS` | `VITE_MONERO_ADDRESS` | Default Monero payout address |
+| `VITE_ENV`         | `VITE_ENV`       | `production` / `staging` / ...     |
+| `VITE_VERSION`     | `VITE_VERSION`   | App version shown in UI            |
+
+> ⚠️ Vite inlines `VITE_*` variables at **build time** — changing them requires a rebuild. If you need runtime configuration, inject them at the nginx level instead (e.g. an `/config.js` endpoint).
+
+## Files
+
+```
+frontend/
+├── Dockerfile      # Multi-stage build (node build → nginx runtime)
+├── nginx.conf      # SPA config: gzip, caching, health, logging
+├── .dockerignore   # Keeps build context small
+└── DOCKER.md       # This document
+```

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,61 @@
+# syntax=docker/dockerfile:1.7
+
+###############################################################################
+# STAGE 1 — Build the React + Vite application
+###############################################################################
 FROM node:20-alpine AS build
+
 WORKDIR /app
-COPY package*.json ./
-RUN npm install
+
+# Install dependencies first (better layer caching)
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+# Copy the rest of the source
 COPY . .
+
+# ── Build-time environment variables ────────────────────────────────────────
+# Vite inlines these at build time. Override with --build-arg or compose args.
+ARG VITE_API_URL
+ARG VITE_GATEWAY_URL
+ARG VITE_BACKEND_URL
+ARG VITE_MONERO_ADDRESS
+ARG VITE_ENV=production
+ARG VITE_VERSION=1.0.0
+
+ENV VITE_API_URL=$VITE_API_URL \
+    VITE_GATEWAY_URL=$VITE_GATEWAY_URL \
+    VITE_BACKEND_URL=$VITE_BACKEND_URL \
+    VITE_MONERO_ADDRESS=$VITE_MONERO_ADDRESS \
+    VITE_ENV=$VITE_ENV \
+    VITE_VERSION=$VITE_VERSION
+
+# Build the static bundle
 RUN npm run build
 
-FROM nginx:alpine
+###############################################################################
+# STAGE 2 — Minimal nginx runtime (static hosting)
+###############################################################################
+FROM nginx:1.27-alpine
+
+# SPA-friendly nginx config: gzip, caching, history fallback, health endpoint,
+# access/error logs to stdout/stderr so `docker logs` works.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built assets from stage 1
 COPY --from=build /app/dist /usr/share/nginx/html
-EXPOSE 3000
+
+# Metadata
+LABEL org.opencontainers.image.title="myzubster-frontend" \
+      org.opencontainers.image.description="Production-ready frontend container for MyZubster" \
+      org.opencontainers.image.version="${VITE_VERSION}" \
+      org.opencontainers.image.source="https://github.com/MyZubster-Ecosystem/MyZubsterGateway"
+
+EXPOSE 80
+
+# Health check — requires wget (available in busybox on nginx:alpine)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/healthz || exit 1
+
+# Run nginx in the foreground so the container stays alive
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,59 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # ── Logging: send to stdout/stderr so `docker logs` captures them ──
+    access_log /dev/stdout combined;
+    error_log  /dev/stderr warn;
+
+    # ── Gzip compression ──
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_comp_level 6;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        application/xml
+        text/xml
+        application/xml+rss
+        text/javascript
+        image/svg+xml;
+
+    # ── Security headers ──
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # ── Health check endpoint ──
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        add_header Cache-Control "no-store";
+        return 200 "ok\n";
+    }
+
+    # ── Hashed static assets: cache aggressively ──
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # ── SPA history fallback ──
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
+    }
+
+    # ── Deny hidden files ──
+    location ~ /\. {
+        deny all;
+    }
+}


### PR DESCRIPTION
## Summary

Production-ready Dockerfile for the React + Vite frontend, per issue #214.

## Requirements Covered

| Requirement | Implementation |
|---|---|
| **Multi-stage build** | `node:20-alpine` build stage + `nginx:1.27-alpine` runtime stage. Final image ~25 MB (no node_modules, no build toolchain) |
| **Environment variables** | `VITE_*` build args inlined at build time; documented table + compose example |
| **Health checks** | `/healthz` endpoint + Docker `HEALTHCHECK` (wget, interval 30s) |
| **Proper logging** | nginx access/error logs to stdout/stderr → `docker logs` works out of the box |
| **Documentation** | `frontend/DOCKER.md` with build/run/compose/env docs |

## Bonus optimizations

- Layer caching: `package.json` + `package-lock.json` installed before copying source
- gzip compression + immutable caching for hashed `/assets/`
- SPA history fallback (`try_files ... /index.html`)
- Security headers (X-Frame-Options, nosniff, referrer policy)
- `.dockerignore` keeps build context small

## Files Changed

- `frontend/Dockerfile` — rewritten (multi-stage)
- `frontend/nginx.conf` — new (SPA config + health + logging)
- `frontend/.dockerignore` — new
- `frontend/DOCKER.md` — new (usage documentation)

Bounty: 0.05 XMR

XMR: `44kLzNXHV9EDxHN948HsvhhEQpQY6iyE6LfgCbFz463JM1bpz3UtWwUTPuQJ25nMzuQmfjYiDcqYvN9uYkTp3v5J2E1hisp`