### PR TITLE
fix: repair corrupted root package-lock.json (conflict markers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1987,7 +1987,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
-<<<<<<< HEAD
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1995,7 +1994,8 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
-=======
+      }
+    },
     "node_modules/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -2008,7 +2008,6 @@
       },
       "engines": {
         "node": ">= 18"
->>>>>>> bdd225a5 (feat: implement bounty, reward, and auth system)
       }
     },
     "node_modules/bcryptjs": {
@@ -5747,13 +5746,12 @@
         "node": ">= 0.6"
       }
     },
-<<<<<<< HEAD
     "node_modules/net": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
       "integrity": "sha512-kbhcj2SVVR4caaVnGLJKmlk2+f+oLkjqdKeQlmUtz6nGzOpbcobwVIeSURNgraV/v3tlmGIX82OcPCl0K6RbHQ==",
       "license": "MIT"
-=======
+    },
     "node_modules/node-addon-api": {
       "version": "8.9.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
@@ -5773,7 +5771,6 @@
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
       }
->>>>>>> bdd225a5 (feat: implement bounty, reward, and auth system)
     },
     "node_modules/node-int64": {
       "version": "0.4.0",


### PR DESCRIPTION
Fixes the broken root `package-lock.json` in main: it contains unresolved git merge conflict markers (`<<<<<<<`/`=======`/`>>>>>>>`) which make **every** CI job fail at `npm ci` with `npm error EUSAGE while parsing`.

Two hunks were affected and both sides kept (both packages are required):
- `node_modules/bcrypt-pbkdf` (old) vs `node_modules/bcrypt@6.0.0` (new dep)
- `node_modules/net` (old) vs `node_modules/node-addon-api` + `node-gyp-build` (needed by bcrypt)

Verified: lockfile parses as valid JSON (lockfileVersion 3, 657 packages) and `npm install --package-lock-only` reports "up to date" (lock matches package.json).
No other lines changed. This unblocks CI for all open PRs (e.g. #221).