### PR TITLE
feat(backup): implement backup/restore system for MongoDB and configs (Bounty B20)

### DIFF
--- a/models/Backup.js
+++ b/models/Backup.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+const BackupSchema = new mongoose.Schema({
+  filename: { type: String, required: true },
+  filepath: { type: String, required: true },
+  size: { type: Number, required: true },        // bytes
+  collections: [{ type: String }],               // nom des collections backupées
+  status: {
+    type: String,
+    enum: ['in_progress', 'completed', 'failed'],
+    default: 'in_progress'
+  },
+  type: {
+    type: String,
+    enum: ['manual', 'scheduled'],
+    default: 'manual'
+  },
+  storage: {
+    type: String,
+    enum: ['filesystem', 's3'],
+    default: 'filesystem'
+  },
+  s3Url: { type: String, default: null },
+  error: { type: String, default: null },
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  createdAt: { type: Date, default: Date.now },
+  completedAt: { type: Date, default: null }
+});
+
+BackupSchema.index({ createdAt: -1 });
+BackupSchema.index({ status: 1 });
+
+module.exports = mongoose.model('Backup', BackupSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "adm-zip": "^0.6.0",
         "axios": "^1.19.0",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "mongoose": "^9.9.1"
+        "mongoose": "^9.9.1",
+        "node-cron": "^4.6.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -57,6 +59,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -872,13 +883,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
+    "node_modules/node-cron": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.6.0.tgz",
+      "integrity": "sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==",
+      "license": "ISC",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "adm-zip": "^0.6.0",
     "axios": "^1.19.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "mongoose": "^9.9.1"
+    "mongoose": "^9.9.1",
+    "node-cron": "^4.6.0"
   }
 }

--- a/routes/backup.js
+++ b/routes/backup.js
@@ -1,0 +1,96 @@
+const express = require("express");
+const router = express.Router();
+const cron = require("node-cron");
+const { createBackup, restoreBackup, listBackups, cleanupOldBackups } = require("../services/backupService");
+const { notifyUser } = require("../notifications");
+
+// POST /api/backup/create - Manual backup trigger
+router.post("/create", async (req, res) => {
+  try {
+    const { type } = req.body;
+    const backup = await createBackup(type || "manual");
+    res.status(201).json({
+      success: true,
+      message: "Backup created successfully",
+      data: {
+        id: backup._id,
+        filename: backup.filename,
+        size: backup.size,
+        collections: backup.collections,
+        status: backup.status,
+        storage: backup.storage,
+        createdAt: backup.createdAt,
+        completedAt: backup.completedAt,
+      },
+    });
+  } catch (err) {
+    console.error("Backup creation failed:", err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// POST /api/backup/restore
+router.post("/restore", async (req, res) => {
+  try {
+    const { backupId } = req.body;
+    if (!backupId) return res.status(400).json({ success: false, error: "backupId is required" });
+    const result = await restoreBackup(backupId);
+    res.json({ success: true, message: "Restore completed", data: result });
+  } catch (err) {
+    console.error("Restore failed:", err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// GET /api/backup/list
+router.get("/list", async (req, res) => {
+  try {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 20;
+    const result = await listBackups(page, limit);
+    res.json({ success: true, data: result });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// GET /api/backup/status
+router.get("/status", async (req, res) => {
+  try {
+    const { backups, total } = await listBackups(1, 1);
+    const last = backups.length > 0 ? backups[0] : null;
+    res.json({ success: true, data: { totalBackups: total, lastBackup: last ? {
+      id: last._id, filename: last.filename, status: last.status,
+      size: last.size, createdAt: last.createdAt } : null } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// POST /api/backup/cleanup
+router.post("/cleanup", async (req, res) => {
+  try {
+    const { retentionDays } = req.body;
+    const count = await cleanupOldBackups(retentionDays || 30);
+    res.json({ success: true, message: "Cleanup completed", deletedCount: count });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// Scheduled daily backup at 03:00 UTC
+cron.schedule("0 3 * * *", async () => {
+  console.log("Scheduled backup starting...");
+  try {
+    const backup = await createBackup("scheduled");
+    await notifyUser("admin", "Scheduled backup completed: " + backup.filename);
+    if (new Date().getDay() === 0) await cleanupOldBackups(30);
+  } catch (err) {
+    console.error("Scheduled backup failed:", err);
+    await notifyUser("admin", "Scheduled backup FAILED: " + err.message);
+  }
+});
+
+console.log("Backup scheduler initialized (daily at 03:00 UTC)");
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -58,6 +58,8 @@ app.use('/api/robot/animal', require('./routes/robotAnimal'));
 
 app.use('/api/ratelimit', require('./routes/ratelimit'));
 
+app.use('/api/backup', require('./routes/backup'));
+
 app.get('/health', (req, res) => {
   res.json({
     status: 'healthy',

--- a/services/backupService.js
+++ b/services/backupService.js
@@ -1,0 +1,157 @@
+const fs = require("fs");
+const path = require("path");
+const AdmZip = require("adm-zip");
+const mongoose = require("mongoose");
+const Backup = require("../models/Backup");
+
+const BACKUP_DIR = process.env.BACKUP_DIR || path.join(__dirname, "..", "backups");
+
+async function uploadToS3(filepath, filename) {
+  try {
+    const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
+    const s3 = new S3Client({
+      region: process.env.AWS_REGION || "us-east-1",
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      },
+    });
+    const bucket = process.env.S3_BACKUP_BUCKET || "myzubster-backups";
+    const fileContent = fs.readFileSync(filepath);
+    await s3.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: "backups/" + filename,
+      Body: fileContent,
+    }));
+    return "s3://" + bucket + "/backups/" + filename;
+  } catch (err) {
+    console.warn("S3 upload failed:", err.message);
+    return null;
+  }
+}
+
+async function createBackup(type) {
+  if (!type) type = "manual";
+  if (!fs.existsSync(BACKUP_DIR)) fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const fn = "myzubster-backup-" + ts + ".zip";
+  const fp = path.join(BACKUP_DIR, fn);
+  const rec = await Backup.create({
+    filename: fn, filepath: fp, size: 0, collections: [],
+    status: "in_progress", type,
+    storage: process.env.S3_BACKUP_BUCKET ? "s3" : "filesystem",
+  });
+  try {
+    const db = mongoose.connection.db;
+    if (!db) throw new Error("MongoDB not connected");
+    const colls = await db.listCollections().toArray();
+    const names = colls.map(c => c.name);
+    const tmp = path.join(BACKUP_DIR, "tmp-" + ts);
+    fs.mkdirSync(tmp, { recursive: true });
+    let total = 0;
+    for (const cn of names) {
+      try {
+        const docs = await db.collection(cn).find({}).toArray();
+        const jp = path.join(tmp, cn + ".json");
+        fs.writeFileSync(jp, JSON.stringify(docs, null, 2));
+        total += fs.statSync(jp).size;
+      } catch(e) { console.warn("Dump err " + cn, e.message); }
+    }
+    const cfg = { NODE_ENV: process.env.NODE_ENV, PORT: process.env.PORT, MONGODB_DB_NAME: process.env.MONGODB_DB_NAME, backedUpAt: new Date().toISOString() };
+    fs.writeFileSync(path.join(tmp, "config.json"), JSON.stringify(cfg, null, 2));
+    const zip = new AdmZip();
+    zip.addLocalFolder(tmp);
+    zip.writeZip(fp);
+    total = fs.statSync(fp).size;
+    if (fs.existsSync(tmp)) fs.rmSync(tmp, { recursive: true, force: true });
+    let s3u = null;
+    if (process.env.S3_BACKUP_BUCKET) s3u = await uploadToS3(fp, fn);
+    rec.size = total;
+    rec.collections = names;
+    rec.status = "completed";
+    rec.completedAt = new Date();
+    rec.s3Url = s3u;
+    rec.storage = s3u ? "s3" : "filesystem";
+    await rec.save();
+    console.log("Backup completed: " + fn);
+    return rec;
+  } catch (err) {
+    rec.status = "failed"; rec.error = err.message; rec.completedAt = new Date();
+    await rec.save();
+    console.error("Backup failed:", err.message);
+    throw err;
+  }
+}
+
+async function restoreBackup(backupId) {
+  const rec = await Backup.findById(backupId);
+  if (!rec) throw new Error("Backup not found");
+  if (rec.status !== "completed") throw new Error("Backup not completed");
+  let fp = rec.filepath;
+  if (rec.storage === "s3" && rec.s3Url) {
+    fp = path.join(BACKUP_DIR, rec.filename);
+    if (!fs.existsSync(fp)) {
+      const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
+      const s3 = new S3Client({
+        region: process.env.AWS_REGION || "us-east-1",
+        credentials: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        },
+      });
+      const bucket = process.env.S3_BACKUP_BUCKET || "myzubster-backups";
+      const resp = await s3.send(new GetObjectCommand({
+        Bucket: bucket, Key: "backups/" + rec.filename,
+      }));
+      const body = await resp.Body.transformToByteArray();
+      fs.writeFileSync(fp, Buffer.from(body));
+    }
+  }
+  if (!fs.existsSync(fp)) throw new Error("File not found: " + fp);
+  const tmp = path.join(BACKUP_DIR, "restore-" + Date.now());
+  fs.mkdirSync(tmp, { recursive: true });
+  const restoreZip = new AdmZip(fp);
+  restoreZip.extractAllTo(tmp, true);
+  const db = mongoose.connection.db;
+  if (!db) throw new Error("MongoDB not connected");
+  const files = fs.readdirSync(tmp).filter(f => f.endsWith(".json") && f !== "config.json");
+  const restored = [];
+  for (const f of files) {
+    const cn = f.replace(".json", "");
+    try {
+      const docs = JSON.parse(fs.readFileSync(path.join(tmp, f), "utf-8"));
+      if (docs.length > 0) {
+        await db.collection(cn).drop().catch(() => {});
+        await db.collection(cn).insertMany(docs);
+      }
+      restored.push(cn);
+    } catch(ce) { console.warn("Restore err " + cn, ce.message); }
+  }
+  if (fs.existsSync(tmp)) fs.rmSync(tmp, { recursive: true, force: true });
+  console.log("Restore completed: " + restored.length + " collections");
+  return { restoredCollections: restored, backupId: rec._id, timestamp: rec.createdAt };
+}
+
+async function listBackups(page, limit) {
+  page = page || 1; limit = limit || 20;
+  const skip = (page - 1) * limit;
+  const [backups, total] = await Promise.all([
+    Backup.find().sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+    Backup.countDocuments(),
+  ]);
+  return { backups, total, page, limit, totalPages: Math.ceil(total / limit) };
+}
+
+async function cleanupOldBackups(retentionDays) {
+  retentionDays = retentionDays || 30;
+  const cutoff = new Date(Date.now() - retentionDays * 86400000);
+  const old = await Backup.find({ createdAt: { $lt: cutoff }, storage: "filesystem" });
+  for (const b of old) {
+    if (fs.existsSync(b.filepath)) fs.unlinkSync(b.filepath);
+    await Backup.deleteOne({ _id: b._id });
+  }
+  console.log("Cleaned up " + old.length + " old backups");
+  return old.length;
+}
+
+module.exports = { createBackup, restoreBackup, listBackups, cleanupOldBackups, BACKUP_DIR };


### PR DESCRIPTION
## Description

Systeme de backup automatique et restore pour MongoDB et configurations.

### Fonctionnalites implementees

- **Backup automatique quotidien** (MongoDB dump) via node-cron (03:00 UTC)
- **Stockage fichiers** : backups sauvegardes localement dans le dossier backups/ au format ZIP
- **Support S3** : upload automatique vers S3 si S3_BACKUP_BUCKET est configure
- **API REST** :
  - POST /api/backup/create - Declencher un backup manuel
  - POST /api/backup/restore - Restaurer depuis un backup (par ID)
  - GET /api/backup/list - Historique pagine des backups
  - GET /api/backup/status - Statut rapide (dernier backup, total)
  - POST /api/backup/cleanup - Nettoyer les vieux backups
- **Historique** : chaque backup trace dans MongoDB (modele Backup)
- **Notifications** : succes/echec via le systeme existant

### Modifications

| Fichier | Description |
|--------|------------|
| models/Backup.js | Nouveau modele Mongoose |
| services/backupService.js | Service core |
| routes/backup.js | Routes API + cron quotidien |
| server.js | Ajout route /api/backup |
| package.json | Dependances : adm-zip, node-cron |

Closes #285

---
🔁 **Rebasé sur main le 04/08/2026**
_Remplace la PR #290 (fermée par force-push)_