### PR TITLE
[DevOps] Add Docker Compose for development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# MyZubsterGateway
+
+## Development setup via Docker Compose
+
+You can easily spin up the Gateway, MongoDB, and wallet stubs (Tari/Monero) using Docker Compose.
+
+1. Install Docker and Docker Compose.
+2. Run the environment:
+   ```bash
+   docker-compose up -d
+   ```
+3. The Gateway will be available at `http://localhost:10000`. MongoDB is on `27017`.
+4. To stop the environment:
+   ```bash
+   docker-compose down
+   ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  gateway:
+    build: .
+    ports:
+      - "10000:10000"
+    environment:
+      - PORT=10000
+      - MONGO_URI=mongodb://mongo:27017/myzubster
+      - TARI_WALLET_URL=http://tari-stub:8080
+      - MONERO_WALLET_URL=http://monero-stub:8081
+    depends_on:
+      - mongo
+      - tari-stub
+      - monero-stub
+
+  mongo:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  tari-stub:
+    image: mendhak/http-https-echo:31
+    ports:
+      - "8080:8080"
+    environment:
+      - HTTP_PORT=8080
+
+  monero-stub:
+    image: mendhak/http-https-echo:31
+    ports:
+      - "8081:8080"
+    environment:
+      - HTTP_PORT=8080
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
Fixes #274

- Created `docker-compose.yml` defining the gateway, MongoDB, and HTTP echo stubs for Tari and Monero.
- Added a `README.md` with instructions to run `docker-compose up -d`.