### PR TITLE
[Backend] Implement Webhooks system for robot events

### DIFF
--- a/models/Webhook.js
+++ b/models/Webhook.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+const schema = new mongoose.Schema({
+  url: { type: String, required: true },
+  events: [{ type: String }],
+  active: { type: Boolean, default: true }
+});
+module.exports = mongoose.model('Webhook', schema);

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const Webhook = require('../models/Webhook');
+
+router.post('/register', async (req, res) => {
+  const { url, events } = req.body;
+  if (!url) return res.status(400).json({ error: 'URL required' });
+  
+  try {
+    const hook = new Webhook({ url, events: events || ['*'] });
+    await hook.save();
+    res.json({ success: true, id: hook._id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await Webhook.findByIdAndDelete(req.params.id);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -38,6 +38,7 @@ app.use('/api/rewards', require('./routes/rewards'));
 app.use('/api/bounty', require('./routes/bounty'));
 app.use('/api/stake', require('./routes/stake'));
 app.use('/api/escrow/house', require('./routes/escrowHouse'));
+app.use('/api/webhooks', require('./routes/webhooks'));
 
 app.use('/api/robot', require('./routes/robot'));
 app.use('/api/robot/escrow', require('./routes/robotEscrow'));

--- a/services/webhookService.js
+++ b/services/webhookService.js
@@ -1,0 +1,36 @@
+const axios = require('axios');
+const Webhook = require('../models/Webhook');
+
+async function sendWebhookWithRetry(url, payload, maxRetries = 3) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await axios.post(url, payload, { timeout: 5000 });
+      if (global.logEvent) global.logEvent(`Webhook delivered to ${url}`);
+      return true; // Success
+    } catch (err) {
+      if (attempt === maxRetries) {
+        if (global.logEvent) global.logEvent(`Webhook failed for ${url} after ${maxRetries} attempts`);
+        return false;
+      }
+      // Exponential backoff
+      const delay = Math.pow(2, attempt) * 1000;
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+}
+
+async function triggerWebhooks(event, data) {
+  try {
+    const hooks = await Webhook.find({ events: event, active: true });
+    const payload = { event, data, timestamp: new Date() };
+    
+    // Process async without blocking
+    hooks.forEach(hook => {
+      sendWebhookWithRetry(hook.url, payload);
+    });
+  } catch (e) {
+    console.error('Error triggering webhooks:', e);
+  }
+}
+
+module.exports = { triggerWebhooks, sendWebhookWithRetry };


### PR DESCRIPTION
Fixes #270

- Created `Webhook` mongoose model for persisting callback URLs.
- Added `/api/webhooks/register` route.
- Created `services/webhookService.js` with `triggerWebhooks` and `sendWebhookWithRetry` using exponential backoff to handle failures robustly.