### PR TITLE
docs: add Monero wallet setup guide with screenshots (#151)

### DIFF
--- a/docs/MONERO_WALLET_GUIDE.md
+++ b/docs/MONERO_WALLET_GUIDE.md
@@ -1,0 +1,112 @@
+# Monero Wallet Setup Guide
+
+> **Goal:** Set up a Monero (XMR) wallet so you can receive bounty payouts from MyZubster.
+>
+> 📌 **Screenshots in this guide are illustrative representations** of the wallet interfaces (Cake Wallet & Monero GUI). They show what each screen looks like so you can follow along. You can replace them with real screenshots of your own device at any time.
+
+## Why you need a Monero wallet
+
+MyZubster pays contributor rewards to the Monero address you register in the public registry. On the backend, the gateway uses `gateway/xmr_wallet.js` over Monero wallet RPC to monitor, release, and refund payouts. No wallet → no address → no payout.
+
+## 1. Choose a wallet
+
+| Wallet | Platform | Best for |
+|--------|----------|----------|
+| **Cake Wallet** | iOS / Android | Beginners, mobile, supports XMR out of the box |
+| **Monero GUI** | Windows / macOS / Linux | Desktop, full control, remote or local node |
+| **Feather Wallet** | Windows / macOS / Linux | Lightweight desktop, no blockchain download |
+| **Monerujo / Stack** | Android | Mobile, advanced users |
+
+Most contributors use **Cake Wallet** (easiest) or **Monero GUI** (desktop). See `images/monero/wallet-types.svg`.
+
+## 2. Install
+
+### Cake Wallet (mobile)
+1. Open the **App Store** (iOS) or **Google Play** (Android).
+2. Search **Cake Wallet**.
+3. Tap **Install / Get**.
+
+See `images/monero/install-cake.svg`.
+
+### Monero GUI (desktop)
+1. Go to the official site `https://www.getmonero.org/downloads/` (always use the official source).
+2. Pick your OS: **Windows / macOS / Linux**.
+3. Download and run the installer.
+
+See `images/monero/install-gui.svg`.
+
+## 3. Create a new wallet
+
+1. Open the app → choose **Create a new wallet** (choose **Restore** only if you already have a 25-word seed).
+2. Give it a name (e.g. `myzubster`).
+3. Tap **Create**.
+
+Your wallet now generates a **25-word mnemonic seed** — this is the master key to your funds.
+
+See `images/monero/create-wallet.svg`.
+
+## 4. Back up your seed phrase 🔐
+
+This is the single most important step.
+
+1. Write down all **25 words**, in order, on paper (not a screenshot, not cloud storage).
+2. **Never** share the seed with anyone — not even MyZubster staff.
+3. Store it offline (a safe or locked drawer).
+4. Confirm you have saved it to continue.
+
+See `images/monero/backup-seed.svg`.
+
+> ⚠️ If you lose your seed, your funds are **gone forever**. There is no recovery, no support ticket that can restore it.
+
+## 5. Receive XMR (get your address)
+
+1. Open the **Receive** tab.
+2. Copy your **XMR address** (starts with `4` or `8`, ~95 characters) or scan the QR code.
+3. Keep this address handy.
+
+See `images/monero/receive-xmr.svg`.
+
+### Register your address with MyZubster
+
+To actually get paid, your XMR address must be in the **public registry**:
+
+- If you have contributed before, your address is likely already saved (the maintainer confirms saved addresses from prior work).
+- Otherwise, open an issue or comment your address so it can be added to the registry.
+- One address per contributor is enough — you can reuse it for every bounty.
+
+## 6. Send XMR
+
+1. Open the **Send** tab.
+2. Paste the recipient **address** and enter the **amount**.
+3. Review the network fee, then tap **Send**.
+
+See `images/monero/send-xmr.svg`.
+
+## 7. View transactions
+
+Open the **History / Transactions** tab to see incoming payouts, outgoing sends, confirmation counts, and block height.
+
+See `images/monero/transactions.svg`.
+
+## Security checklist ✅
+
+- [ ] Seed written on paper and stored offline
+- [ ] Seed never typed into any website
+- [ ] Wallet app downloaded from the official source only
+- [ ] XMR address registered in the MyZubster registry
+- [ ] Tested with a tiny amount before any large transfer
+
+## FAQ
+
+**Q: Which wallet should I pick?**
+A: Cake Wallet if you are on a phone; Monero GUI if you want desktop control.
+
+**Q: Do I need to download the whole blockchain?**
+A: No — Cake Wallet and Monero GUI use remote nodes by default, so there is nothing to sync manually.
+
+**Q: Is my address private?**
+A: Your XMR address is public by design (it is needed to receive funds), but it does not reveal your identity or your seed.
+
+---
+
+*Contributor guide for issue #151 — community contribution (no XMR bounty). Screenshots are illustrative mockups.*

--- a/docs/images/monero/backup-seed.svg
+++ b/docs/images/monero/backup-seed.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="180" y="56" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Back up your seed</text>
+
+  <rect x="36" y="80" width="288" height="48" rx="12" fill="#3A1A1A" stroke="#FF5C5C"/>
+  <text x="52" y="104" fill="#FF8A8A" font-size="12" font-weight="700">⚠ Never share. Lose it = lose funds.</text>
+
+  <text x="36" y="160" fill="#C8C8D4" font-size="13">Write these 25 words in order:</text>
+
+  <g font-size="11" fill="#E8E8EF" text-anchor="middle">
+    <rect x="36" y="176" width="84" height="34" rx="8" fill="#23232E"/><text x="78" y="197">1. wheat</text>
+    <rect x="128" y="176" width="84" height="34" rx="8" fill="#23232E"/><text x="170" y="197">2. island</text>
+    <rect x="220" y="176" width="84" height="34" rx="8" fill="#23232E"/><text x="262" y="197">3. lunar</text>
+
+    <rect x="36" y="218" width="84" height="34" rx="8" fill="#23232E"/><text x="78" y="239">4. velvet</text>
+    <rect x="128" y="218" width="84" height="34" rx="8" fill="#23232E"/><text x="170" y="239">5. rocket</text>
+    <rect x="220" y="218" width="84" height="34" rx="8" fill="#23232E"/><text x="262" y="239">6. amber</text>
+
+    <rect x="36" y="260" width="84" height="34" rx="8" fill="#23232E"/><text x="78" y="281">7. forest</text>
+    <rect x="128" y="260" width="84" height="34" rx="8" fill="#23232E"/><text x="170" y="281">8. crystal</text>
+    <rect x="220" y="260" width="84" height="34" rx="8" fill="#23232E"/><text x="262" y="281">9. nebula</text>
+
+    <rect x="36" y="302" width="84" height="34" rx="8" fill="#23232E"/><text x="78" y="323">10. ocean</text>
+    <rect x="128" y="302" width="84" height="34" rx="8" fill="#23232E"/><text x="170" y="323">11. granite</text>
+    <rect x="220" y="302" width="84" height="34" rx="8" fill="#23232E"/><text x="262" y="323">12. ember</text>
+  </g>
+
+  <text x="36" y="380" fill="#6A6A78" font-size="11">… (25 words total) …</text>
+
+  <rect x="36" y="420" width="20" height="20" rx="5" fill="#FF8400"/>
+  <text x="66" y="436" fill="#C8C8D4" font-size="13">I have written down my seed offline</text>
+
+  <rect x="36" y="480" width="288" height="50" rx="14" fill="#2EC28B"/>
+  <text x="180" y="512" fill="#0E0E12" font-size="16" font-weight="700" text-anchor="middle">Confirm &amp; continue</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/create-wallet.svg
+++ b/docs/images/monero/create-wallet.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="36" y="60" fill="#9A9AA8" font-size="12">9:41</text>
+  <text x="180" y="56" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Create wallet</text>
+
+  <circle cx="180" cy="140" r="30" fill="#FF8400"/>
+  <text x="180" y="150" fill="#0E0E12" font-size="26" font-weight="800" text-anchor="middle">C</text>
+
+  <text x="36" y="220" fill="#C8C8D4" font-size="13">Wallet name</text>
+  <rect x="36" y="236" width="288" height="46" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="52" y="265" fill="#E8E8EF" font-size="14">myzubster</text>
+
+  <text x="36" y="316" fill="#C8C8D4" font-size="13">A new 25-word seed will be generated.</text>
+  <text x="36" y="338" fill="#9A9AA8" font-size="12">Write it down and store it offline.</text>
+
+  <rect x="36" y="380" width="288" height="46" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="52" y="409" fill="#6A6A78" font-size="13">•••••••••••••••••••••••</text>
+
+  <rect x="36" y="470" width="288" height="50" rx="14" fill="#FF8400"/>
+  <text x="180" y="502" fill="#0E0E12" font-size="16" font-weight="700" text-anchor="middle">Create wallet</text>
+
+  <text x="36" y="560" fill="#9A9AA8" font-size="12">Already have a seed?</text>
+  <text x="36" y="582" fill="#FF8400" font-size="13" font-weight="700">Restore existing wallet →</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/install-cake.svg
+++ b/docs/images/monero/install-cake.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="36" y="64" fill="#E8E8EF" font-size="20" font-weight="700">App Store</text>
+
+  <rect x="36" y="92" width="72" height="72" rx="16" fill="#FF8400"/>
+  <text x="72" y="140" fill="#0E0E12" font-size="34" font-weight="800" text-anchor="middle">C</text>
+  <text x="124" y="118" fill="#E8E8EF" font-size="18" font-weight="700">Cake Wallet</text>
+  <text x="124" y="140" fill="#9A9AA8" font-size="12">Finance · XMR wallet</text>
+  <rect x="256" y="104" width="60" height="30" rx="15" fill="#2EC28B"/>
+  <text x="286" y="124" fill="#0E0E12" font-size="13" font-weight="700" text-anchor="middle">GET</text>
+
+  <line x1="36" y1="186" x2="324" y2="186" stroke="#2A2A36"/>
+
+  <text x="36" y="216" fill="#C8C8D4" font-size="13">Preview</text>
+  <rect x="36" y="230" width="130" height="220" rx="12" fill="#23232E"/>
+  <rect x="178" y="230" width="130" height="220" rx="12" fill="#23232E"/>
+  <text x="101" y="346" fill="#6A6A78" font-size="12" text-anchor="middle">Wallet home</text>
+  <text x="243" y="346" fill="#6A6A78" font-size="12" text-anchor="middle">Receive</text>
+
+  <text x="36" y="486" fill="#C8C8D4" font-size="13">Description</text>
+  <text x="36" y="510" fill="#9A9AA8" font-size="12">Simple, open-source Monero</text>
+  <text x="36" y="530" fill="#9A9AA8" font-size="12">wallet for iOS &amp; Android.</text>
+
+  <rect x="36" y="588" width="288" height="46" rx="12" fill="#FF8400"/>
+  <text x="180" y="617" fill="#0E0E12" font-size="15" font-weight="700" text-anchor="middle">Install Cake Wallet</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/install-gui.svg
+++ b/docs/images/monero/install-gui.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 460" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="720" height="460" fill="#0E0E12"/>
+  <!-- browser window -->
+  <rect x="24" y="24" width="672" height="412" rx="14" fill="#16161E" stroke="#2A2A36"/>
+  <rect x="24" y="24" width="672" height="44" rx="14" fill="#1F1F29"/>
+  <circle cx="48" cy="46" r="6" fill="#FF5C5C"/>
+  <circle cx="68" cy="46" r="6" fill="#FBCA04"/>
+  <circle cx="88" cy="46" r="6" fill="#2EC28B"/>
+  <rect x="120" y="36" width="520" height="20" rx="10" fill="#0E0E12"/>
+  <text x="132" y="50" fill="#9A9AA8" font-size="12">getmonero.org/downloads</text>
+
+  <text x="48" y="108" fill="#E8E8EF" font-size="24" font-weight="700">Download Monero GUI</text>
+  <text x="48" y="136" fill="#9A9AA8" font-size="14">Official, free, open-source. Always download from getmonero.org.</text>
+
+  <!-- OS buttons -->
+  <g>
+    <rect x="48" y="170" width="180" height="64" rx="12" fill="#1A1A22" stroke="#2A2A36"/>
+    <text x="138" y="208" fill="#E8E8EF" font-size="16" font-weight="700" text-anchor="middle">Windows</text>
+    <rect x="244" y="170" width="180" height="64" rx="12" fill="#1A1A22" stroke="#2A2A36"/>
+    <text x="334" y="208" fill="#E8E8EF" font-size="16" font-weight="700" text-anchor="middle">macOS</text>
+    <rect x="440" y="170" width="180" height="64" rx="12" fill="#1A1A22" stroke="#2A2A36"/>
+    <text x="530" y="208" fill="#E8E8EF" font-size="16" font-weight="700" text-anchor="middle">Linux</text>
+  </g>
+
+  <rect x="48" y="266" width="220" height="48" rx="12" fill="#FF8400"/>
+  <text x="158" y="296" fill="#0E0E12" font-size="16" font-weight="700" text-anchor="middle">⬇ Download GUI</text>
+
+  <text x="48" y="360" fill="#C8C8D4" font-size="13">After download:</text>
+  <text x="48" y="384" fill="#9A9AA8" font-size="13">1. Run the installer   2. Choose "Create new wallet"   3. Back up your 25-word seed</text>
+
+  <text x="360" y="446" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/receive-xmr.svg
+++ b/docs/images/monero/receive-xmr.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="180" y="56" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Receive</text>
+
+  <rect x="100" y="90" width="160" height="160" rx="12" fill="#FFFFFF"/>
+  <g fill="#0E0E12">
+    <rect x="112" y="102" width="36" height="36"/><rect x="120" y="110" width="20" height="20" fill="#FFFFFF"/><rect x="128" y="118" width="6" height="6" fill="#0E0E12"/>
+    <rect x="212" y="102" width="36" height="36"/><rect x="220" y="110" width="20" height="20" fill="#FFFFFF"/><rect x="228" y="118" width="6" height="6" fill="#0E0E12"/>
+    <rect x="112" y="202" width="36" height="36"/><rect x="120" y="210" width="20" height="20" fill="#FFFFFF"/><rect x="128" y="218" width="6" height="6" fill="#0E0E12"/>
+    <rect x="160" y="150" width="10" height="10"/><rect x="180" y="160" width="10" height="10"/><rect x="200" y="140" width="10" height="10"/><rect x="170" y="190" width="10" height="10"/><rect x="210" y="180" width="10" height="10"/>
+  </g>
+
+  <text x="36" y="290" fill="#C8C8D4" font-size="13">Your XMR address</text>
+  <rect x="36" y="304" width="288" height="60" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="52" y="326" fill="#9A9AA8" font-size="11">42Xmr8sJ...a9F3kQ2m...</text>
+  <text x="52" y="348" fill="#9A9AA8" font-size="11">...7vB1cD4eR5tY8uI0oP</text>
+
+  <rect x="36" y="392" width="138" height="46" rx="12" fill="#FF8400"/>
+  <text x="105" y="421" fill="#0E0E12" font-size="14" font-weight="700" text-anchor="middle">Copy</text>
+  <rect x="186" y="392" width="138" height="46" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="255" y="421" fill="#E8E8EF" font-size="14" font-weight="700" text-anchor="middle">Share</text>
+
+  <text x="36" y="500" fill="#9A9AA8" font-size="12">Share this address to receive</text>
+  <text x="36" y="520" fill="#9A9AA8" font-size="12">bounty payouts from MyZubster.</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/send-xmr.svg
+++ b/docs/images/monero/send-xmr.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="180" y="56" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Send</text>
+
+  <text x="36" y="110" fill="#C8C8D4" font-size="13">Recipient address</text>
+  <rect x="36" y="124" width="288" height="56" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="52" y="148" fill="#9A9AA8" font-size="11">4Ad1x...kQ2m...7vB1cD4eR</text>
+  <text x="52" y="168" fill="#9A9AA8" font-size="11">paste recipient XMR address</text>
+
+  <text x="36" y="212" fill="#C8C8D4" font-size="13">Amount</text>
+  <rect x="36" y="226" width="288" height="56" rx="12" fill="#23232E" stroke="#2A2A36"/>
+  <text x="52" y="262" fill="#E8E8EF" font-size="20" font-weight="700">0.500000</text>
+  <text x="300" y="262" fill="#FF8400" font-size="14" font-weight="700" text-anchor="end">XMR</text>
+
+  <text x="36" y="312" fill="#9A9AA8" font-size="12">Network fee: ~0.000012 XMR</text>
+  <text x="36" y="334" fill="#9A9AA8" font-size="12">Total: 0.500012 XMR</text>
+
+  <rect x="36" y="392" width="288" height="50" rx="14" fill="#FF8400"/>
+  <text x="180" y="424" fill="#0E0E12" font-size="16" font-weight="700" text-anchor="middle">Send 0.500000 XMR</text>
+
+  <text x="36" y="500" fill="#9A9AA8" font-size="12">Double-check the address before</text>
+  <text x="36" y="520" fill="#9A9AA8" font-size="12">sending — XMR transfers are final.</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/transactions.svg
+++ b/docs/images/monero/transactions.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 720" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="360" height="720" fill="#0E0E12"/>
+  <rect x="20" y="20" width="320" height="680" rx="28" fill="#1A1A22" stroke="#2A2A36"/>
+  <text x="180" y="56" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Transactions</text>
+
+  <g>
+    <rect x="36" y="84" width="288" height="72" rx="14" fill="#23232E"/>
+    <circle cx="68" cy="120" r="18" fill="#163A2C"/>
+    <text x="68" y="126" fill="#2EC28B" font-size="16" font-weight="800" text-anchor="middle">↓</text>
+    <text x="100" y="112" fill="#E8E8EF" font-size="14" font-weight="700">Received</text>
+    <text x="100" y="134" fill="#9A9AA8" font-size="11">Bounty payout · 10 conf</text>
+    <text x="308" y="120" fill="#2EC28B" font-size="14" font-weight="700" text-anchor="end">+8.000</text>
+  </g>
+
+  <g>
+    <rect x="36" y="168" width="288" height="72" rx="14" fill="#23232E"/>
+    <circle cx="68" cy="204" r="18" fill="#3A1A1A"/>
+    <text x="68" y="210" fill="#FF5C5C" font-size="16" font-weight="800" text-anchor="middle">↑</text>
+    <text x="100" y="196" fill="#E8E8EF" font-size="14" font-weight="700">Sent</text>
+    <text x="100" y="218" fill="#9A9AA8" font-size="11">To external wallet · 12 conf</text>
+    <text x="308" y="204" fill="#FF5C5C" font-size="14" font-weight="700" text-anchor="end">-0.500</text>
+  </g>
+
+  <g>
+    <rect x="36" y="252" width="288" height="72" rx="14" fill="#23232E"/>
+    <circle cx="68" cy="288" r="18" fill="#3A3416"/>
+    <text x="68" y="294" fill="#FBCA04" font-size="14" font-weight="800" text-anchor="middle">⏳</text>
+    <text x="100" y="280" fill="#E8E8EF" font-size="14" font-weight="700">Pending</text>
+    <text x="100" y="302" fill="#9A9AA8" font-size="11">Incoming · 2 / 10 conf</text>
+    <text x="308" y="288" fill="#FBCA04" font-size="14" font-weight="700" text-anchor="end">+1.200</text>
+  </g>
+
+  <text x="36" y="372" fill="#9A9AA8" font-size="12">Tap any row for details (txid, block</text>
+  <text x="36" y="392" fill="#9A9AA8" font-size="12">height, confirmations).</text>
+
+  <text x="180" y="700" fill="#5A5A66" font-size="10" text-anchor="middle">illustrative mockup</text>
+</svg>

--- a/docs/images/monero/wallet-types.svg
+++ b/docs/images/monero/wallet-types.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 420" font-family="system-ui,Segoe UI,Roboto,sans-serif">
+  <rect width="720" height="420" fill="#0E0E12"/>
+  <text x="36" y="48" fill="#E8E8EF" font-size="26" font-weight="700">Choose your Monero wallet</text>
+  <text x="36" y="78" fill="#9A9AA8" font-size="15">Pick one that fits your device. All of them can receive XMR payouts.</text>
+
+  <g>
+    <rect x="36" y="110" width="200" height="270" rx="16" fill="#1A1A22" stroke="#2A2A36"/>
+    <circle cx="136" cy="170" r="26" fill="#FF8400"/>
+    <text x="136" y="179" fill="#0E0E12" font-size="22" font-weight="800" text-anchor="middle">M</text>
+    <text x="136" y="225" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Monero GUI</text>
+    <text x="136" y="250" fill="#9A9AA8" font-size="12" text-anchor="middle">Desktop · Win/Mac/Linux</text>
+    <text x="136" y="300" fill="#C8C8D4" font-size="12" text-anchor="middle">Full control</text>
+    <text x="136" y="320" fill="#C8C8D4" font-size="12" text-anchor="middle">Remote or local node</text>
+    <text x="136" y="356" fill="#2EC28B" font-size="12" font-weight="700" text-anchor="middle">Recommended (desktop)</text>
+  </g>
+
+  <g>
+    <rect x="260" y="110" width="200" height="270" rx="16" fill="#1A1A22" stroke="#FF8400"/>
+    <circle cx="360" cy="170" r="26" fill="#FF8400"/>
+    <text x="360" y="179" fill="#0E0E12" font-size="22" font-weight="800" text-anchor="middle">C</text>
+    <text x="360" y="225" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Cake Wallet</text>
+    <text x="360" y="250" fill="#9A9AA8" font-size="12" text-anchor="middle">Mobile · iOS / Android</text>
+    <text x="360" y="300" fill="#C8C8D4" font-size="12" text-anchor="middle">Easiest to start</text>
+    <text x="360" y="320" fill="#C8C8D4" font-size="12" text-anchor="middle">No blockchain download</text>
+    <text x="360" y="356" fill="#2EC28B" font-size="12" font-weight="700" text-anchor="middle">Recommended (mobile)</text>
+  </g>
+
+  <g>
+    <rect x="484" y="110" width="200" height="270" rx="16" fill="#1A1A22" stroke="#2A2A36"/>
+    <circle cx="584" cy="170" r="26" fill="#6C5CE7"/>
+    <text x="584" y="178" fill="#FFFFFF" font-size="20" font-weight="800" text-anchor="middle">F</text>
+    <text x="584" y="225" fill="#E8E8EF" font-size="17" font-weight="700" text-anchor="middle">Feather</text>
+    <text x="584" y="250" fill="#9A9AA8" font-size="12" text-anchor="middle">Desktop · light wallet</text>
+    <text x="584" y="300" fill="#C8C8D4" font-size="12" text-anchor="middle">Fast, portable</text>
+    <text x="584" y="320" fill="#C8C8D4" font-size="12" text-anchor="middle">Advanced options</text>
+    <text x="584" y="356" fill="#9A9AA8" font-size="12" text-anchor="middle">Optional</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
Adds a comprehensive Monero wallet setup guide for the MyZubster contributor payout flow (issue #151).

- `docs/MONERO_WALLET_GUIDE.md`: why you need a wallet, wallet type comparison (Cake Wallet / Monero GUI / Feather), install steps, create wallet, seed backup & security, receive XMR + register address with the MyZubster registry, send XMR, view transactions, security checklist, FAQ.
- `docs/images/monero/*.svg`: 8 dark-themed illustrative mockups (wallet-types, install-cake, install-gui, create-wallet, backup-seed, receive-xmr, send-xmr, transactions).

## Notes
- The screenshots are **illustrative SVG mockups** (no real wallet software / funds involved) — each is labeled as such in the doc and the images.
- Documentation-only change; no code/build impact.

Closes #151
