### PR TITLE
feat: real monero-wallet-rpc integration for XMR wallet (Closes #258)

### DIFF
--- a/gateway/xmr_wallet.js
+++ b/gateway/xmr_wallet.js
@@ -1,21 +1,161 @@
-// gateway/xmr_wallet.js – Gestione XMR (mock per test)
-const escrowLocks = new Map();
+// gateway/xmr_wallet.js – Real Monero (XMR) wallet backed by monero-wallet-rpc
+//
+// Replaces the previous mock stub. Talks to a monero-wallet-rpc endpoint over
+// JSON-RPC. All network access goes through a single `rpc()` helper so the
+// module is fully testable: callers (and tests) may inject their own `client`
+// instead of the default axios instance.
+const axios = require('axios');
 
-async function lockXMR(userId, amount) {
-  console.log(`🔒 [MOCK] Locked ${amount} XMR for user ${userId}`);
-  const mockTx = `mock_xmr_tx_${Date.now()}`;
-  escrowLocks.set(userId, { amount, txId: mockTx });
-  return mockTx;
+// XMR has 12 decimal places; the wallet RPC expects the atomic unit (piconeros).
+function toAtomic(amount) {
+  return Math.round(Number(amount) * 1e12);
 }
 
-async function releaseXMR(userId, amount) {
-  console.log(`💰 [MOCK] Released ${amount} XMR to user ${userId}`);
-  return `mock_release_${Date.now()}`;
+function createXmrWallet({ client, env = {} } = {}) {
+  const E = env || {};
+  const XMR_WALLET_URL = E.XMR_WALLET_URL || process.env.XMR_WALLET_URL || '';
+  const XMR_WALLET_PASSWORD = E.XMR_WALLET_PASSWORD || process.env.XMR_WALLET_PASSWORD || '';
+
+  const requiredConfirmations = parseInt(
+    E.XMR_REQUIRED_CONFIRMATIONS || process.env.XMR_REQUIRED_CONFIRMATIONS || '10',
+    10
+  );
+  const fcmpRequiredConfirmations = parseInt(
+    E.XMR_FCMP_REQUIRED_CONFIRMATIONS || process.env.XMR_FCMP_REQUIRED_CONFIRMATIONS || '10',
+    10
+  );
+  const fcmpPlusPlusConfigured =
+    (E.XMR_FCMP_PLUS_PLUS_ENABLED || process.env.XMR_FCMP_PLUS_PLUS_ENABLED || '') === 'true';
+
+  const rpcUrl = XMR_WALLET_URL.replace(/\/+$/, '') + '/json_rpc';
+
+  // Default client: real monero-wallet-rpc. Tests inject a mock instead.
+  const http =
+    client ||
+    axios.create({
+      baseURL: XMR_WALLET_URL ? rpcUrl : undefined,
+      auth: XMR_WALLET_PASSWORD ? { username: '', password: XMR_WALLET_PASSWORD } : undefined,
+    });
+
+  async function rpc(method, params) {
+    const body = { jsonrpc: '2.0', id: 'myz-gateway', method, params };
+    try {
+      const resp = await http.post(rpcUrl, body);
+      return resp.data.result;
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      throw new Error(`Monero wallet RPC ${method} failed: ${msg}`);
+    }
+  }
+
+  const locks = new Map();
+
+  function buildStatus(t, amount) {
+    const protocol = t.protocol ?? t.proof_type ?? 'ringct';
+    const isFcmp = protocol === 'fcmp++';
+    const required = isFcmp ? fcmpRequiredConfirmations : requiredConfirmations;
+    const confirmations = t.confirmations ?? 0;
+
+    let status = 'confirmed';
+    let reason = null;
+    const inPool = t.in_pool === true || t.type === 'pool';
+
+    if (inPool) {
+      status = 'pending';
+      reason = 'in_pool';
+    } else if (t.double_spend_seen) {
+      status = 'failed';
+      reason = 'double_spend_seen';
+    } else if ((t.amount ?? 0) < toAtomic(amount)) {
+      status = 'pending';
+      reason = 'underpaid';
+    } else if (confirmations < required) {
+      status = 'pending';
+      reason = 'insufficient_confirmations';
+    }
+
+    return {
+      status,
+      txHash: t.txid,
+      confirmations,
+      amount,
+      inPool,
+      unlockTime: t.unlock_time ?? 0,
+      protocol,
+      isFcmpPlusPlus: isFcmp,
+      requiredConfirmations: required,
+      reason,
+    };
+  }
+
+  async function lockXMR(userId, amount) {
+    const result = await rpc('create_address', { account_index: 0, label: `escrow:${userId}` });
+    locks.set(userId, result.address);
+    return result.address;
+  }
+
+  async function releaseXMR(address, amount) {
+    const result = await rpc('transfer', {
+      destinations: [{ amount: toAtomic(amount), address }],
+    });
+    return result.tx_hash ?? result.tx_hash_list?.[0];
+  }
+
+  async function refundXMR(address, amount) {
+    const result = await rpc('transfer', {
+      destinations: [{ amount: toAtomic(amount), address }],
+    });
+    return result.tx_hash_list?.[0] ?? result.tx_hash;
+  }
+
+  async function getTransferStatus(txid, amount) {
+    const result = await rpc('get_transfer_by_txid', { txid });
+    return buildStatus(result.transfer, amount);
+  }
+
+  async function getLockStatus(userId) {
+    const result = await rpc('get_transfers', { in: true, account_index: 0 });
+    const transfers = result.in || [];
+    const addr = locks.get(userId);
+    const t = addr ? transfers.find((x) => x.address === addr) : transfers[0];
+    if (!t) {
+      return {
+        status: 'unknown',
+        txHash: null,
+        confirmations: 0,
+        amount: undefined,
+        inPool: false,
+        unlockTime: 0,
+        protocol: 'ringct',
+        isFcmpPlusPlus: false,
+        requiredConfirmations,
+        reason: 'no_transfer_found',
+      };
+    }
+    return buildStatus(t, undefined);
+  }
+
+  async function getWalletCapabilities() {
+    const versionRes = await rpc('get_version', {});
+    const heightRes = await rpc('get_height', {});
+    return {
+      version: versionRes.version,
+      height: heightRes.height,
+      fcmpPlusPlusConfigured,
+      supportedProtocols: ['ringct', 'fcmp++'],
+      requiredConfirmations,
+      fcmpRequiredConfirmations,
+    };
+  }
+
+  return {
+    lockXMR,
+    releaseXMR,
+    refundXMR,
+    getTransferStatus,
+    getLockStatus,
+    getWalletCapabilities,
+  };
 }
 
-async function refundXMR(userId, amount) {
-  console.log(`↩️ [MOCK] Refunded ${amount} XMR to user ${userId}`);
-  return `mock_refund_${Date.now()}`;
-}
-
-module.exports = { lockXMR, releaseXMR, refundXMR };
+module.exports = { createXmrWallet };


### PR DESCRIPTION
## Summary

Implements the real `monero-wallet-rpc` integration for `gateway/xmr_wallet.js`, replacing the previous mock stub so the existing `tests/xmr-wallet.test.js` passes green.

The module now exports a `createXmrWallet({ client, env })` factory that talks to a Monero wallet RPC endpoint over JSON-RPC:

- **`lockXMR(userId, amount)`** – calls `create_address` to mint an isolated escrow subaddress and returns it
- **`releaseXMR(address, amount)`** – `transfer` to release escrowed XMR (returns `tx_hash`)
- **`refundXMR(address, amount)`** – `transfer` to refund the client (returns `tx_hash_list[0]`)
- **`getTransferStatus(txid, amount)`** – resolves confirmation state with FCMP++ / RingCT protocol detection, confirmation thresholds, double-spend and in-pool checks
- **`getLockStatus(userId)`** – monitors inbound transfers to the locked subaddress
- **`getWalletCapabilities()`** – reports wallet version/height and FCMP++ configuration

Error handling wraps every RPC failure with operation context (e.g. `Monero wallet RPC create_address failed: <cause>`), and configuration is driven by env vars (`XMR_WALLET_URL`, `XMR_WALLET_PASSWORD`, `XMR_REQUIRED_CONFIRMATIONS`, `XMR_FCMP_REQUIRED_CONFIRMATIONS`, `XMR_FCMP_PLUS_PLUS_ENABLED`).

## Test plan

The implementation is fully covered by the existing `tests/xmr-wallet.test.js` (node:test). All RPC access flows through a single `rpc()` helper, so tests inject a mock client and assert on the exact JSON-RPC payloads and returned statuses — no live wallet or network required.

```
$ node --test tests/xmr-wallet.test.js
# tests 11  # pass 11  # fail 0
```

To run against a real node, set `XMR_WALLET_URL` / `XMR_WALLET_PASSWORD` and the default axios client is used instead of the injected mock.

## Notes

- The test file (`tests/xmr-wallet.test.js`) already existed on `main`; this PR supplies the matching implementation so the suite goes green.
- XMR payout address already on file: `44kLzNXHV9EDxHN948HsvhhEQpQY6iyE6LfgCbFz463JM1bpz3UtWwUTPuQJ25nMzuQmfjYiDcqYvN9uYkTp3v5J2E1hisp`

Closes #258
