### PR TITLE
Fix issue with safely handle localstorage access in themepro

### DIFF
--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -20,7 +20,11 @@ export const ThemeProvider = ({ children }) => {
       root.classList.toggle('dark', isDark);
     };
     apply();
-    localStorage.setItem(STORAGE_KEY, theme);
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      // Ignore quota or security exceptions in restricted environments
+    }
 
     if (theme === 'system') {
       const mq = window.matchMedia('(prefers-color-scheme: dark)');


### PR DESCRIPTION
Wrap localStorage.setItem in a try/catch block to prevent runtime crashes in restricted browser environments where storage is disabled or quota is exceeded.

$ https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/214
Fixes https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/214