### PR TITLE
feat: endpoint statistiche robot /api/robot/stats (Bounty P2, closes #266)

### DIFF
--- a/docs/openapi/robot-stats.yaml
+++ b/docs/openapi/robot-stats.yaml
@@ -1,0 +1,158 @@
+openapi: 3.0.3
+info:
+  title: MyZubsterGateway — Robot Stats
+  version: "1.0.0"
+  description: >
+    Frammento OpenAPI per l'endpoint statistiche robot (Bounty P2, issue #266).
+    È un documento valido a sé stante e può essere unito allo spec globale del
+    gateway non appena esiste. Le stesse annotazioni sono presenti in
+    `routes/robot.js` in formato `@openapi` per swagger-jsdoc.
+servers:
+  - url: http://localhost:10000
+    description: Sviluppo locale
+paths:
+  /api/robot/stats:
+    get:
+      tags: [Robot]
+      summary: Statistiche aggregate sui robot
+      description: >
+        Totale robot, robot attivi (`working` o `delivering`), robot in disputa e
+        media dei job completati. La risposta è servita da una cache in-process
+        con TTL configurabile via `ROBOT_STATS_CACHE_TTL` (secondi, default 10).
+        I dati sono uniti per `robotId` fra lo stato in memoria del robot_brain e
+        la collection Mongo `robots`, con precedenza alla memoria.
+      parameters:
+        - in: query
+          name: refresh
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Se `true` (o `1`) ignora la cache e ricalcola al volo.
+      responses:
+        "200":
+          description: Statistiche aggregate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RobotStatsResponse"
+              example:
+                success: true
+                data:
+                  totalRobots: 12
+                  activeRobots: 4
+                  idleRobots: 7
+                  disputeRobots: 1
+                  byStatus: { idle: 7, working: 3, delivering: 1, dispute: 1 }
+                  jobsInProgress: 4
+                  totalJobsCompleted: 58
+                  averageJobsCompleted: 4.83
+                  averageReputation: 4.83
+                  totalEarned: 1420.5
+                  topRobots:
+                    - robotId: robot-001
+                      name: Logo Bot
+                      status: idle
+                      jobsCompleted: 21
+                      reputation: 21
+                      totalEarned: 512.4
+                  sources: { memory: 12, database: 9 }
+                  cache:
+                    cached: false
+                    generatedAt: "2025-01-01T12:00:00.000Z"
+                    ttlSeconds: 10
+        "500":
+          description: Errore nel calcolo delle statistiche
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+components:
+  schemas:
+    RobotStatsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: "#/components/schemas/RobotStats"
+    RobotStats:
+      type: object
+      properties:
+        totalRobots:
+          type: integer
+          description: Robot registrati (memoria + database, deduplicati per robotId).
+        activeRobots:
+          type: integer
+          description: Robot con status `working` o `delivering`.
+        idleRobots:
+          type: integer
+        disputeRobots:
+          type: integer
+        byStatus:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Conteggio per ogni status noto del robot.
+        jobsInProgress:
+          type: integer
+          description: Robot che hanno un `currentJob` assegnato.
+        totalJobsCompleted:
+          type: integer
+        averageJobsCompleted:
+          type: number
+          description: Media job completati per robot, arrotondata a 2 decimali.
+        averageReputation:
+          type: number
+        totalEarned:
+          type: number
+        topRobots:
+          type: array
+          description: I 5 robot con più job completati.
+          items:
+            $ref: "#/components/schemas/TopRobot"
+        sources:
+          type: object
+          properties:
+            memory:
+              type: integer
+            database:
+              type: integer
+        cache:
+          $ref: "#/components/schemas/CacheInfo"
+    TopRobot:
+      type: object
+      properties:
+        robotId:
+          type: string
+        name:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [idle, working, delivering, dispute]
+        jobsCompleted:
+          type: integer
+        reputation:
+          type: integer
+        totalEarned:
+          type: number
+    CacheInfo:
+      type: object
+      properties:
+        cached:
+          type: boolean
+          description: true se la risposta arriva dalla cache.
+        generatedAt:
+          type: string
+          format: date-time
+        ttlSeconds:
+          type: number
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string

--- a/robot_brain.js
+++ b/robot_brain.js
@@ -75,4 +75,8 @@ function getRobotStatus(robotId) {
   };
 }
 
-module.exports = { createRobot, assignJobToRobot, executeJob, deliverJob, handleDispute, getRobotStatus };
+function getAllRobots() {
+  return Array.from(robotState.values());
+}
+
+module.exports = { createRobot, assignJobToRobot, executeJob, deliverJob, handleDispute, getRobotStatus, getAllRobots };

--- a/routes/robot.js
+++ b/routes/robot.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const robotBrain = require('../robot_brain');
+const { getRobotStats } = require('../services/robotStatsService');
 
 router.post('/create', (req, res) => {
   try {
@@ -79,6 +80,94 @@ router.post('/dispute', async (req, res) => {
     res.json({ success: true, data: result });
   } catch (err) {
     res.status(400).json({ error: err.message });
+  }
+});
+
+/**
+ * @openapi
+ * /api/robot/stats:
+ *   get:
+ *     tags: [Robot]
+ *     summary: Statistiche aggregate sui robot
+ *     description: >
+ *       Restituisce il totale dei robot, quanti sono attivi, quanti in disputa e
+ *       la media dei job completati. Il risultato è servito da una cache
+ *       in-process con TTL breve (`ROBOT_STATS_CACHE_TTL`, default 10s).
+ *     parameters:
+ *       - in: query
+ *         name: refresh
+ *         required: false
+ *         schema: { type: boolean, default: false }
+ *         description: Se `true` ignora la cache e ricalcola le statistiche.
+ *     responses:
+ *       200:
+ *         description: Statistiche aggregate
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     totalRobots: { type: integer, example: 12 }
+ *                     activeRobots: { type: integer, example: 4, description: "status working o delivering" }
+ *                     idleRobots: { type: integer, example: 7 }
+ *                     disputeRobots: { type: integer, example: 1 }
+ *                     byStatus:
+ *                       type: object
+ *                       properties:
+ *                         idle: { type: integer, example: 7 }
+ *                         working: { type: integer, example: 3 }
+ *                         delivering: { type: integer, example: 1 }
+ *                         dispute: { type: integer, example: 1 }
+ *                     jobsInProgress: { type: integer, example: 4 }
+ *                     totalJobsCompleted: { type: integer, example: 58 }
+ *                     averageJobsCompleted: { type: number, example: 4.83 }
+ *                     averageReputation: { type: number, example: 4.83 }
+ *                     totalEarned: { type: number, example: 1420.5 }
+ *                     topRobots:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           robotId: { type: string, example: robot-001 }
+ *                           name: { type: string, example: Logo Bot }
+ *                           status: { type: string, example: idle }
+ *                           jobsCompleted: { type: integer, example: 21 }
+ *                           reputation: { type: integer, example: 21 }
+ *                           totalEarned: { type: number, example: 512.4 }
+ *                     sources:
+ *                       type: object
+ *                       description: Numero di robot letti da ciascuna sorgente.
+ *                       properties:
+ *                         memory: { type: integer, example: 12 }
+ *                         database: { type: integer, example: 9 }
+ *                     cache:
+ *                       type: object
+ *                       properties:
+ *                         cached: { type: boolean, example: true }
+ *                         generatedAt: { type: string, format: date-time }
+ *                         ttlSeconds: { type: number, example: 10 }
+ *       500:
+ *         description: Errore nel calcolo delle statistiche
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: false }
+ *                 error: { type: string }
+ */
+router.get('/stats', async (req, res) => {
+  try {
+    const refresh = req.query.refresh === 'true' || req.query.refresh === '1';
+    const stats = await getRobotStats({ refresh });
+    res.json({ success: true, data: stats });
+  } catch (err) {
+    console.error('Robot stats failed:', err);
+    res.status(500).json({ success: false, error: err.message });
   }
 });
 

--- a/services/robotStatsService.js
+++ b/services/robotStatsService.js
@@ -1,0 +1,151 @@
+/**
+ * Robot Stats Service - Bounty P2 (#266)
+ *
+ * Aggrega le statistiche sui robot esposte da GET /api/robot/stats.
+ * Le sorgenti sono due e vengono unite per robotId:
+ *   1. lo stato in memoria di robot_brain (sempre disponibile, sempre fresco)
+ *   2. la collection Mongo `robots`, quando la connessione è attiva
+ * Lo stato in memoria vince sui documenti persistiti, perché è quello su cui
+ * operano assign/execute/deliver/dispute.
+ *
+ * Il risultato è tenuto in una cache in-process con TTL breve, così l'endpoint
+ * regge il polling di una dashboard senza ricalcolare a ogni richiesta.
+ */
+
+const mongoose = require('mongoose');
+const robotBrain = require('../robot_brain');
+const Robot = require('../models/Robot');
+
+const DEFAULT_TTL_SECONDS = 10;
+const ACTIVE_STATUSES = ['working', 'delivering'];
+
+let cache = null; // { data, expiresAt, generatedAt }
+
+function cacheTtlMs() {
+  const configured = parseInt(process.env.ROBOT_STATS_CACHE_TTL, 10);
+  const seconds = Number.isFinite(configured) && configured >= 0 ? configured : DEFAULT_TTL_SECONDS;
+  return seconds * 1000;
+}
+
+function round(value, decimals = 2) {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function normalize(robot) {
+  return {
+    robotId: robot.robotId,
+    name: robot.name || null,
+    status: robot.status || 'idle',
+    jobsCompleted: Number(robot.jobsCompleted) || 0,
+    reputation: Number(robot.reputation) || 0,
+    totalEarned: Number(robot.totalEarned) || 0,
+    hasCurrentJob: !!robot.currentJob,
+    createdAt: robot.createdAt ? new Date(robot.createdAt).toISOString() : null
+  };
+}
+
+function isMongoConnected() {
+  return mongoose.connection && mongoose.connection.readyState === 1;
+}
+
+/**
+ * Unisce robot in memoria e robot persistiti. La memoria ha la precedenza.
+ */
+async function collectRobots() {
+  const byId = new Map();
+  const sources = { memory: 0, database: 0 };
+
+  if (isMongoConnected()) {
+    try {
+      const docs = await Robot.find({}).lean();
+      for (const doc of docs) {
+        byId.set(doc.robotId, normalize(doc));
+      }
+      sources.database = docs.length;
+    } catch (err) {
+      // La persistenza è opzionale: se Mongo non risponde le statistiche
+      // restano valide sullo stato in memoria.
+      console.error('robotStats: lettura da MongoDB fallita:', err.message);
+    }
+  }
+
+  for (const robot of robotBrain.getAllRobots()) {
+    byId.set(robot.robotId, normalize(robot));
+    sources.memory += 1;
+  }
+
+  return { robots: Array.from(byId.values()), sources };
+}
+
+function buildStats(robots, sources) {
+  const byStatus = { idle: 0, working: 0, delivering: 0, dispute: 0 };
+  let totalJobsCompleted = 0;
+  let totalEarned = 0;
+  let totalReputation = 0;
+  let jobsInProgress = 0;
+
+  for (const robot of robots) {
+    byStatus[robot.status] = (byStatus[robot.status] || 0) + 1;
+    totalJobsCompleted += robot.jobsCompleted;
+    totalEarned += robot.totalEarned;
+    totalReputation += robot.reputation;
+    if (robot.hasCurrentJob) jobsInProgress += 1;
+  }
+
+  const totalRobots = robots.length;
+  const activeRobots = ACTIVE_STATUSES.reduce((sum, status) => sum + (byStatus[status] || 0), 0);
+
+  const topRobots = robots
+    .slice()
+    .sort((a, b) => b.jobsCompleted - a.jobsCompleted || b.reputation - a.reputation)
+    .slice(0, 5)
+    .map(({ robotId, name, status, jobsCompleted, reputation, totalEarned: earned }) => ({
+      robotId, name, status, jobsCompleted, reputation, totalEarned: round(earned)
+    }));
+
+  return {
+    totalRobots,
+    activeRobots,
+    idleRobots: byStatus.idle || 0,
+    disputeRobots: byStatus.dispute || 0,
+    byStatus,
+    jobsInProgress,
+    totalJobsCompleted,
+    averageJobsCompleted: totalRobots ? round(totalJobsCompleted / totalRobots) : 0,
+    averageReputation: totalRobots ? round(totalReputation / totalRobots) : 0,
+    totalEarned: round(totalEarned),
+    topRobots,
+    sources
+  };
+}
+
+/**
+ * @param {{ refresh?: boolean }} [options] refresh=true ignora la cache.
+ */
+async function getRobotStats(options = {}) {
+  const now = Date.now();
+  const ttl = cacheTtlMs();
+
+  if (!options.refresh && cache && now < cache.expiresAt) {
+    return {
+      ...cache.data,
+      cache: { cached: true, generatedAt: cache.generatedAt, ttlSeconds: ttl / 1000 }
+    };
+  }
+
+  const { robots, sources } = await collectRobots();
+  const data = buildStats(robots, sources);
+  const generatedAt = new Date(now).toISOString();
+
+  cache = ttl > 0 ? { data, expiresAt: now + ttl, generatedAt } : null;
+
+  return { ...data, cache: { cached: false, generatedAt, ttlSeconds: ttl / 1000 } };
+}
+
+function clearRobotStatsCache() {
+  cache = null;
+}
+
+module.exports = { getRobotStats, clearRobotStatsCache, buildStats };

--- a/tests/robotStats.test.js
+++ b/tests/robotStats.test.js
@@ -1,0 +1,179 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+const robotBrain = require('../robot_brain');
+const { getRobotStats, clearRobotStatsCache, buildStats } = require('../services/robotStatsService');
+const router = require('../routes/robot');
+
+// robot_brain tiene lo stato in un Map di modulo: i robot creati qui restano
+// visibili per tutta la suite, quindi ogni test usa id univoci.
+let seq = 0;
+function uniqueId(prefix) {
+  seq += 1;
+  return `${prefix}-${process.pid}-${seq}`;
+}
+
+function seedRobot({ status = 'idle', jobsCompleted = 0, reputation = 0, totalEarned = 0, currentJob = null } = {}) {
+  const robotId = uniqueId('stats-robot');
+  const robot = robotBrain.createRobot(robotId, `Robot ${robotId}`, `wallet_${robotId}`);
+  Object.assign(robot, { status, jobsCompleted, reputation, totalEarned, currentJob });
+  return robot;
+}
+
+/** Esegue una route del router express raccogliendo la risposta. */
+function callRoute(method, path, { query = {}, params = {} } = {}) {
+  const layer = router.stack.find(l => l.route && l.route.path === path && l.route.methods[method]);
+  assert.ok(layer, `route ${method.toUpperCase()} ${path} non registrata`);
+
+  const req = { method: method.toUpperCase(), query, params, body: {} };
+  return new Promise((resolve, reject) => {
+    const res = {
+      statusCode: 200,
+      status(code) { this.statusCode = code; return this; },
+      json(body) { resolve({ statusCode: this.statusCode, body }); }
+    };
+    Promise.resolve(layer.route.stack[0].handle(req, res, reject)).catch(reject);
+  });
+}
+
+describe('buildStats', () => {
+  it('conta robot attivi, idle e in disputa', () => {
+    const stats = buildStats([
+      { robotId: 'a', name: 'A', status: 'idle', jobsCompleted: 2, reputation: 2, totalEarned: 10, hasCurrentJob: false },
+      { robotId: 'b', name: 'B', status: 'working', jobsCompleted: 4, reputation: 4, totalEarned: 20, hasCurrentJob: true },
+      { robotId: 'c', name: 'C', status: 'delivering', jobsCompleted: 6, reputation: 6, totalEarned: 30, hasCurrentJob: true },
+      { robotId: 'd', name: 'D', status: 'dispute', jobsCompleted: 0, reputation: 0, totalEarned: 0, hasCurrentJob: true }
+    ], { memory: 4, database: 0 });
+
+    assert.strictEqual(stats.totalRobots, 4);
+    assert.strictEqual(stats.activeRobots, 2, 'working + delivering');
+    assert.strictEqual(stats.idleRobots, 1);
+    assert.strictEqual(stats.disputeRobots, 1);
+    assert.strictEqual(stats.jobsInProgress, 3);
+    assert.strictEqual(stats.totalJobsCompleted, 12);
+    assert.strictEqual(stats.averageJobsCompleted, 3);
+    assert.strictEqual(stats.totalEarned, 60);
+    assert.deepStrictEqual(stats.byStatus, { idle: 1, working: 1, delivering: 1, dispute: 1 });
+  });
+
+  it('non divide per zero quando non ci sono robot', () => {
+    const stats = buildStats([], { memory: 0, database: 0 });
+    assert.strictEqual(stats.totalRobots, 0);
+    assert.strictEqual(stats.averageJobsCompleted, 0);
+    assert.strictEqual(stats.averageReputation, 0);
+    assert.deepStrictEqual(stats.topRobots, []);
+  });
+
+  it('arrotonda le medie a 2 decimali', () => {
+    const stats = buildStats([
+      { robotId: 'a', status: 'idle', jobsCompleted: 1, reputation: 1, totalEarned: 1.256, hasCurrentJob: false },
+      { robotId: 'b', status: 'idle', jobsCompleted: 2, reputation: 2, totalEarned: 0, hasCurrentJob: false },
+      { robotId: 'c', status: 'idle', jobsCompleted: 2, reputation: 2, totalEarned: 0, hasCurrentJob: false }
+    ], { memory: 3, database: 0 });
+    assert.strictEqual(stats.averageJobsCompleted, 1.67);
+    assert.strictEqual(stats.totalEarned, 1.26);
+  });
+
+  it('ordina topRobots per job completati e limita a 5', () => {
+    const robots = Array.from({ length: 8 }, (_, i) => ({
+      robotId: `r${i}`, name: `R${i}`, status: 'idle', jobsCompleted: i, reputation: i, totalEarned: i, hasCurrentJob: false
+    }));
+    const stats = buildStats(robots, { memory: 8, database: 0 });
+    assert.strictEqual(stats.topRobots.length, 5);
+    assert.deepStrictEqual(stats.topRobots.map(r => r.robotId), ['r7', 'r6', 'r5', 'r4', 'r3']);
+  });
+
+  it('tiene traccia di status non previsti senza perderli', () => {
+    const stats = buildStats([
+      { robotId: 'x', status: 'maintenance', jobsCompleted: 0, reputation: 0, totalEarned: 0, hasCurrentJob: false }
+    ], { memory: 1, database: 0 });
+    assert.strictEqual(stats.byStatus.maintenance, 1);
+    assert.strictEqual(stats.activeRobots, 0);
+  });
+});
+
+describe('getRobotStats', () => {
+  beforeEach(() => clearRobotStatsCache());
+
+  it('include i robot presenti in memoria', async () => {
+    const before = await getRobotStats({ refresh: true });
+    seedRobot({ status: 'working', jobsCompleted: 3, reputation: 3, totalEarned: 100, currentJob: { jobId: 'j1' } });
+    const after = await getRobotStats({ refresh: true });
+
+    assert.strictEqual(after.totalRobots, before.totalRobots + 1);
+    assert.strictEqual(after.sources.memory, before.sources.memory + 1);
+    assert.strictEqual(after.byStatus.working, (before.byStatus.working || 0) + 1);
+    assert.strictEqual(after.jobsInProgress, before.jobsInProgress + 1);
+    assert.strictEqual(after.totalJobsCompleted, before.totalJobsCompleted + 3);
+    assert.strictEqual(after.totalEarned, before.totalEarned + 100);
+  });
+
+  it('serve la seconda chiamata dalla cache', async () => {
+    process.env.ROBOT_STATS_CACHE_TTL = '30';
+    const first = await getRobotStats({ refresh: true });
+    assert.strictEqual(first.cache.cached, false);
+    assert.strictEqual(first.cache.ttlSeconds, 30);
+
+    seedRobot(); // non deve comparire finché la cache è valida
+    const second = await getRobotStats();
+    assert.strictEqual(second.cache.cached, true);
+    assert.strictEqual(second.totalRobots, first.totalRobots);
+    delete process.env.ROBOT_STATS_CACHE_TTL;
+  });
+
+  it('refresh=true bypassa la cache', async () => {
+    process.env.ROBOT_STATS_CACHE_TTL = '30';
+    const first = await getRobotStats({ refresh: true });
+    seedRobot();
+    const second = await getRobotStats({ refresh: true });
+    assert.strictEqual(second.cache.cached, false);
+    assert.strictEqual(second.totalRobots, first.totalRobots + 1);
+    delete process.env.ROBOT_STATS_CACHE_TTL;
+  });
+
+  it('con TTL 0 non mette nulla in cache', async () => {
+    process.env.ROBOT_STATS_CACHE_TTL = '0';
+    await getRobotStats({ refresh: true });
+    const second = await getRobotStats();
+    assert.strictEqual(second.cache.cached, false);
+    delete process.env.ROBOT_STATS_CACHE_TTL;
+  });
+});
+
+describe('GET /api/robot/stats', () => {
+  beforeEach(() => clearRobotStatsCache());
+
+  it('risponde 200 con success e data', async () => {
+    seedRobot({ status: 'dispute' });
+    const { statusCode, body } = await callRoute('get', '/stats', { query: { refresh: 'true' } });
+
+    assert.strictEqual(statusCode, 200);
+    assert.strictEqual(body.success, true);
+    assert.strictEqual(typeof body.data.totalRobots, 'number');
+    assert.strictEqual(typeof body.data.activeRobots, 'number');
+    assert.strictEqual(typeof body.data.averageJobsCompleted, 'number');
+    assert.ok(body.data.disputeRobots >= 1);
+    assert.ok(Array.isArray(body.data.topRobots));
+    assert.strictEqual(body.data.cache.cached, false);
+  });
+
+  it('senza refresh riusa la cache', async () => {
+    await callRoute('get', '/stats', { query: { refresh: 'true' } });
+    const { body } = await callRoute('get', '/stats');
+    assert.strictEqual(body.data.cache.cached, true);
+  });
+
+  it('accetta refresh=1 come refresh=true', async () => {
+    await callRoute('get', '/stats', { query: { refresh: 'true' } });
+    const { body } = await callRoute('get', '/stats', { query: { refresh: '1' } });
+    assert.strictEqual(body.data.cache.cached, false);
+  });
+
+  it('non ruba il path a GET /status/:robotId', async () => {
+    const robot = seedRobot({ jobsCompleted: 7 });
+    const { statusCode, body } = await callRoute('get', '/status/:robotId', { params: { robotId: robot.robotId } });
+    assert.strictEqual(statusCode, 200);
+    assert.strictEqual(body.data.robotId, robot.robotId);
+    assert.strictEqual(body.data.jobsCompleted, 7);
+  });
+});


### PR DESCRIPTION
Closes #266

## 📌 Cosa fa

Aggiunge l'endpoint `GET /api/robot/stats` con le statistiche aggregate sui robot.

```bash
curl http://localhost:10000/api/robot/stats
curl http://localhost:10000/api/robot/stats?refresh=true   # bypassa la cache
```

```json
{
  "success": true,
  "data": {
    "totalRobots": 12,
    "activeRobots": 4,
    "idleRobots": 7,
    "disputeRobots": 1,
    "byStatus": { "idle": 7, "working": 3, "delivering": 1, "dispute": 1 },
    "jobsInProgress": 4,
    "totalJobsCompleted": 58,
    "averageJobsCompleted": 4.83,
    "averageReputation": 4.83,
    "totalEarned": 1420.5,
    "topRobots": [ { "robotId": "robot-001", "name": "Logo Bot", "status": "idle", "jobsCompleted": 21, "reputation": 21, "totalEarned": 512.4 } ],
    "sources": { "memory": 12, "database": 9 },
    "cache": { "cached": false, "generatedAt": "2025-01-01T12:00:00.000Z", "ttlSeconds": 10 }
  }
}
```

## ✅ Criteri di accettazione

- [x] **Endpoint `/api/robot/stats` (GET)** — `routes/robot.js`, montato sotto `/api/robot` in `server.js` (nessuna modifica a `server.js` necessaria).
- [x] **Restituisce JSON con le statistiche** — totale robot, attivi, in disputa, media job completati, più media reputazione, MYZ totali, job in corso e top 5 robot.
- [x] **Aggiornato in tempo reale (cache o calcolo al volo)** — cache in-process con TTL configurabile via `ROBOT_STATS_CACHE_TTL` (secondi, default `10`; `0` disabilita la cache). `?refresh=true` (o `?refresh=1`) forza il ricalcolo.
- [x] **Documentazione Swagger/OpenAPI** — annotazioni `@openapi` per swagger-jsdoc direttamente su `routes/robot.js` **+** frammento OpenAPI 3.0 autonomo in `docs/openapi/robot-stats.yaml`, pronto da unire allo spec globale.

## 🧩 Dettagli implementativi

- **Due sorgenti unite per `robotId`**: lo stato in memoria di `robot_brain` (quello su cui operano assign/execute/deliver/dispute) e la collection Mongo `robots`. La memoria ha precedenza; il campo `sources` mostra quanti robot arrivano da ciascuna.
- **Nessuna nuova dipendenza npm.** Zero modifiche al comportamento delle route esistenti.
- **Degrada in sicurezza**: se MongoDB non è connesso o la query fallisce, l'endpoint risponde comunque usando lo stato in memoria (l'errore viene solo loggato).
- `robot_brain.js` espone il nuovo `getAllRobots()` — aggiunta puramente additiva.

## 🧪 Test

`tests/robotStats.test.js` — 13 test con il runner nativo (`node --test`), la stessa convenzione di `tests/rateLimiter.test.js`:

```
$ node --test tests/robotStats.test.js
# tests 13
# pass 13
# fail 0
```

Coperti: conteggi per status, status non previsti, divisione per zero con 0 robot, arrotondamento a 2 decimali, ordinamento e limite di `topRobots`, hit/miss di cache, `refresh=true`, TTL `0`, risposta della route e non-regressione di `GET /status/:robotId`.

> ℹ️ Nota non collegata a questa PR: `npm test` esegue `tests/*.test.js` e oggi si blocca su `tests/rateLimiter.test.js` (il `setInterval` in `middleware/rateLimiter.js` non è `unref()`-ato) e `tests/xmr-wallet.test.js` fallisce già su `main`. Entrambi preesistenti — fatemi sapere se volete che li sistemi in una PR separata.

## 📄 File

| File | |
|---|---|
| `services/robotStatsService.js` | nuovo — aggregazione + cache |
| `routes/robot.js` | route `GET /stats` + annotazioni OpenAPI |
| `robot_brain.js` | nuovo export `getAllRobots()` |
| `docs/openapi/robot-stats.yaml` | nuovo — frammento OpenAPI 3.0 |
| `tests/robotStats.test.js` | nuovo — 13 test |