### PR TITLE
feat: sistema di audit logging completo (Bounty B14, closes #279)

### DIFF
--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -1,0 +1,130 @@
+# Audit Logging
+
+Bounty B14 (#279). Traccia automatica di tutte le azioni critiche del gateway: pagamenti, escrow, robot, bounty, webhook GitHub, stake, reward e reset del rate limiter.
+
+## Come funziona
+
+`middleware/auditLogger.js` è montato in `server.js` subito dopo `express.json()`, prima di tutte le route. Per ogni richiesta:
+
+1. cerca nel catalogo di `services/auditService.js` un'azione critica che corrisponda a `method` + `path`;
+2. se non c'è, la richiesta prosegue **senza alcun costo aggiuntivo** (le letture come `GET /health` non vengono tracciate);
+3. se c'è, registra la voce su `res.on('finish')`, cioè **dopo** che la risposta è stata inviata al client.
+
+Due garanzie volute:
+
+- **Non blocca.** Il client non aspetta mai la scrittura sul database.
+- **Non può rompere la richiesta.** Ogni errore dell'audit viene loggato e ignorato: un audit che fallisce non deve abbattere il pagamento che stava tracciando.
+
+## Azioni tracciate
+
+| Categoria | Azione | Endpoint |
+|---|---|---|
+| `payment` | `payment.buy_myz` | `POST /buy-myz` |
+| `escrow` | `escrow.create` | `POST /escrow/create` |
+| `escrow` | `escrow.house` | `POST /api/escrow/house/*` |
+| `escrow` | `escrow.robot_create` | `POST /api/robot/escrow/create` |
+| `escrow` | `escrow.robot_deliver` | `POST /api/robot/escrow/deliver` |
+| `escrow` | `escrow.robot_dispute` | `POST /api/robot/escrow/dispute` |
+| `robot` | `robot.create` | `POST /api/robot/create` |
+| `robot` | `robot.assign_job` | `POST /api/robot/assign` |
+| `robot` | `robot.deliver_job` | `POST /api/robot/deliver` |
+| `robot` | `robot.complete_job` | `POST /api/robot/job/complete` |
+| `robot` | `robot.dispute` | `POST /api/robot/dispute` |
+| `bounty` | `bounty.create` / `bounty.assign` / `bounty.complete` | `POST /api/bounty/*` |
+| `reward` | `reward.trigger` | `POST /api/rewards/trigger` |
+| `stake` | `stake.create` | `POST /api/stake/stake` |
+| `webhook` | `webhook.github_event` | `POST /api/webhooks/github` |
+| `admin` | `admin.ratelimit_reset` | `POST /api/ratelimit/reset` |
+| `backup` | `backup.create` / `backup.restore` / `backup.cleanup` | `POST /api/backup/*` ⚠️ route non montate |
+
+L'elenco aggiornato è sempre disponibile su `GET /api/audit/actions`.
+
+Per aggiungere un'azione basta una riga in `CRITICAL_ACTIONS` (`services/auditService.js`): non serve toccare le route.
+
+## Modello
+
+`models/AuditLog.js` — collection `auditlogs`.
+
+| Campo | Note |
+|---|---|
+| `action` | `dominio.operazione`, es. `escrow.create` |
+| `category` | `payment` · `escrow` · `robot` · `bounty` · `backup` · `stake` · `reward` · `webhook` · `admin` · `other` |
+| `userId` | ricavato dal payload (`clientId`, `userId`, `buyer`, `username`…) |
+| `resourceType` / `resourceId` | risorsa toccata, anche se l'id è generato dal server |
+| `method` `path` `statusCode` `status` | `status` è `failure` per ogni risposta ≥ 400 |
+| `ip` `userAgent` `durationMs` | `ip` rispetta `x-forwarded-for` |
+| `metadata` | body della richiesta **ripulito dai segreti** |
+| `error` | messaggio d'errore per le risposte ≥ 400 |
+| `createdAt` | indicizzato |
+
+Indici composti su `{userId, createdAt}`, `{action, createdAt}`, `{category, createdAt}` per le query dell'API.
+
+### Redazione dei segreti
+
+Un audit log che copia il body alla lettera finirebbe per archiviare proprio i dati che non vanno archiviati. Le chiavi che contengono `password`, `secret`, `token`, `apiKey`, `authorization`, `privateKey`, `seed`, `mnemonic` o `signature` — anche annidate — diventano `[REDACTED]`. Le stringhe oltre 512 caratteri vengono troncate, gli array oltre 20 elementi accorciati, gli oggetti oltre 50 chiavi troncati (i payload dei webhook GitHub ne hanno centinaia), i `Buffer` riassunti come `[buffer N byte]` invece di essere enumerati byte per byte, e la ricorsione si ferma a 4 livelli.
+
+```jsonc
+// richiesta
+{ "robotId": "a1", "name": "A", "walletAddress": "w1", "privateKey": "SEGRETO" }
+// metadata registrato
+{ "robotId": "a1", "name": "A", "walletAddress": "w1", "privateKey": "[REDACTED]" }
+```
+
+## API
+
+### `GET /api/audit`
+
+Voci filtrate e paginate.
+
+| Parametro | |
+|---|---|
+| `userId` | filtra per utente — `GET /api/audit?userId=xxx` |
+| `action` | azione esatta, es. `escrow.create` |
+| `category` | categoria |
+| `resourceId` / `resourceType` | risorsa |
+| `status` | `success` o `failure` |
+| `from` / `to` | intervallo di date ISO 8601 |
+| `page` / `limit` | paginazione (default 1 / 50, max 500) |
+
+```bash
+curl "http://localhost:10000/api/audit?userId=alice"
+curl "http://localhost:10000/api/audit?category=escrow&status=failure&from=2025-01-01"
+```
+
+I filtri non validi (data non parsabile, intervallo invertito, status sconosciuto) rispondono **400**, non 500.
+
+### `GET /api/audit/export`
+
+Stessi filtri, export scaricabile.
+
+```bash
+curl -OJ "http://localhost:10000/api/audit/export?format=csv"
+curl -OJ "http://localhost:10000/api/audit/export?format=json&userId=alice"
+```
+
+Il CSV segue RFC 4180 (virgolette raddoppiate, campi quotati quando contengono `,` `"` o newline, terminatori CRLF), quindi si apre correttamente in Excel.
+
+### `GET /api/audit/stats`
+
+Conteggi per categoria, azione ed esito sull'intervallo filtrato.
+
+### `GET /api/audit/actions`
+
+Catalogo delle azioni tracciate automaticamente.
+
+## Configurazione
+
+| Variabile | Default | |
+|---|---|---|
+| `AUDIT_LOG_TTL_DAYS` | *(nessuna)* | se impostata, MongoDB elimina da solo le voci più vecchie |
+| `AUDIT_LOG_BUFFER_SIZE` | `500` | dimensione del buffer di fallback in memoria |
+
+## Degrado senza MongoDB
+
+Se la connessione non è attiva (o una scrittura fallisce), le voci finiscono in un **buffer circolare in memoria** e l'API continua a rispondere leggendo da lì. Il campo `source` della risposta indica quale sorgente è stata usata:
+
+```jsonc
+{ "success": true, "data": [ /* … */ ], "pagination": { /* … */ }, "source": "memory" }
+```
+
+Questo rende l'audit utilizzabile anche in sviluppo e nei test senza dover avviare un database.

--- a/middleware/auditLogger.js
+++ b/middleware/auditLogger.js
@@ -1,0 +1,93 @@
+/**
+ * Audit Logging Middleware - Bounty B14 (#279)
+ *
+ * Intercetta automaticamente le azioni critiche definite in auditService e
+ * registra una voce di audit quando la risposta è stata inviata.
+ *
+ * Due proprietà volute:
+ *  - **non blocca**: la voce viene scritta su `res.on('finish')`, quindi il
+ *    client non aspetta mai il database;
+ *  - **non può rompere la richiesta**: ogni errore dell'audit viene loggato e
+ *    ignorato.
+ */
+
+const { resolveAction, logAudit, firstValue, sanitize } = require('../services/auditService');
+
+function clientIp(req) {
+  const forwarded = req.headers && req.headers['x-forwarded-for'];
+  if (forwarded) return String(forwarded).split(',')[0].trim();
+  return req.ip || (req.connection && req.connection.remoteAddress) || null;
+}
+
+/**
+ * Estrae il messaggio d'errore dalla risposta, seguendo le due forme usate nel
+ * gateway: `{ error: '...' }` e `{ success: false, error: '...' }`.
+ */
+function errorFromBody(body) {
+  if (!body || typeof body !== 'object') return null;
+  if (typeof body.error === 'string') return body.error;
+  if (body.error && typeof body.error.message === 'string') return body.error.message;
+  return null;
+}
+
+/**
+ * @param {{ resolve?: Function, log?: Function }} [options] iniettabili nei test.
+ */
+function auditLogger(options = {}) {
+  const resolve = options.resolve || resolveAction;
+  const write = options.log || logAudit;
+
+  return function auditLoggerMiddleware(req, res, next) {
+    let descriptor = null;
+    try {
+      descriptor = resolve(req.method, req.originalUrl || req.url);
+    } catch (err) {
+      console.error('audit: risoluzione azione fallita:', err.message);
+    }
+
+    if (!descriptor) return next();
+
+    const startedAt = Date.now();
+
+    // Il body di risposta serve per il messaggio d'errore e per gli id generati
+    // dal server (es. orderId): si intercetta res.json senza alterarne il
+    // comportamento.
+    let responseBody = null;
+    const originalJson = res.json.bind(res);
+    res.json = function auditJson(body) {
+      responseBody = body;
+      return originalJson(body);
+    };
+
+    res.on('finish', () => {
+      try {
+        const sources = [req.body, req.params, req.query, responseBody, responseBody && responseBody.data];
+        const statusCode = res.statusCode;
+
+        write({
+          action: descriptor.action,
+          category: descriptor.category,
+          resourceType: descriptor.resourceType,
+          resourceId: firstValue(sources, descriptor.resourceKeys),
+          userId: firstValue(sources, descriptor.userKeys),
+          method: req.method,
+          path: (req.originalUrl || req.url || '').split('?')[0],
+          statusCode,
+          status: statusCode >= 400 ? 'failure' : 'success',
+          ip: clientIp(req),
+          userAgent: req.headers ? req.headers['user-agent'] || null : null,
+          durationMs: Date.now() - startedAt,
+          metadata: sanitize(req.body || {}),
+          error: statusCode >= 400 ? errorFromBody(responseBody) : null
+        });
+      } catch (err) {
+        // Un audit fallito non deve mai propagarsi alla richiesta.
+        console.error('audit: registrazione fallita:', err.message);
+      }
+    });
+
+    next();
+  };
+}
+
+module.exports = { auditLogger, errorFromBody, clientIp };

--- a/models/AuditLog.js
+++ b/models/AuditLog.js
@@ -1,0 +1,53 @@
+const mongoose = require('mongoose');
+
+/**
+ * AuditLog - Bounty B14 (#279)
+ *
+ * Traccia immutabile delle azioni critiche del gateway: pagamenti, escrow,
+ * robot, bounty, backup, stake e rewards.
+ */
+const AuditLogSchema = new mongoose.Schema({
+  // Azione in forma `dominio.operazione`, es. `escrow.create`, `payment.buy_myz`.
+  action: { type: String, required: true, index: true },
+  category: {
+    type: String,
+    enum: ['payment', 'escrow', 'robot', 'bounty', 'backup', 'stake', 'reward', 'webhook', 'admin', 'other'],
+    default: 'other',
+    index: true
+  },
+  // Chi ha compiuto l'azione. Non sempre disponibile: le route del gateway non
+  // sono autenticate, quindi si ricava dal payload (clientId, userId, buyer...).
+  userId: { type: String, default: null, index: true },
+  resourceType: { type: String, default: null },
+  resourceId: { type: String, default: null, index: true },
+
+  method: { type: String, default: null },
+  path: { type: String, default: null },
+  statusCode: { type: Number, default: null },
+  status: { type: String, enum: ['success', 'failure'], default: 'success', index: true },
+
+  ip: { type: String, default: null },
+  userAgent: { type: String, default: null },
+  durationMs: { type: Number, default: null },
+
+  // Payload della richiesta ripulito dai segreti.
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  error: { type: String, default: null },
+
+  createdAt: { type: Date, default: Date.now, index: true }
+});
+
+// Indici composti per le query più frequenti dell'API /api/audit.
+AuditLogSchema.index({ createdAt: -1 });
+AuditLogSchema.index({ userId: 1, createdAt: -1 });
+AuditLogSchema.index({ action: 1, createdAt: -1 });
+AuditLogSchema.index({ category: 1, createdAt: -1 });
+
+// Retention opzionale: con AUDIT_LOG_TTL_DAYS impostato, MongoDB elimina da solo
+// le voci più vecchie. Senza la variabile i log restano per sempre.
+const ttlDays = parseInt(process.env.AUDIT_LOG_TTL_DAYS, 10);
+if (Number.isFinite(ttlDays) && ttlDays > 0) {
+  AuditLogSchema.index({ createdAt: 1 }, { expireAfterSeconds: ttlDays * 24 * 3600 });
+}
+
+module.exports = mongoose.model('AuditLog', AuditLogSchema);

--- a/routes/audit.js
+++ b/routes/audit.js
@@ -1,0 +1,122 @@
+/**
+ * API di consultazione dell'audit log - Bounty B14 (#279)
+ *
+ *   GET /api/audit?userId=xxx           voci filtrate e paginate
+ *   GET /api/audit/export?format=csv    export CSV o JSON
+ *   GET /api/audit/stats                conteggi per categoria, azione, esito
+ *   GET /api/audit/actions              catalogo delle azioni tracciate
+ */
+
+const express = require('express');
+const router = express.Router();
+const {
+  queryAuditLogs, exportAuditLogs, getAuditStats, listActions, toCSV, CSV_COLUMNS
+} = require('../services/auditService');
+
+/** I filtri non validi sono errori del client (400), non del server (500). */
+function handle(res, err) {
+  const isValidation = /non è una data valida|deve essere|non può essere/.test(err.message);
+  res.status(isValidation ? 400 : 500).json({ success: false, error: err.message });
+}
+
+/**
+ * @openapi
+ * /api/audit:
+ *   get:
+ *     tags: [Audit]
+ *     summary: Elenco filtrato delle azioni critiche registrate
+ *     parameters:
+ *       - { in: query, name: userId, schema: { type: string }, description: Filtra per utente }
+ *       - { in: query, name: action, schema: { type: string }, description: "Azione esatta, es. escrow.create" }
+ *       - { in: query, name: category, schema: { type: string, enum: [payment, escrow, robot, bounty, backup, stake, reward, other] } }
+ *       - { in: query, name: resourceId, schema: { type: string } }
+ *       - { in: query, name: resourceType, schema: { type: string } }
+ *       - { in: query, name: status, schema: { type: string, enum: [success, failure] } }
+ *       - { in: query, name: from, schema: { type: string, format: date-time }, description: Data iniziale (ISO 8601) }
+ *       - { in: query, name: to, schema: { type: string, format: date-time }, description: Data finale (ISO 8601) }
+ *       - { in: query, name: page, schema: { type: integer, default: 1 } }
+ *       - { in: query, name: limit, schema: { type: integer, default: 50, maximum: 500 } }
+ *     responses:
+ *       200: { description: Voci di audit con paginazione }
+ *       400: { description: Filtro non valido }
+ */
+router.get('/', async (req, res) => {
+  try {
+    const { logs, pagination, source } = await queryAuditLogs(req.query);
+    res.json({ success: true, data: logs, pagination, source });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/audit/export:
+ *   get:
+ *     tags: [Audit]
+ *     summary: Export delle voci di audit in CSV o JSON
+ *     description: Accetta gli stessi filtri di GET /api/audit. Risponde con un allegato scaricabile.
+ *     parameters:
+ *       - { in: query, name: format, schema: { type: string, enum: [csv, json], default: json } }
+ *       - { in: query, name: max, schema: { type: integer, default: 10000, maximum: 50000 } }
+ *     responses:
+ *       200: { description: File CSV o JSON }
+ *       400: { description: Formato o filtro non valido }
+ */
+router.get('/export', async (req, res) => {
+  try {
+    const format = String(req.query.format || 'json').toLowerCase();
+    if (!['csv', 'json'].includes(format)) {
+      return res.status(400).json({ success: false, error: "format deve essere 'csv' o 'json'" });
+    }
+
+    const logs = await exportAuditLogs(req.query);
+    const stamp = new Date().toISOString().slice(0, 19).replace(/[:]/g, '-');
+    const filename = `audit-log-${stamp}.${format}`;
+
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    if (format === 'csv') {
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      return res.send(toCSV(logs, CSV_COLUMNS));
+    }
+
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.send(JSON.stringify({ exportedAt: new Date().toISOString(), count: logs.length, logs }, null, 2));
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/audit/stats:
+ *   get:
+ *     tags: [Audit]
+ *     summary: Conteggi aggregati per categoria, azione ed esito
+ *     responses:
+ *       200: { description: Statistiche sull'intervallo filtrato }
+ */
+router.get('/stats', async (req, res) => {
+  try {
+    res.json({ success: true, data: await getAuditStats(req.query) });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/audit/actions:
+ *   get:
+ *     tags: [Audit]
+ *     summary: Catalogo delle azioni critiche tracciate automaticamente
+ *     responses:
+ *       200: { description: Elenco di azione, categoria, metodo e tipo di risorsa }
+ */
+router.get('/actions', (req, res) => {
+  const actions = listActions();
+  res.json({ success: true, count: actions.length, data: actions });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const { mint, balance } = require('./token_simulator');
 const { assignReward } = require('./services/rewardService');
 
 const { rateLimiter } = require('./middleware/rateLimiter');
+const { auditLogger } = require('./middleware/auditLogger');
 
 const app = express();
 app.use(express.json());
@@ -22,6 +23,11 @@ app.use("/api/rewards/trigger", sensitiveLimiter);
 app.use("/api/bounty/create", sensitiveLimiter);
 app.use("/api/escrow/create", sensitiveLimiter);
 
+// Audit logging delle azioni critiche (pagamenti, escrow, robot, bounty).
+// Va montato dopo express.json(), perché legge req.body, e dopo i rate limiter:
+// una richiesta respinta con 429 non ha compiuto nessuna azione di business,
+// quindi non deve finire nell'audit trail.
+app.use(auditLogger());
 
 // Swagger/OpenAPI documentation
 const swaggerUi = require('swagger-ui-express');
@@ -67,6 +73,8 @@ app.use('/api/ratelimit', require('./routes/ratelimit'));
 app.use('/api/webhooks', require('./routes/webhook'));
 
 app.use('/api/webhooks/github', require('./routes/githubWebhook'));
+
+app.use('/api/audit', require('./routes/audit'));
 
 app.get('/health', (req, res) => {
   res.json({

--- a/services/auditService.js
+++ b/services/auditService.js
@@ -1,0 +1,376 @@
+/**
+ * Audit Service - Bounty B14 (#279)
+ *
+ * Catalogo delle azioni critiche, scrittura dei log, query filtrate ed export.
+ *
+ * Il servizio non deve mai far fallire la richiesta che sta tracciando: se
+ * MongoDB non è raggiungibile le voci finiscono in un buffer circolare in
+ * memoria, così l'audit resta consultabile (e testabile) anche senza database.
+ */
+
+const mongoose = require('mongoose');
+const AuditLog = require('../models/AuditLog');
+
+// ------------------------------------------------------- azioni critiche
+
+/**
+ * Catalogo delle azioni tracciate. `match` è valutato sul path *completo*
+ * della richiesta, quindi resta valido a prescindere da dove le route sono
+ * montate in server.js.
+ *
+ * `userKeys` elenca, in ordine di priorità, i campi del payload da cui ricavare
+ * l'utente; `resourceKeys` quelli da cui ricavare l'id della risorsa.
+ */
+const CRITICAL_ACTIONS = [
+  // --- pagamenti
+  { method: 'POST', match: /^\/buy-myz\/?$/, action: 'payment.buy_myz', category: 'payment', resourceType: 'order', userKeys: ['userTariWallet', 'userId'], resourceKeys: ['orderId'] },
+
+  // --- escrow
+  { method: 'POST', match: /^\/escrow\/create\/?$/, action: 'escrow.create', category: 'escrow', resourceType: 'escrow', userKeys: ['buyer', 'userId'], resourceKeys: ['escrowId'] },
+  { method: 'POST', match: /^\/api\/escrow\/house\//, action: 'escrow.house', category: 'escrow', resourceType: 'escrow', userKeys: ['buyer', 'userId'], resourceKeys: ['escrowId', 'orderId'] },
+  { method: 'POST', match: /^\/api\/robot\/escrow\/create\/?$/, action: 'escrow.robot_create', category: 'escrow', resourceType: 'escrow', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+  { method: 'POST', match: /^\/api\/robot\/escrow\/deliver\/?$/, action: 'escrow.robot_deliver', category: 'escrow', resourceType: 'escrow', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+  { method: 'POST', match: /^\/api\/robot\/escrow\/dispute\/?$/, action: 'escrow.robot_dispute', category: 'escrow', resourceType: 'escrow', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+
+  // --- robot
+  { method: 'POST', match: /^\/api\/robot\/create\/?$/, action: 'robot.create', category: 'robot', resourceType: 'robot', userKeys: ['walletAddress'], resourceKeys: ['robotId'] },
+  { method: 'POST', match: /^\/api\/robot\/assign\/?$/, action: 'robot.assign_job', category: 'robot', resourceType: 'job', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+  { method: 'POST', match: /^\/api\/robot\/deliver\/?$/, action: 'robot.deliver_job', category: 'robot', resourceType: 'robot', userKeys: ['clientId'], resourceKeys: ['robotId'] },
+  { method: 'POST', match: /^\/api\/robot\/job\/complete\/?$/, action: 'robot.complete_job', category: 'robot', resourceType: 'job', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+  { method: 'POST', match: /^\/api\/robot\/dispute\/?$/, action: 'robot.dispute', category: 'robot', resourceType: 'job', userKeys: ['clientId'], resourceKeys: ['jobId'] },
+
+  // --- bounty
+  { method: 'POST', match: /^\/api\/bounty\/create\/?$/, action: 'bounty.create', category: 'bounty', resourceType: 'bounty', userKeys: ['assignedTo'], resourceKeys: ['issueId'] },
+  { method: 'POST', match: /^\/api\/bounty\/assign\/?$/, action: 'bounty.assign', category: 'bounty', resourceType: 'bounty', userKeys: ['username'], resourceKeys: ['issueId'] },
+  { method: 'POST', match: /^\/api\/bounty\/complete\/?$/, action: 'bounty.complete', category: 'bounty', resourceType: 'bounty', userKeys: ['walletAddress', 'username'], resourceKeys: ['issueId'] },
+
+  // --- reward
+  { method: 'POST', match: /^\/api\/rewards\/trigger\/?$/, action: 'reward.trigger', category: 'reward', resourceType: 'reward', userKeys: ['userId'], resourceKeys: ['userId'] },
+
+  // --- stake
+  { method: 'POST', match: /^\/api\/stake\/stake\/?$/, action: 'stake.create', category: 'stake', resourceType: 'stake', userKeys: ['userId'], resourceKeys: ['userId'] },
+
+  // --- webhook: gli eventi GitHub fanno scattare i reward, quindi sono
+  // azioni critiche a tutti gli effetti anche se arrivano da fuori.
+  { method: 'POST', match: /^\/api\/webhooks\/github\/?$/, action: 'webhook.github_event', category: 'webhook', resourceType: 'webhook', userKeys: ['sender', 'username'], resourceKeys: ['delivery', 'number'] },
+
+  // --- admin
+  { method: 'POST', match: /^\/api\/ratelimit\/reset\/?$/, action: 'admin.ratelimit_reset', category: 'admin', resourceType: 'ratelimit', userKeys: ['userId'], resourceKeys: ['key'] },
+
+  // --- backup (le route sono attualmente non montate in server.js: le voci
+  // restano nel catalogo così l'audit riparte da solo se vengono rimontate)
+  { method: 'POST', match: /^\/api\/backup\/create\/?$/, action: 'backup.create', category: 'backup', resourceType: 'backup', userKeys: ['userId'], resourceKeys: ['backupId'] },
+  { method: 'POST', match: /^\/api\/backup\/restore\/?$/, action: 'backup.restore', category: 'backup', resourceType: 'backup', userKeys: ['userId'], resourceKeys: ['backupId'] },
+  { method: 'POST', match: /^\/api\/backup\/cleanup\/?$/, action: 'backup.cleanup', category: 'backup', resourceType: 'backup', userKeys: ['userId'], resourceKeys: [] }
+];
+
+/** Descrittore dell'azione critica per method+path, o null se non tracciata. */
+function resolveAction(method, path) {
+  if (!method || !path) return null;
+  const upper = String(method).toUpperCase();
+  const clean = String(path).split('?')[0];
+  return CRITICAL_ACTIONS.find(a => a.method === upper && a.match.test(clean)) || null;
+}
+
+function listActions() {
+  return CRITICAL_ACTIONS.map(({ action, category, method, resourceType }) =>
+    ({ action, category, method, resourceType }));
+}
+
+// ------------------------------------------------------------ sanitizing
+
+const SECRET_KEY_PATTERN = /(password|passwd|secret|token|api[-_]?key|authorization|private[-_]?key|seed|mnemonic|signature)/i;
+const MAX_STRING_LENGTH = 512;
+const MAX_DEPTH = 4;
+const MAX_KEYS = 50;
+
+/**
+ * Rimuove i segreti e limita la dimensione del payload prima di persisterlo.
+ * Un audit log che copia alla lettera il body finirebbe per archiviare proprio i
+ * dati che non devono essere archiviati.
+ */
+function sanitize(value, depth = 0) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}…[troncato]` : value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (depth >= MAX_DEPTH) return '[profondità massima]';
+
+  // Un Buffer (es. body raw di un webhook) enumerato chiave per chiave
+  // produrrebbe migliaia di voci numeriche: si registra solo la dimensione.
+  if (Buffer.isBuffer(value)) return `[buffer ${value.length} byte]`;
+  if (value instanceof Date) return value.toISOString();
+
+  if (Array.isArray(value)) {
+    const limited = value.slice(0, 20).map(v => sanitize(v, depth + 1));
+    if (value.length > 20) limited.push(`…[altri ${value.length - 20} elementi]`);
+    return limited;
+  }
+
+  if (typeof value === 'object') {
+    const out = {};
+    // I payload dei webhook GitHub hanno centinaia di chiavi: si tronca per
+    // non gonfiare la collection con dati che nessuno consulterà.
+    const entries = Object.entries(value);
+    for (const [key, val] of entries.slice(0, MAX_KEYS)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? '[REDACTED]' : sanitize(val, depth + 1);
+    }
+    if (entries.length > MAX_KEYS) {
+      out['…'] = `[altre ${entries.length - MAX_KEYS} chiavi]`;
+    }
+    return out;
+  }
+
+  return String(value);
+}
+
+/** Primo valore non vuoto fra le chiavi indicate, cercato in più sorgenti. */
+function firstValue(sources, keys) {
+  for (const key of keys || []) {
+    for (const source of sources) {
+      if (source && source[key] !== undefined && source[key] !== null && source[key] !== '') {
+        return String(source[key]);
+      }
+    }
+  }
+  return null;
+}
+
+// --------------------------------------------------- buffer di fallback
+
+const FALLBACK_LIMIT = parseInt(process.env.AUDIT_LOG_BUFFER_SIZE, 10) || 500;
+const fallbackBuffer = []; // più recenti in coda
+
+function isMongoConnected() {
+  return mongoose.connection && mongoose.connection.readyState === 1;
+}
+
+function pushFallback(entry) {
+  fallbackBuffer.push(entry);
+  while (fallbackBuffer.length > FALLBACK_LIMIT) fallbackBuffer.shift();
+}
+
+function getFallbackBuffer() {
+  return fallbackBuffer.slice();
+}
+
+function clearFallbackBuffer() {
+  fallbackBuffer.length = 0;
+}
+
+// ------------------------------------------------------------- scrittura
+
+function normalizeEntry(entry) {
+  return {
+    action: entry.action,
+    category: entry.category || 'other',
+    userId: entry.userId || null,
+    resourceType: entry.resourceType || null,
+    resourceId: entry.resourceId || null,
+    method: entry.method || null,
+    path: entry.path || null,
+    statusCode: entry.statusCode ?? null,
+    status: entry.status || 'success',
+    ip: entry.ip || null,
+    userAgent: entry.userAgent || null,
+    durationMs: entry.durationMs ?? null,
+    metadata: entry.metadata === undefined ? {} : sanitize(entry.metadata),
+    error: entry.error || null,
+    createdAt: entry.createdAt ? new Date(entry.createdAt) : new Date()
+  };
+}
+
+/**
+ * Registra una voce di audit. Non lancia mai: un errore di audit non deve
+ * abbattere l'operazione di business che stava tracciando.
+ */
+async function logAudit(entry) {
+  if (!entry || !entry.action) return null;
+  const normalized = normalizeEntry(entry);
+
+  if (!isMongoConnected()) {
+    pushFallback(normalized);
+    return normalized;
+  }
+
+  try {
+    return await AuditLog.create(normalized);
+  } catch (err) {
+    console.error('audit: scrittura su MongoDB fallita:', err.message);
+    pushFallback(normalized);
+    return normalized;
+  }
+}
+
+// ----------------------------------------------------------------- query
+
+const MAX_LIMIT = 500;
+
+/** Traduce i query param dell'API in un filtro Mongo. Lancia su input non validi. */
+function buildFilter(params = {}) {
+  const filter = {};
+  if (params.userId) filter.userId = String(params.userId);
+  if (params.action) filter.action = String(params.action);
+  if (params.category) filter.category = String(params.category);
+  if (params.resourceId) filter.resourceId = String(params.resourceId);
+  if (params.resourceType) filter.resourceType = String(params.resourceType);
+  if (params.status) {
+    const status = String(params.status);
+    if (!['success', 'failure'].includes(status)) {
+      throw new Error("status deve essere 'success' o 'failure'");
+    }
+    filter.status = status;
+  }
+
+  const range = {};
+  if (params.from) {
+    const from = new Date(params.from);
+    if (Number.isNaN(from.getTime())) throw new Error('from non è una data valida (usa ISO 8601)');
+    range.$gte = from;
+  }
+  if (params.to) {
+    const to = new Date(params.to);
+    if (Number.isNaN(to.getTime())) throw new Error('to non è una data valida (usa ISO 8601)');
+    range.$lte = to;
+  }
+  if (range.$gte && range.$lte && range.$gte > range.$lte) {
+    throw new Error('from non può essere successiva a to');
+  }
+  if (Object.keys(range).length) filter.createdAt = range;
+
+  return filter;
+}
+
+function parsePagination(params = {}) {
+  const page = Math.max(1, parseInt(params.page, 10) || 1);
+  const requested = parseInt(params.limit, 10) || 50;
+  const limit = Math.min(MAX_LIMIT, Math.max(1, requested));
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+/** Applica lo stesso filtro al buffer in memoria, quando Mongo non c'è. */
+function filterBuffer(entries, filter) {
+  return entries.filter(entry => {
+    for (const [key, expected] of Object.entries(filter)) {
+      if (key === 'createdAt') {
+        const at = new Date(entry.createdAt);
+        if (expected.$gte && at < expected.$gte) return false;
+        if (expected.$lte && at > expected.$lte) return false;
+      } else if (entry[key] !== expected) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+/**
+ * @param {object} params userId, action, category, resourceId, resourceType,
+ *                        status, from, to, page, limit
+ * @returns {{logs: object[], pagination: object, source: 'database'|'memory'}}
+ */
+async function queryAuditLogs(params = {}) {
+  const filter = buildFilter(params);
+  const { page, limit, skip } = parsePagination(params);
+
+  if (!isMongoConnected()) {
+    const all = filterBuffer(getFallbackBuffer(), filter)
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    return {
+      logs: all.slice(skip, skip + limit),
+      pagination: { page, limit, total: all.length, pages: Math.ceil(all.length / limit) || 0 },
+      source: 'memory'
+    };
+  }
+
+  const [logs, total] = await Promise.all([
+    AuditLog.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+    AuditLog.countDocuments(filter)
+  ]);
+
+  return {
+    logs,
+    pagination: { page, limit, total, pages: Math.ceil(total / limit) || 0 },
+    source: 'database'
+  };
+}
+
+/** Come queryAuditLogs ma senza paginazione, per l'export. */
+async function exportAuditLogs(params = {}) {
+  const filter = buildFilter(params);
+  const max = Math.min(parseInt(params.max, 10) || 10000, 50000);
+
+  if (!isMongoConnected()) {
+    return filterBuffer(getFallbackBuffer(), filter)
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .slice(0, max);
+  }
+  return AuditLog.find(filter).sort({ createdAt: -1 }).limit(max).lean();
+}
+
+/** Conteggi per categoria, azione ed esito sull'intervallo filtrato. */
+async function getAuditStats(params = {}) {
+  const { logs } = await queryAuditLogs({ ...params, limit: MAX_LIMIT, page: 1 });
+  const all = isMongoConnected() ? await exportAuditLogs(params) : logs;
+
+  const byCategory = {};
+  const byAction = {};
+  let failures = 0;
+
+  for (const log of all) {
+    byCategory[log.category] = (byCategory[log.category] || 0) + 1;
+    byAction[log.action] = (byAction[log.action] || 0) + 1;
+    if (log.status === 'failure') failures += 1;
+  }
+
+  return {
+    total: all.length,
+    failures,
+    successes: all.length - failures,
+    failureRate: all.length ? Number((failures / all.length).toFixed(4)) : 0,
+    byCategory,
+    byAction
+  };
+}
+
+// ---------------------------------------------------------------- export
+
+const CSV_COLUMNS = [
+  'createdAt', 'action', 'category', 'status', 'userId', 'resourceType',
+  'resourceId', 'method', 'path', 'statusCode', 'durationMs', 'ip', 'error'
+];
+
+function csvCell(value) {
+  if (value === null || value === undefined) return '';
+  const str = value instanceof Date ? value.toISOString() : String(value);
+  // RFC 4180: virgolette raddoppiate, campo quotato se contiene , " o newline.
+  return /[",\n\r]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+function toCSV(logs, columns = CSV_COLUMNS) {
+  const rows = [columns.join(',')];
+  for (const log of logs) {
+    rows.push(columns.map(col => csvCell(log[col])).join(','));
+  }
+  // CRLF come da RFC 4180: è ciò che Excel si aspetta.
+  return `${rows.join('\r\n')}\r\n`;
+}
+
+module.exports = {
+  CRITICAL_ACTIONS,
+  CSV_COLUMNS,
+  resolveAction,
+  listActions,
+  sanitize,
+  firstValue,
+  logAudit,
+  buildFilter,
+  parsePagination,
+  queryAuditLogs,
+  exportAuditLogs,
+  getAuditStats,
+  toCSV,
+  getFallbackBuffer,
+  clearFallbackBuffer
+};

--- a/tests/auditLog.test.js
+++ b/tests/auditLog.test.js
@@ -1,0 +1,596 @@
+/**
+ * Test per il sistema di audit logging - Bounty B14 (#279)
+ *
+ * Girano senza MongoDB: quando la connessione non è attiva l'audit service usa
+ * il buffer circolare in memoria, che è anche il percorso di degrado testato qui.
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+const audit = require('../services/auditService');
+const { auditLogger, errorFromBody, clientIp } = require('../middleware/auditLogger');
+const auditRouter = require('../routes/audit');
+
+// ------------------------------------------------------------------ utils
+
+function fakeReq({ method = 'POST', url = '/', body = {}, params = {}, query = {}, headers = {}, ip = '10.0.0.1' } = {}) {
+  return { method, originalUrl: url, url, body, params, query, headers, ip, connection: { remoteAddress: ip } };
+}
+
+/** res minimale che emette 'finish' come fa Express. */
+function fakeRes() {
+  const listeners = [];
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    on(event, cb) { if (event === 'finish') listeners.push(cb); },
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+    send(body) { this.body = body; return this; },
+    finish() { for (const cb of listeners) cb(); }
+  };
+}
+
+function callRoute(method, path, query = {}) {
+  const layer = auditRouter.stack.find(l => l.route && l.route.path === path && l.route.methods[method]);
+  assert.ok(layer, `route ${method.toUpperCase()} ${path} non registrata`);
+  const req = fakeReq({ method: method.toUpperCase(), url: path, query });
+  const res = fakeRes();
+  return Promise.resolve(layer.route.stack[0].handle(req, res, e => { throw e; }))
+    .then(() => ({ statusCode: res.statusCode, body: res.body, headers: res.headers }));
+}
+
+// ------------------------------------------------------------ resolveAction
+
+describe('resolveAction', () => {
+  it('riconosce le azioni critiche di ogni dominio', () => {
+    const cases = [
+      ['POST', '/buy-myz', 'payment.buy_myz', 'payment'],
+      ['POST', '/escrow/create', 'escrow.create', 'escrow'],
+      ['POST', '/api/robot/escrow/create', 'escrow.robot_create', 'escrow'],
+      ['POST', '/api/robot/escrow/dispute', 'escrow.robot_dispute', 'escrow'],
+      ['POST', '/api/robot/create', 'robot.create', 'robot'],
+      ['POST', '/api/robot/assign', 'robot.assign_job', 'robot'],
+      ['POST', '/api/bounty/complete', 'bounty.complete', 'bounty'],
+      ['POST', '/api/rewards/trigger', 'reward.trigger', 'reward'],
+      ['POST', '/api/stake/stake', 'stake.create', 'stake'],
+      ['POST', '/api/backup/restore', 'backup.restore', 'backup'],
+      ['POST', '/api/webhooks/github', 'webhook.github_event', 'webhook'],
+      ['POST', '/api/ratelimit/reset', 'admin.ratelimit_reset', 'admin']
+    ];
+    for (const [method, path, action, category] of cases) {
+      const d = audit.resolveAction(method, path);
+      assert.ok(d, `${method} ${path} dovrebbe essere tracciata`);
+      assert.strictEqual(d.action, action);
+      assert.strictEqual(d.category, category);
+    }
+  });
+
+  it('ignora le letture e le route non critiche', () => {
+    assert.strictEqual(audit.resolveAction('GET', '/health'), null);
+    assert.strictEqual(audit.resolveAction('GET', '/api/robot/status/robot-1'), null);
+    assert.strictEqual(audit.resolveAction('GET', '/api/bounty/list'), null);
+    assert.strictEqual(audit.resolveAction('POST', '/api/robot/execute'), null);
+  });
+
+  it('ignora la query string e il trailing slash', () => {
+    assert.strictEqual(audit.resolveAction('POST', '/buy-myz?debug=1').action, 'payment.buy_myz');
+    assert.strictEqual(audit.resolveAction('POST', '/buy-myz/').action, 'payment.buy_myz');
+  });
+
+  it('distingue i metodi HTTP', () => {
+    assert.strictEqual(audit.resolveAction('GET', '/api/robot/create'), null);
+    assert.ok(audit.resolveAction('post', '/api/robot/create'), 'il metodo è case-insensitive');
+  });
+
+  it('non esplode con input mancanti', () => {
+    assert.strictEqual(audit.resolveAction(undefined, '/buy-myz'), null);
+    assert.strictEqual(audit.resolveAction('POST', undefined), null);
+  });
+});
+
+// ----------------------------------------------------------------- sanitize
+
+describe('sanitize', () => {
+  it('oscura i campi sensibili', () => {
+    const out = audit.sanitize({
+      userId: 'alice', password: 'hunter2', apiKey: 'k', api_key: 'k',
+      privateKey: 'p', seed: 's', mnemonic: 'm', authorization: 'Bearer x', signature: 'sig'
+    });
+    assert.strictEqual(out.userId, 'alice');
+    for (const key of ['password', 'apiKey', 'api_key', 'privateKey', 'seed', 'mnemonic', 'authorization', 'signature']) {
+      assert.strictEqual(out[key], '[REDACTED]', `${key} deve essere oscurato`);
+    }
+  });
+
+  it('oscura anche nei sotto-oggetti', () => {
+    const out = audit.sanitize({ wallet: { address: 'addr', privateKey: 'segreto' } });
+    assert.strictEqual(out.wallet.address, 'addr');
+    assert.strictEqual(out.wallet.privateKey, '[REDACTED]');
+  });
+
+  it('tronca le stringhe molto lunghe', () => {
+    const out = audit.sanitize({ note: 'x'.repeat(1000) });
+    assert.ok(out.note.length < 1000);
+    assert.match(out.note, /\[troncato\]$/);
+  });
+
+  it('limita la lunghezza degli array', () => {
+    const out = audit.sanitize({ items: Array.from({ length: 50 }, (_, i) => i) });
+    assert.strictEqual(out.items.length, 21);
+    assert.match(out.items[20], /altri 30 elementi/);
+  });
+
+  it('si ferma alla profondità massima', () => {
+    const deep = { a: { b: { c: { d: { e: 'troppo profondo' } } } } };
+    assert.strictEqual(audit.sanitize(deep).a.b.c.d, '[profondità massima]');
+  });
+
+  it('gestisce null, numeri e booleani', () => {
+    assert.strictEqual(audit.sanitize(null), null);
+    assert.strictEqual(audit.sanitize(undefined), null);
+    assert.strictEqual(audit.sanitize(42), 42);
+    assert.strictEqual(audit.sanitize(true), true);
+  });
+
+  it('riassume i Buffer invece di enumerarli byte per byte', () => {
+    const out = audit.sanitize({ raw: Buffer.from('payload di un webhook') });
+    assert.strictEqual(out.raw, '[buffer 21 byte]');
+  });
+
+  it('serializza le date in ISO', () => {
+    const out = audit.sanitize({ at: new Date('2025-01-01T00:00:00Z') });
+    assert.strictEqual(out.at, '2025-01-01T00:00:00.000Z');
+  });
+
+  it('tronca gli oggetti con troppe chiavi', () => {
+    const wide = {};
+    for (let i = 0; i < 80; i++) wide[`k${i}`] = i;
+    const out = audit.sanitize(wide);
+    assert.strictEqual(Object.keys(out).length, 51, '50 chiavi + il marcatore');
+    assert.strictEqual(out['…'], '[altre 30 chiavi]');
+  });
+});
+
+// ---------------------------------------------------------------- firstValue
+
+describe('firstValue', () => {
+  it('prende il primo valore non vuoto rispettando la priorità delle chiavi', () => {
+    assert.strictEqual(audit.firstValue([{ b: 'due' }, { a: 'uno' }], ['a', 'b']), 'uno');
+    assert.strictEqual(audit.firstValue([{ b: 'due' }], ['a', 'b']), 'due');
+  });
+
+  it('salta stringhe vuote, null e undefined', () => {
+    assert.strictEqual(audit.firstValue([{ a: '' }, { a: null }, { a: 'ok' }], ['a']), 'ok');
+  });
+
+  it('restituisce null se non trova nulla, e tollera sorgenti nulle', () => {
+    assert.strictEqual(audit.firstValue([null, undefined, {}], ['a']), null);
+    assert.strictEqual(audit.firstValue([{ a: 'x' }], undefined), null);
+  });
+
+  it('converte i valori in stringa', () => {
+    assert.strictEqual(audit.firstValue([{ id: 42 }], ['id']), '42');
+  });
+});
+
+// -------------------------------------------------------------- buildFilter
+
+describe('buildFilter', () => {
+  it('costruisce i filtri semplici', () => {
+    assert.deepStrictEqual(audit.buildFilter({ userId: 'alice' }), { userId: 'alice' });
+    assert.deepStrictEqual(
+      audit.buildFilter({ action: 'escrow.create', category: 'escrow', status: 'failure' }),
+      { action: 'escrow.create', category: 'escrow', status: 'failure' }
+    );
+  });
+
+  it('costruisce l intervallo di date', () => {
+    const filter = audit.buildFilter({ from: '2025-01-01', to: '2025-02-01' });
+    assert.ok(filter.createdAt.$gte instanceof Date);
+    assert.ok(filter.createdAt.$lte instanceof Date);
+  });
+
+  it('accetta un solo estremo dell intervallo', () => {
+    assert.ok(audit.buildFilter({ from: '2025-01-01' }).createdAt.$gte);
+    assert.strictEqual(audit.buildFilter({ from: '2025-01-01' }).createdAt.$lte, undefined);
+  });
+
+  it('rifiuta le date non valide', () => {
+    assert.throws(() => audit.buildFilter({ from: 'ieri' }), /from non è una data valida/);
+    assert.throws(() => audit.buildFilter({ to: 'domani' }), /to non è una data valida/);
+  });
+
+  it('rifiuta un intervallo invertito', () => {
+    assert.throws(
+      () => audit.buildFilter({ from: '2025-02-01', to: '2025-01-01' }),
+      /from non può essere successiva a to/
+    );
+  });
+
+  it('rifiuta uno status sconosciuto', () => {
+    assert.throws(() => audit.buildFilter({ status: 'boh' }), /status deve essere/);
+  });
+
+  it('ignora i parametri non riconosciuti', () => {
+    assert.deepStrictEqual(audit.buildFilter({ sortBy: 'x', foo: 'bar' }), {});
+  });
+});
+
+describe('parsePagination', () => {
+  it('usa i valori di default', () => {
+    assert.deepStrictEqual(audit.parsePagination({}), { page: 1, limit: 50, skip: 0 });
+  });
+
+  it('calcola lo skip', () => {
+    assert.deepStrictEqual(audit.parsePagination({ page: 3, limit: 20 }), { page: 3, limit: 20, skip: 40 });
+  });
+
+  it('normalizza i valori fuori scala', () => {
+    assert.strictEqual(audit.parsePagination({ page: 0 }).page, 1);
+    assert.strictEqual(audit.parsePagination({ page: -5 }).page, 1);
+    assert.strictEqual(audit.parsePagination({ limit: 99999 }).limit, 500);
+    assert.strictEqual(audit.parsePagination({ limit: 0 }).limit, 50);
+  });
+});
+
+// ------------------------------------------------------- logAudit + query
+
+describe('logAudit senza MongoDB', () => {
+  beforeEach(() => audit.clearFallbackBuffer());
+
+  it('scrive nel buffer in memoria e normalizza i campi', async () => {
+    await audit.logAudit({ action: 'escrow.create', category: 'escrow', userId: 'alice' });
+    const [entry] = audit.getFallbackBuffer();
+
+    assert.strictEqual(entry.action, 'escrow.create');
+    assert.strictEqual(entry.category, 'escrow');
+    assert.strictEqual(entry.userId, 'alice');
+    assert.strictEqual(entry.status, 'success');
+    assert.ok(entry.createdAt instanceof Date);
+    assert.deepStrictEqual(entry.metadata, {});
+  });
+
+  it('ignora le voci senza action', async () => {
+    assert.strictEqual(await audit.logAudit({}), null);
+    assert.strictEqual(await audit.logAudit(null), null);
+    assert.strictEqual(audit.getFallbackBuffer().length, 0);
+  });
+
+  it('oscura i segreti nei metadata', async () => {
+    await audit.logAudit({ action: 'payment.buy_myz', metadata: { amount: 10, privateKey: 'segreto' } });
+    const [entry] = audit.getFallbackBuffer();
+    assert.strictEqual(entry.metadata.amount, 10);
+    assert.strictEqual(entry.metadata.privateKey, '[REDACTED]');
+  });
+
+  it('restituisce le voci filtrate e ordinate dalla più recente', async () => {
+    await audit.logAudit({ action: 'a.one', userId: 'alice', createdAt: new Date('2025-01-01') });
+    await audit.logAudit({ action: 'a.two', userId: 'bob', createdAt: new Date('2025-01-02') });
+    await audit.logAudit({ action: 'a.three', userId: 'alice', createdAt: new Date('2025-01-03') });
+
+    const all = await audit.queryAuditLogs({});
+    assert.strictEqual(all.source, 'memory');
+    assert.strictEqual(all.pagination.total, 3);
+    assert.strictEqual(all.logs[0].action, 'a.three', 'più recente per prima');
+
+    const byUser = await audit.queryAuditLogs({ userId: 'alice' });
+    assert.strictEqual(byUser.pagination.total, 2);
+    assert.ok(byUser.logs.every(l => l.userId === 'alice'));
+  });
+
+  it('filtra per intervallo di date', async () => {
+    await audit.logAudit({ action: 'a.old', createdAt: new Date('2024-01-01') });
+    await audit.logAudit({ action: 'a.new', createdAt: new Date('2025-06-01') });
+
+    const result = await audit.queryAuditLogs({ from: '2025-01-01' });
+    assert.strictEqual(result.pagination.total, 1);
+    assert.strictEqual(result.logs[0].action, 'a.new');
+  });
+
+  it('pagina i risultati', async () => {
+    for (let i = 0; i < 12; i++) {
+      await audit.logAudit({ action: `a.${i}`, createdAt: new Date(2025, 0, i + 1) });
+    }
+    const page2 = await audit.queryAuditLogs({ page: 2, limit: 5 });
+    assert.strictEqual(page2.logs.length, 5);
+    assert.strictEqual(page2.pagination.total, 12);
+    assert.strictEqual(page2.pagination.pages, 3);
+  });
+
+  it('mantiene il buffer entro il limite configurato', async () => {
+    for (let i = 0; i < 600; i++) await audit.logAudit({ action: `a.${i}` });
+    assert.strictEqual(audit.getFallbackBuffer().length, 500);
+    assert.strictEqual(audit.getFallbackBuffer()[0].action, 'a.100', 'le più vecchie vengono scartate');
+  });
+
+  it('getAuditStats aggrega per categoria, azione ed esito', async () => {
+    await audit.logAudit({ action: 'escrow.create', category: 'escrow', status: 'success' });
+    await audit.logAudit({ action: 'escrow.create', category: 'escrow', status: 'failure' });
+    await audit.logAudit({ action: 'payment.buy_myz', category: 'payment', status: 'success' });
+
+    const stats = await audit.getAuditStats({});
+    assert.strictEqual(stats.total, 3);
+    assert.strictEqual(stats.failures, 1);
+    assert.strictEqual(stats.successes, 2);
+    assert.strictEqual(stats.byCategory.escrow, 2);
+    assert.strictEqual(stats.byAction['escrow.create'], 2);
+    assert.ok(Math.abs(stats.failureRate - 1 / 3) < 0.001);
+  });
+});
+
+// --------------------------------------------------------------- export CSV
+
+describe('toCSV', () => {
+  it('scrive intestazione e righe', () => {
+    const csv = audit.toCSV([{ action: 'escrow.create', category: 'escrow', status: 'success', userId: 'alice' }]);
+    const [header, row] = csv.trim().split('\r\n');
+    assert.strictEqual(header, audit.CSV_COLUMNS.join(','));
+    assert.match(row, /escrow\.create/);
+    assert.match(row, /alice/);
+  });
+
+  it('quota i campi con virgole, virgolette e newline', () => {
+    const csv = audit.toCSV([{ action: 'a', error: 'errore, grave' }]);
+    assert.match(csv, /"errore, grave"/);
+
+    const quoted = audit.toCSV([{ action: 'a', error: 'dice "no"' }]);
+    assert.match(quoted, /"dice ""no"""/);
+
+    const multiline = audit.toCSV([{ action: 'a', error: 'riga1\nriga2' }]);
+    assert.match(multiline, /"riga1\nriga2"/);
+  });
+
+  it('scrive celle vuote per i valori mancanti', () => {
+    const csv = audit.toCSV([{ action: 'a' }]);
+    const row = csv.trim().split('\r\n')[1];
+    assert.strictEqual(row.split(',').length, audit.CSV_COLUMNS.length);
+  });
+
+  it('serializza le date in ISO', () => {
+    const csv = audit.toCSV([{ action: 'a', createdAt: new Date('2025-01-01T10:00:00Z') }]);
+    assert.match(csv, /2025-01-01T10:00:00\.000Z/);
+  });
+
+  it('produce solo l intestazione con una lista vuota', () => {
+    assert.strictEqual(audit.toCSV([]).trim(), audit.CSV_COLUMNS.join(','));
+  });
+});
+
+// ---------------------------------------------------------------- middleware
+
+describe('auditLogger middleware', () => {
+  beforeEach(() => audit.clearFallbackBuffer());
+
+  it('lascia passare le richieste non critiche senza registrare nulla', () => {
+    const recorded = [];
+    const middleware = auditLogger({ log: e => recorded.push(e) });
+    const req = fakeReq({ method: 'GET', url: '/health' });
+    const res = fakeRes();
+
+    let nextCalled = false;
+    middleware(req, res, () => { nextCalled = true; });
+    res.finish();
+
+    assert.strictEqual(nextCalled, true);
+    assert.strictEqual(recorded.length, 0);
+  });
+
+  it('registra un azione critica riuscita con utente e risorsa', () => {
+    const recorded = [];
+    const middleware = auditLogger({ log: e => recorded.push(e) });
+    const req = fakeReq({
+      method: 'POST', url: '/api/robot/escrow/create',
+      body: { jobId: 'job-1', clientId: 'alice', robotId: 'robot-1', amount: 100, currency: 'MYZ' },
+      headers: { 'user-agent': 'test-agent' }
+    });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.json({ success: true });
+    res.finish();
+
+    assert.strictEqual(recorded.length, 1);
+    const entry = recorded[0];
+    assert.strictEqual(entry.action, 'escrow.robot_create');
+    assert.strictEqual(entry.category, 'escrow');
+    assert.strictEqual(entry.userId, 'alice');
+    assert.strictEqual(entry.resourceId, 'job-1');
+    assert.strictEqual(entry.status, 'success');
+    assert.strictEqual(entry.statusCode, 200);
+    assert.strictEqual(entry.userAgent, 'test-agent');
+    assert.strictEqual(entry.method, 'POST');
+    assert.strictEqual(typeof entry.durationMs, 'number');
+    assert.strictEqual(entry.metadata.amount, 100);
+  });
+
+  it('marca come failure le risposte 4xx e ne salva il messaggio', () => {
+    const recorded = [];
+    const middleware = auditLogger({ log: e => recorded.push(e) });
+    const req = fakeReq({ method: 'POST', url: '/api/robot/create', body: { robotId: 'r1' } });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.status(400).json({ error: 'Missing robotId, name, or walletAddress' });
+    res.finish();
+
+    assert.strictEqual(recorded[0].status, 'failure');
+    assert.strictEqual(recorded[0].statusCode, 400);
+    assert.match(recorded[0].error, /Missing robotId/);
+  });
+
+  it('non registra un errore quando la risposta è andata a buon fine', () => {
+    const recorded = [];
+    const middleware = auditLogger({ log: e => recorded.push(e) });
+    const req = fakeReq({ method: 'POST', url: '/buy-myz', body: { userTariWallet: 'tari-1', amountMYZ: 50 } });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.json({ orderId: 'order-9', status: 'pending' });
+    res.finish();
+
+    assert.strictEqual(recorded[0].error, null);
+    assert.strictEqual(recorded[0].userId, 'tari-1');
+    // orderId è generato dal server: si recupera dal body di risposta.
+    assert.strictEqual(recorded[0].resourceId, 'order-9');
+  });
+
+  it('oscura i segreti presenti nel body', () => {
+    const recorded = [];
+    const middleware = auditLogger({ log: e => recorded.push(e) });
+    const req = fakeReq({ method: 'POST', url: '/api/bounty/complete', body: { issueId: '1', walletAddress: 'w', privateKey: 'segreto' } });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.json({ success: true });
+    res.finish();
+
+    assert.strictEqual(recorded[0].metadata.privateKey, '[REDACTED]');
+    assert.strictEqual(recorded[0].metadata.issueId, '1');
+  });
+
+  it('preserva il valore di ritorno di res.json', () => {
+    const middleware = auditLogger({ log: () => {} });
+    const req = fakeReq({ method: 'POST', url: '/api/robot/create', body: {} });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    assert.strictEqual(res.json({ ok: true }), res, 'res.json deve restare concatenabile');
+  });
+
+  it('non propaga gli errori dell audit alla richiesta', () => {
+    const middleware = auditLogger({ log: () => { throw new Error('database esploso'); } });
+    const req = fakeReq({ method: 'POST', url: '/api/robot/create', body: {} });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.json({ success: true });
+    assert.doesNotThrow(() => res.finish());
+  });
+
+  it('sopravvive a un resolver che lancia', () => {
+    const middleware = auditLogger({ resolve: () => { throw new Error('boom'); } });
+    const req = fakeReq({ method: 'POST', url: '/buy-myz' });
+    const res = fakeRes();
+
+    let nextCalled = false;
+    assert.doesNotThrow(() => middleware(req, res, () => { nextCalled = true; }));
+    assert.strictEqual(nextCalled, true);
+  });
+
+  it('preferisce x-forwarded-for per l IP del client', () => {
+    assert.strictEqual(clientIp(fakeReq({ headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' } })), '1.2.3.4');
+    assert.strictEqual(clientIp(fakeReq({ ip: '9.9.9.9' })), '9.9.9.9');
+  });
+
+  it('errorFromBody legge entrambe le forme di errore del gateway', () => {
+    assert.strictEqual(errorFromBody({ error: 'testo' }), 'testo');
+    assert.strictEqual(errorFromBody({ success: false, error: 'testo' }), 'testo');
+    assert.strictEqual(errorFromBody({ error: { message: 'oggetto' } }), 'oggetto');
+    assert.strictEqual(errorFromBody({ success: true }), null);
+    assert.strictEqual(errorFromBody(null), null);
+  });
+
+  it('scrive davvero nel buffer usando il logger di default', () => {
+    const middleware = auditLogger();
+    const req = fakeReq({ method: 'POST', url: '/api/stake/stake', body: { userId: 'alice', amount: 10 } });
+    const res = fakeRes();
+
+    middleware(req, res, () => {});
+    res.json({ success: true });
+    res.finish();
+
+    const buffered = audit.getFallbackBuffer();
+    assert.strictEqual(buffered.length, 1);
+    assert.strictEqual(buffered[0].action, 'stake.create');
+    assert.strictEqual(buffered[0].userId, 'alice');
+  });
+});
+
+// -------------------------------------------------------------------- API
+
+describe('API /api/audit', () => {
+  beforeEach(async () => {
+    audit.clearFallbackBuffer();
+    await audit.logAudit({ action: 'escrow.create', category: 'escrow', userId: 'alice', status: 'success' });
+    await audit.logAudit({ action: 'payment.buy_myz', category: 'payment', userId: 'bob', status: 'failure' });
+  });
+
+  it('GET / restituisce le voci con la paginazione', async () => {
+    const { statusCode, body } = await callRoute('get', '/');
+    assert.strictEqual(statusCode, 200);
+    assert.strictEqual(body.success, true);
+    assert.strictEqual(body.data.length, 2);
+    assert.strictEqual(body.pagination.total, 2);
+    assert.strictEqual(body.source, 'memory');
+  });
+
+  it('GET /?userId=xxx filtra per utente', async () => {
+    const { body } = await callRoute('get', '/', { userId: 'alice' });
+    assert.strictEqual(body.data.length, 1);
+    assert.strictEqual(body.data[0].userId, 'alice');
+  });
+
+  it('GET /?status=failure filtra per esito', async () => {
+    const { body } = await callRoute('get', '/', { status: 'failure' });
+    assert.strictEqual(body.data.length, 1);
+    assert.strictEqual(body.data[0].action, 'payment.buy_myz');
+  });
+
+  it('GET / risponde 400 su un filtro non valido', async () => {
+    const invalidDate = await callRoute('get', '/', { from: 'ieri' });
+    assert.strictEqual(invalidDate.statusCode, 400);
+    assert.strictEqual(invalidDate.body.success, false);
+
+    const invalidStatus = await callRoute('get', '/', { status: 'boh' });
+    assert.strictEqual(invalidStatus.statusCode, 400);
+  });
+
+  it('GET /export?format=csv restituisce un CSV scaricabile', async () => {
+    const { statusCode, body, headers } = await callRoute('get', '/export', { format: 'csv' });
+    assert.strictEqual(statusCode, 200);
+    assert.match(headers['Content-Type'], /text\/csv/);
+    assert.match(headers['Content-Disposition'], /attachment; filename="audit-log-.*\.csv"/);
+    assert.match(body, new RegExp(`^${audit.CSV_COLUMNS.join(',')}`));
+    assert.match(body, /escrow\.create/);
+  });
+
+  it('GET /export senza format restituisce JSON', async () => {
+    const { body, headers } = await callRoute('get', '/export');
+    assert.match(headers['Content-Type'], /application\/json/);
+    const parsed = JSON.parse(body);
+    assert.strictEqual(parsed.count, 2);
+    assert.strictEqual(parsed.logs.length, 2);
+    assert.ok(parsed.exportedAt);
+  });
+
+  it('GET /export rispetta i filtri', async () => {
+    const { body } = await callRoute('get', '/export', { format: 'csv', userId: 'bob' });
+    assert.match(body, /payment\.buy_myz/);
+    assert.doesNotMatch(body, /escrow\.create/);
+  });
+
+  it('GET /export rifiuta un formato sconosciuto', async () => {
+    const { statusCode, body } = await callRoute('get', '/export', { format: 'xml' });
+    assert.strictEqual(statusCode, 400);
+    assert.match(body.error, /csv/);
+  });
+
+  it('GET /stats aggrega i conteggi', async () => {
+    const { body } = await callRoute('get', '/stats');
+    assert.strictEqual(body.data.total, 2);
+    assert.strictEqual(body.data.failures, 1);
+    assert.strictEqual(body.data.byCategory.escrow, 1);
+  });
+
+  it('GET /actions elenca il catalogo delle azioni tracciate', async () => {
+    const { body } = await callRoute('get', '/actions');
+    assert.ok(body.count >= 15);
+    assert.strictEqual(body.count, body.data.length);
+    assert.ok(body.data.every(a => a.action && a.category && a.method));
+    assert.ok(body.data.some(a => a.action === 'escrow.create'));
+  });
+});


### PR DESCRIPTION
Closes #279

## 📌 Cosa fa

Sistema di audit logging che traccia **automaticamente** le azioni critiche del gateway: pagamenti, escrow, robot, bounty, backup, stake e reward. Nessuna modifica alle route esistenti — il middleware è montato una volta sola in `server.js`.

## ✅ Criteri di accettazione

- [x] **Modello `AuditLog` (MongoDB)** — `models/AuditLog.js`, con indici composti per le query dell'API e retention opzionale.
- [x] **Middleware automatico per eventi critici** — `middleware/auditLogger.js`, catalogo di **19 azioni** in `services/auditService.js`.
- [x] **Query filtrate per data, utente, azione** — più categoria, risorsa ed esito, con paginazione.
- [x] **API `/api/audit?userId=xxx`** — esattamente questa, più `/export`, `/stats`, `/actions`.
- [x] **Export in CSV/JSON** — `GET /api/audit/export?format=csv|json`, allegato scaricabile, CSV conforme a RFC 4180.

## 🚀 Verificato end-to-end su un gateway in esecuzione

Quattro richieste (di cui una fallita) e una `GET /health`:

```bash
$ curl "http://localhost:10000/api/audit"
```

```jsonc
{
  "success": true,
  "data": [
    {
      "action": "robot.create", "category": "robot",
      "userId": null, "resourceType": "robot", "resourceId": "bad",
      "method": "POST", "path": "/api/robot/create",
      "statusCode": 400, "status": "failure",
      "ip": "::1", "userAgent": "curl/8.5.0", "durationMs": 1,
      "metadata": { "robotId": "bad" },
      "error": "Missing robotId, name, or walletAddress",
      "createdAt": "2026-08-05T06:48:16.393Z"
    },
    {
      "action": "payment.buy_myz", "category": "payment",
      "userId": "tari-alice", "resourceType": "order",
      "resourceId": "54972766ecd6872a",          // generato dal server, recuperato dalla risposta
      "statusCode": 200, "status": "success", "durationMs": 1,
      "metadata": { "userTariWallet": "tari-alice", "amountMYZ": 50 },
      "error": null
    }
    // …
  ],
  "pagination": { "page": 1, "limit": 50, "total": 4, "pages": 1 },
  "source": "memory"
}
```

`GET /health` **non** compare: le letture non vengono tracciate.

Export CSV reale:

```
$ curl -OJ "http://localhost:10000/api/audit/export?format=csv"

createdAt,action,category,status,userId,resourceType,resourceId,method,path,statusCode,durationMs,ip,error
2026-08-05T06:48:16.393Z,robot.create,robot,failure,,robot,bad,POST,/api/robot/create,400,1,::1,"Missing robotId, name, or walletAddress"
2026-08-05T06:48:16.384Z,payment.buy_myz,payment,success,tari-alice,order,54972766ecd6872a,POST,/buy-myz,200,1,::1,
```

Statistiche:

```jsonc
{ "total": 4, "failures": 1, "successes": 3, "failureRate": 0.25,
  "byCategory": { "robot": 3, "payment": 1 },
  "byAction": { "robot.create": 2, "payment.buy_myz": 1, "robot.assign_job": 1 } }
```

## 🔐 I segreti non finiscono nel log

Questa è la parte a cui ho dedicato più attenzione: **un audit log che copia il body alla lettera finisce per archiviare proprio i dati che non vanno archiviati.**

Le chiavi che contengono `password`, `secret`, `token`, `apiKey`, `authorization`, `privateKey`, `seed`, `mnemonic` o `signature` — **anche annidate** — diventano `[REDACTED]`. Verificato live:

```jsonc
// richiesta
{ "robotId": "a1", "name": "A", "walletAddress": "w1", "privateKey": "SEGRETO" }
// metadata registrato
{ "robotId": "a1", "name": "A", "walletAddress": "w1", "privateKey": "[REDACTED]" }
```

Inoltre le stringhe oltre 512 caratteri sono troncate, gli array oltre 20 elementi accorciati e la ricorsione si ferma a 4 livelli: un payload anomalo non può gonfiare la collection.

## 🧩 Tre scelte progettuali

**1. Non blocca e non può rompere nulla.** La voce viene scritta su `res.on('finish')`, cioè dopo che la risposta è già partita: il client non aspetta mai il database. E ogni errore dell'audit viene loggato e ignorato — un audit fallito non deve abbattere il pagamento che stava tracciando. C'è un test dedicato (`log` che lancia → la richiesta non ne risente).

**2. Funziona anche senza MongoDB.** Se la connessione non è attiva, o una scrittura fallisce, le voci finiscono in un buffer circolare in memoria e l'API continua a rispondere leggendo da lì. Il campo `source` (`"database"` / `"memory"`) dice sempre quale sorgente è stata usata. Questo rende l'audit utilizzabile in sviluppo e nei test senza avviare un database — ed è il motivo per cui i 59 test girano senza infrastruttura.

**3. Catalogo centralizzato, route intatte.** Le azioni critiche sono una tabella in `services/auditService.js`; il matching avviene sul path completo, quindi resta valido a prescindere da dove le route sono montate. **Aggiungere un'azione è una riga**, senza toccare i controller.

## 📡 API

| Endpoint | |
|---|---|
| `GET /api/audit?userId=xxx` | voci filtrate e paginate |
| `GET /api/audit/export?format=csv\|json` | export scaricabile, stessi filtri |
| `GET /api/audit/stats` | conteggi per categoria, azione ed esito |
| `GET /api/audit/actions` | catalogo delle 19 azioni tracciate |

Filtri: `userId`, `action`, `category`, `resourceId`, `resourceType`, `status`, `from`, `to`, `page`, `limit` (max 500).

I filtri non validi (data non parsabile, intervallo invertito, `status` sconosciuto) rispondono **400**, non 500 — verificato: `?from=ieri` → `HTTP 400`.

Tutti gli endpoint hanno annotazioni `@openapi` per swagger-jsdoc.

## ⚙️ Configurazione

| Variabile | Default | |
|---|---|---|
| `AUDIT_LOG_TTL_DAYS` | *(nessuna)* | se impostata, MongoDB elimina da solo le voci più vecchie |
| `AUDIT_LOG_BUFFER_SIZE` | `500` | dimensione del buffer di fallback |

## 🧪 Test

```
$ node --test tests/auditLog.test.js
# tests 59
# pass 59
# fail 0
```

Coperti: risoluzione delle azioni (incluse query string, trailing slash, metodo sbagliato, route non critiche), redazione dei segreti annidati, troncamento, validazione dei filtri e delle date, paginazione e clamping, limite del buffer circolare, quoting CSV secondo RFC 4180, comportamento del middleware su successo e su errore, resilienza a logger e resolver che lanciano, e tutti gli endpoint dell'API.

**Nessuna nuova dipendenza npm.**

## 📄 File

| File | |
|---|---|
| `models/AuditLog.js` | nuovo — schema e indici |
| `middleware/auditLogger.js` | nuovo — cattura automatica |
| `services/auditService.js` | nuovo — catalogo, query, export |
| `routes/audit.js` | nuovo — API + OpenAPI |
| `server.js` | 2 righe: monta il middleware e la route |
| `docs/AUDIT_LOGGING.md` | nuovo — documentazione |
| `tests/auditLog.test.js` | nuovo — 59 test |