### PR TITLE
feat: sistema di reputazione e feedback per robot (Bounty BOT-6, closes #343)

### DIFF
--- a/frontend/dashboard-reputation.html
+++ b/frontend/dashboard-reputation.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MyZubster - Reputazione Robot</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; }
+    .header { background: linear-gradient(135deg, #1e293b, #0f172a); padding: 24px 32px; border-bottom: 1px solid #334155; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; }
+    .header h1 { font-size: 24px; color: #38bdf8; }
+    .total-box { background: #1e293b; padding: 16px 24px; border-radius: 12px; border: 1px solid #334155; text-align: right; }
+    .total-box .label { font-size: 12px; color: #94a3b8; text-transform: uppercase; }
+    .total-box .amount { font-size: 32px; font-weight: bold; color: #38bdf8; }
+    .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    .controls { display: flex; gap: 12px; margin-bottom: 20px; flex-wrap: wrap; }
+    .controls input, .controls select, .controls button { padding: 10px 16px; border-radius: 8px; border: 1px solid #334155; background: #1e293b; color: #e2e8f0; font-size: 14px; }
+    .controls input::placeholder { color: #64748b; }
+    .controls button { cursor: pointer; }
+    .controls button:hover { border-color: #38bdf8; color: #38bdf8; }
+    table { width: 100%; border-collapse: collapse; background: #1e293b; border-radius: 12px; overflow: hidden; }
+    th { background: #0f172a; padding: 14px 16px; text-align: left; font-weight: 600; font-size: 12px; text-transform: uppercase; color: #94a3b8; }
+    td { padding: 14px 16px; border-top: 1px solid #334155; }
+    tr:hover { background: #0f172a; }
+    .badge { padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 600; white-space: nowrap; }
+    .badge-Platinum { background: #334155; color: #e2e8f0; border: 1px solid #94a3b8; }
+    .badge-Gold { background: #78350f; color: #fbbf24; }
+    .badge-Silver { background: #1e3a5f; color: #93c5fd; }
+    .badge-Bronze { background: #431407; color: #fb923c; }
+    .score-bar { display: flex; align-items: center; gap: 10px; min-width: 140px; }
+    .score-bar .track { flex: 1; height: 8px; background: #0f172a; border-radius: 4px; overflow: hidden; }
+    .score-bar .fill { height: 100%; background: linear-gradient(90deg, #38bdf8, #34d399); }
+    .score-bar .value { font-variant-numeric: tabular-nums; font-weight: 600; min-width: 44px; text-align: right; }
+    .stars { color: #fbbf24; letter-spacing: 2px; }
+    .muted { color: #64748b; }
+    .loading, .empty, .error { text-align: center; padding: 48px; color: #64748b; }
+    .error { color: #f87171; }
+    .detail { margin-top: 28px; background: #1e293b; border: 1px solid #334155; border-radius: 12px; padding: 24px; display: none; }
+    .detail h2 { font-size: 18px; color: #38bdf8; margin-bottom: 16px; }
+    .components { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; margin-bottom: 20px; }
+    .component { background: #0f172a; padding: 16px; border-radius: 10px; border: 1px solid #334155; }
+    .component .label { font-size: 12px; color: #94a3b8; text-transform: uppercase; margin-bottom: 6px; }
+    .component .val { font-size: 22px; font-weight: bold; color: #e2e8f0; }
+    .feedback-item { border-top: 1px solid #334155; padding: 14px 0; }
+    .feedback-item:first-of-type { border-top: none; }
+    .feedback-head { display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 6px; }
+    .feedback-comment { color: #cbd5e1; font-size: 14px; }
+    .disputed-tag { background: #7f1d1d; color: #f87171; padding: 2px 10px; border-radius: 20px; font-size: 11px; font-weight: 600; }
+    @media (max-width: 640px) {
+      .header { padding: 16px; }
+      .container { padding: 16px; }
+      th:nth-child(4), td:nth-child(4) { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>Reputazione Robot</h1>
+    <div class="total-box">
+      <div class="label">Robot valutati</div>
+      <div class="amount" id="totalRobots">0</div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="controls">
+      <input type="text" id="search" placeholder="Cerca per robotId o nome…">
+      <select id="badgeFilter">
+        <option value="">Tutti i badge</option>
+        <option value="Platinum">Platinum</option>
+        <option value="Gold">Gold</option>
+        <option value="Silver">Silver</option>
+        <option value="Bronze">Bronze</option>
+      </select>
+      <button id="refresh" type="button">Aggiorna</button>
+    </div>
+
+    <div id="state" class="loading">Caricamento…</div>
+
+    <table id="table" style="display:none">
+      <thead>
+        <tr>
+          <th>Robot</th>
+          <th>Badge</th>
+          <th>Punteggio</th>
+          <th>Valutazione</th>
+          <th>Job</th>
+          <th>Dispute</th>
+        </tr>
+      </thead>
+      <tbody id="tbody"></tbody>
+    </table>
+
+    <div class="detail" id="detail"></div>
+  </div>
+
+<script>
+  const API = window.location.origin;
+  let rows = [];
+
+  const stars = n => n === null ? '<span class="muted">nessun voto</span>'
+    : '<span class="stars">' + '★'.repeat(Math.round(n)) + '☆'.repeat(5 - Math.round(n)) + '</span> ' + n.toFixed(2);
+
+  const scoreBar = score =>
+    `<div class="score-bar"><div class="track"><div class="fill" style="width:${score}%"></div></div>
+     <span class="value">${score.toFixed(1)}</span></div>`;
+
+  function render() {
+    const term = document.getElementById('search').value.trim().toLowerCase();
+    const badge = document.getElementById('badgeFilter').value;
+    const filtered = rows.filter(r =>
+      (!badge || r.badge === badge) &&
+      (!term || r.robotId.toLowerCase().includes(term) || (r.name || '').toLowerCase().includes(term)));
+
+    document.getElementById('totalRobots').textContent = filtered.length;
+    const tbody = document.getElementById('tbody');
+    const state = document.getElementById('state');
+    const table = document.getElementById('table');
+
+    if (!filtered.length) {
+      table.style.display = 'none';
+      state.style.display = 'block';
+      state.className = 'empty';
+      state.textContent = rows.length ? 'Nessun robot corrisponde ai filtri.' : 'Nessun robot ancora valutato.';
+      return;
+    }
+
+    state.style.display = 'none';
+    table.style.display = 'table';
+    tbody.innerHTML = filtered.map(r => `
+      <tr data-robot="${r.robotId}" style="cursor:pointer">
+        <td><strong>${r.name || r.robotId}</strong><br><span class="muted">${r.robotId}</span></td>
+        <td><span class="badge badge-${r.badge}">${r.badge}</span></td>
+        <td>${scoreBar(r.score)}</td>
+        <td>${stars(r.averageRating)}<br><span class="muted">${r.totalFeedback} feedback</span></td>
+        <td>${r.jobsCompleted}</td>
+        <td>${r.disputes ? '<span class="disputed-tag">' + r.disputes + '</span>' : '0'}</td>
+      </tr>`).join('');
+
+    tbody.querySelectorAll('tr').forEach(tr =>
+      tr.addEventListener('click', () => showDetail(tr.dataset.robot)));
+  }
+
+  async function showDetail(robotId) {
+    const box = document.getElementById('detail');
+    box.style.display = 'block';
+    box.innerHTML = '<div class="loading">Caricamento…</div>';
+    try {
+      const [repRes, fbRes] = await Promise.all([
+        fetch(`${API}/api/robot/reputation/${encodeURIComponent(robotId)}`).then(r => r.json()),
+        fetch(`${API}/api/robot/feedback/${encodeURIComponent(robotId)}?limit=10`).then(r => r.json())
+      ]);
+      const r = repRes.data;
+      const next = r.nextBadge
+        ? `Per <strong>${r.nextBadge.name}</strong> servono ancora ${r.nextBadge.scoreNeeded} punti e ${r.nextBadge.jobsNeeded} job.`
+        : 'Badge massimo raggiunto. 🏆';
+
+      box.innerHTML = `
+        <h2>${r.name || r.robotId} — <span class="badge badge-${r.badge}">${r.badge}</span></h2>
+        <div class="components">
+          <div class="component"><div class="label">Punteggio</div><div class="val">${r.score.toFixed(1)}</div></div>
+          <div class="component"><div class="label">Qualità (60%)</div><div class="val">${r.components.quality.toFixed(1)}</div></div>
+          <div class="component"><div class="label">Esperienza (25%)</div><div class="val">${r.components.experience.toFixed(1)}</div></div>
+          <div class="component"><div class="label">Affidabilità (15%)</div><div class="val">${r.components.reliability.toFixed(1)}</div></div>
+        </div>
+        <p class="muted" style="margin-bottom:20px">${next}</p>
+        <h2>Ultimi feedback</h2>
+        ${(fbRes.data || []).length ? (fbRes.data).map(f => `
+          <div class="feedback-item">
+            <div class="feedback-head">
+              <span>${'★'.repeat(f.rating)}<span class="muted">${'☆'.repeat(5 - f.rating)}</span>
+                &nbsp;<span class="muted">da ${f.clientId} · job ${f.jobId}</span></span>
+              <span class="muted">${new Date(f.createdAt).toLocaleString('it-IT')}
+                ${f.disputed ? '<span class="disputed-tag">disputa</span>' : ''}</span>
+            </div>
+            ${f.comment ? `<div class="feedback-comment">${f.comment.replace(/</g, '&lt;')}</div>` : ''}
+          </div>`).join('') : '<p class="muted">Nessun feedback.</p>'}`;
+      box.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    } catch (err) {
+      box.innerHTML = `<div class="error">Errore nel caricamento: ${err.message}</div>`;
+    }
+  }
+
+  async function load() {
+    const state = document.getElementById('state');
+    state.style.display = 'block';
+    state.className = 'loading';
+    state.textContent = 'Caricamento…';
+    try {
+      const res = await fetch(`${API}/api/robot/reputation?limit=100`);
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || 'Risposta non valida');
+      rows = json.data || [];
+      render();
+    } catch (err) {
+      document.getElementById('table').style.display = 'none';
+      state.className = 'error';
+      state.textContent = `Errore nel caricamento: ${err.message}`;
+    }
+  }
+
+  document.getElementById('search').addEventListener('input', render);
+  document.getElementById('badgeFilter').addEventListener('change', render);
+  document.getElementById('refresh').addEventListener('click', load);
+  load();
+  setInterval(load, 30000);
+</script>
+</body>
+</html>

--- a/models/RobotFeedback.js
+++ b/models/RobotFeedback.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+/**
+ * RobotFeedback - Bounty BOT-6 (#343)
+ *
+ * Un feedback lasciato da un cliente su un job svolto da un robot.
+ * La reputazione è derivata da questi documenti, mai scritta a mano.
+ */
+const RobotFeedbackSchema = new mongoose.Schema({
+  robotId: { type: String, required: true, index: true },
+  clientId: { type: String, required: true, index: true },
+  // Il job a cui il feedback si riferisce: un cliente può valutare un robot
+  // una sola volta per job (indice unico più sotto).
+  jobId: { type: String, required: true, index: true },
+
+  rating: { type: Number, required: true, min: 1, max: 5 },
+  comment: { type: String, default: null, maxlength: 1000 },
+
+  // Un feedback lasciato dopo una disputa pesa di più nel calcolo, perché
+  // segnala un problema reale e non una semplice preferenza.
+  disputed: { type: Boolean, default: false },
+
+  createdAt: { type: Date, default: Date.now, index: true }
+});
+
+RobotFeedbackSchema.index({ robotId: 1, createdAt: -1 });
+// Un solo feedback per (robot, job, cliente): impedisce di gonfiare o
+// affossare la reputazione con voti ripetuti sullo stesso lavoro.
+RobotFeedbackSchema.index({ robotId: 1, jobId: 1, clientId: 1 }, { unique: true });
+
+module.exports = mongoose.model('RobotFeedback', RobotFeedbackSchema);

--- a/routes/robotFeedback.js
+++ b/routes/robotFeedback.js
@@ -1,0 +1,154 @@
+/**
+ * API feedback e reputazione robot - Bounty BOT-6 (#343)
+ *
+ *   POST /api/robot/feedback              lascia un feedback
+ *   GET  /api/robot/feedback/:robotId     storico feedback del robot
+ *   GET  /api/robot/reputation/:robotId   reputazione, badge e progresso
+ *   GET  /api/robot/reputation            classifica
+ *   GET  /api/robot/badges                soglie dei badge
+ */
+
+const express = require('express');
+const router = express.Router();
+const reputation = require('../services/reputationService');
+
+function handle(res, err) {
+  if (err instanceof reputation.ValidationError) {
+    return res.status(400).json({ success: false, error: err.message });
+  }
+  if (err instanceof reputation.ConflictError) {
+    return res.status(409).json({ success: false, error: err.message });
+  }
+  console.error('Reputation API error:', err);
+  res.status(500).json({ success: false, error: err.message });
+}
+
+/**
+ * @openapi
+ * /api/robot/feedback:
+ *   post:
+ *     tags: [Robot Reputation]
+ *     summary: Lascia un feedback su un job svolto da un robot
+ *     description: >
+ *       Un cliente può lasciare un solo feedback per ogni coppia (robot, job).
+ *       Un secondo tentativo risponde 409.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [robotId, clientId, jobId, rating]
+ *             properties:
+ *               robotId: { type: string, example: robot-001 }
+ *               clientId: { type: string, example: alice }
+ *               jobId: { type: string, example: job-42 }
+ *               rating: { type: integer, minimum: 1, maximum: 5, example: 5 }
+ *               comment: { type: string, maxLength: 1000 }
+ *               disputed: { type: boolean, default: false, description: Feedback lasciato dopo una disputa }
+ *     responses:
+ *       201: { description: Feedback registrato, con la reputazione aggiornata }
+ *       400: { description: Payload non valido }
+ *       409: { description: Feedback già presente per questo job e cliente }
+ */
+router.post('/feedback', async (req, res) => {
+  try {
+    const feedback = await reputation.submitFeedback(req.body || {});
+    const updated = await reputation.getReputation(feedback.robotId);
+    res.status(201).json({ success: true, data: { feedback, reputation: updated } });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/robot/feedback/{robotId}:
+ *   get:
+ *     tags: [Robot Reputation]
+ *     summary: Storico dei feedback di un robot
+ *     parameters:
+ *       - { in: path, name: robotId, required: true, schema: { type: string } }
+ *       - { in: query, name: page, schema: { type: integer, default: 1 } }
+ *       - { in: query, name: limit, schema: { type: integer, default: 20, maximum: 100 } }
+ *     responses:
+ *       200: { description: Feedback paginati, dal più recente }
+ */
+router.get('/feedback/:robotId', async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 20));
+    const { items, total } = await reputation.findFeedback(
+      { robotId: req.params.robotId },
+      { limit, skip: (page - 1) * limit }
+    );
+    res.json({
+      success: true,
+      data: items,
+      pagination: { page, limit, total, pages: Math.ceil(total / limit) || 0 }
+    });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/robot/reputation:
+ *   get:
+ *     tags: [Robot Reputation]
+ *     summary: Classifica dei robot per punteggio di reputazione
+ *     parameters:
+ *       - { in: query, name: limit, schema: { type: integer, default: 20, maximum: 100 } }
+ *       - { in: query, name: badge, schema: { type: string, enum: [Bronze, Silver, Gold, Platinum] } }
+ *     responses:
+ *       200: { description: Classifica ordinata per punteggio decrescente }
+ */
+router.get('/reputation', async (req, res) => {
+  try {
+    const limit = parseInt(req.query.limit, 10) || 20;
+    const badge = req.query.badge || null;
+    const data = await reputation.getLeaderboard({ limit, badge });
+    res.json({ success: true, count: data.length, data });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+/**
+ * @openapi
+ * /api/robot/badges:
+ *   get:
+ *     tags: [Robot Reputation]
+ *     summary: Soglie dei badge (Bronze, Silver, Gold, Platinum)
+ *     responses:
+ *       200: { description: Elenco dei badge con punteggio e job minimi }
+ */
+router.get('/badges', (req, res) => {
+  res.json({ success: true, data: reputation.BADGES });
+});
+
+/**
+ * @openapi
+ * /api/robot/reputation/{robotId}:
+ *   get:
+ *     tags: [Robot Reputation]
+ *     summary: Reputazione di un robot con badge e progresso
+ *     description: >
+ *       Il punteggio 0-100 è derivato da valutazioni (60%), esperienza (25%) e
+ *       affidabilità (15%). Un robot senza feedback parte da un valore neutro:
+ *       non è inaffidabile, è solo sconosciuto.
+ *     parameters:
+ *       - { in: path, name: robotId, required: true, schema: { type: string } }
+ *     responses:
+ *       200: { description: Punteggio, badge, componenti e progresso verso il badge successivo }
+ */
+router.get('/reputation/:robotId', async (req, res) => {
+  try {
+    res.json({ success: true, data: await reputation.getReputation(req.params.robotId) });
+  } catch (err) {
+    handle(res, err);
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -58,6 +58,9 @@ app.use('/api/stake', require('./routes/stake'));
 app.use('/api/escrow/house', require('./routes/escrowHouse'));
 
 app.use('/api/robot', require('./routes/robot'));
+// Feedback e reputazione (Bounty BOT-6): montato sullo stesso prefisso, dopo
+// routes/robot.js, che non ha catch-all e quindi lascia passare i path nuovi.
+app.use('/api/robot', require('./routes/robotFeedback'));
 app.use('/api/robot/escrow', require('./routes/robotEscrow'));
 app.use('/api/robot/logo', require('./routes/robotLogo'));
 app.use('/api/robot/code', require('./routes/robotCode'));

--- a/services/reputationService.js
+++ b/services/reputationService.js
@@ -1,0 +1,286 @@
+/**
+ * Robot Reputation Service - Bounty BOT-6 (#343)
+ *
+ * Calcola la reputazione di un robot a partire da tre segnali:
+ *   - i job completati (esperienza)
+ *   - le valutazioni ricevute (qualità percepita)
+ *   - le dispute aperte (affidabilità)
+ *
+ * Il punteggio è sempre **derivato**: non esiste un campo "reputation" che
+ * qualcuno possa scrivere direttamente. Ricalcolarlo dai feedback rende il
+ * sistema verificabile e impossibile da falsare senza lasciare traccia.
+ *
+ * Come per l'audit, senza MongoDB i feedback finiscono in un archivio in
+ * memoria: il servizio resta usabile in sviluppo e nei test.
+ */
+
+const mongoose = require('mongoose');
+const RobotFeedback = require('../models/RobotFeedback');
+const robotBrain = require('../robot_brain');
+
+// ------------------------------------------------------------------ badge
+
+/**
+ * Soglie dei badge. `minScore` è il punteggio 0-100, `minJobs` evita che un
+ * robot con un solo job perfetto scavalchi uno con cento job ottimi.
+ */
+const BADGES = [
+  { name: 'Platinum', minScore: 90, minJobs: 50 },
+  { name: 'Gold', minScore: 75, minJobs: 20 },
+  { name: 'Silver', minScore: 60, minJobs: 5 },
+  { name: 'Bronze', minScore: 0, minJobs: 0 }
+];
+
+function badgeFor(score, jobsCompleted) {
+  return BADGES.find(b => score >= b.minScore && jobsCompleted >= b.minJobs) || BADGES[BADGES.length - 1];
+}
+
+/** Cosa manca per il badge successivo: serve alla dashboard. */
+function nextBadge(score, jobsCompleted) {
+  const current = badgeFor(score, jobsCompleted);
+  const currentIndex = BADGES.findIndex(b => b.name === current.name);
+  if (currentIndex === 0) return null; // già Platinum
+  const next = BADGES[currentIndex - 1];
+  return {
+    name: next.name,
+    scoreNeeded: Math.max(0, round(next.minScore - score)),
+    jobsNeeded: Math.max(0, next.minJobs - jobsCompleted)
+  };
+}
+
+// ------------------------------------------------------------- punteggio
+
+const WEIGHTS = { rating: 0.6, experience: 0.25, reliability: 0.15 };
+const EXPERIENCE_PLATEAU = 50; // job oltre i quali l'esperienza non cresce più
+
+function round(value, decimals = 2) {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Punteggio 0-100 da valutazioni, esperienza e dispute.
+ *
+ * Un robot senza feedback parte da 50 (neutro) invece che da 0: uno appena
+ * creato non è inaffidabile, è semplicemente sconosciuto.
+ *
+ * @param {{averageRating: number|null, totalFeedback: number, jobsCompleted: number, disputes: number}} input
+ */
+function computeScore({ averageRating = null, totalFeedback = 0, jobsCompleted = 0, disputes = 0 }) {
+  // Qualità: media voti 1-5 riportata su 0-100; 50 se non ci sono voti.
+  const quality = totalFeedback > 0 && averageRating !== null
+    ? ((averageRating - 1) / 4) * 100
+    : 50;
+
+  // Esperienza: cresce con i job completati e si appiattisce a EXPERIENCE_PLATEAU.
+  const experience = clamp((jobsCompleted / EXPERIENCE_PLATEAU) * 100, 0, 100);
+
+  // Affidabilità: percentuale di job senza disputa.
+  const denominator = Math.max(jobsCompleted, disputes);
+  const reliability = denominator > 0
+    ? clamp(((denominator - disputes) / denominator) * 100, 0, 100)
+    : 100;
+
+  const score = quality * WEIGHTS.rating + experience * WEIGHTS.experience + reliability * WEIGHTS.reliability;
+  return {
+    score: round(clamp(score, 0, 100)),
+    components: { quality: round(quality), experience: round(experience), reliability: round(reliability) }
+  };
+}
+
+// ------------------------------------------------- archivio di fallback
+
+const memoryFeedback = []; // usato quando MongoDB non è connesso
+
+function isMongoConnected() {
+  return mongoose.connection && mongoose.connection.readyState === 1;
+}
+
+function getMemoryFeedback() {
+  return memoryFeedback.slice();
+}
+
+function clearMemoryFeedback() {
+  memoryFeedback.length = 0;
+}
+
+// ------------------------------------------------------------ scrittura
+
+class ValidationError extends Error {}
+class ConflictError extends Error {}
+
+/** Valida e normalizza il payload di un feedback. Lancia ValidationError. */
+function validateFeedback({ robotId, clientId, jobId, rating, comment, disputed }) {
+  if (!robotId) throw new ValidationError('robotId è obbligatorio');
+  if (!clientId) throw new ValidationError('clientId è obbligatorio');
+  if (!jobId) throw new ValidationError('jobId è obbligatorio');
+
+  const parsed = Number(rating);
+  if (!Number.isFinite(parsed)) throw new ValidationError('rating è obbligatorio e deve essere un numero');
+  if (!Number.isInteger(parsed)) throw new ValidationError('rating deve essere un numero intero');
+  if (parsed < 1 || parsed > 5) throw new ValidationError('rating deve essere compreso fra 1 e 5');
+
+  if (comment !== undefined && comment !== null && typeof comment !== 'string') {
+    throw new ValidationError('comment deve essere una stringa');
+  }
+  if (typeof comment === 'string' && comment.length > 1000) {
+    throw new ValidationError('comment non può superare i 1000 caratteri');
+  }
+
+  return {
+    robotId: String(robotId),
+    clientId: String(clientId),
+    jobId: String(jobId),
+    rating: parsed,
+    comment: comment ? String(comment) : null,
+    disputed: disputed === true || disputed === 'true',
+    createdAt: new Date()
+  };
+}
+
+/**
+ * Registra un feedback. Rifiuta i duplicati (stesso robot, job e cliente).
+ * @throws {ValidationError|ConflictError}
+ */
+async function submitFeedback(payload) {
+  const feedback = validateFeedback(payload);
+
+  if (!isMongoConnected()) {
+    const duplicate = memoryFeedback.some(f =>
+      f.robotId === feedback.robotId && f.jobId === feedback.jobId && f.clientId === feedback.clientId);
+    if (duplicate) throw new ConflictError('Feedback già presente per questo job e cliente');
+    memoryFeedback.push(feedback);
+    return feedback;
+  }
+
+  try {
+    return await RobotFeedback.create(feedback);
+  } catch (err) {
+    // 11000 = violazione dell'indice unico su (robotId, jobId, clientId).
+    if (err.code === 11000) throw new ConflictError('Feedback già presente per questo job e cliente');
+    throw err;
+  }
+}
+
+// ------------------------------------------------------------- lettura
+
+async function findFeedback(filter = {}, { limit = 50, skip = 0 } = {}) {
+  if (!isMongoConnected()) {
+    const all = memoryFeedback
+      .filter(f => Object.entries(filter).every(([k, v]) => f[k] === v))
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    return { items: all.slice(skip, skip + limit), total: all.length };
+  }
+  const [items, total] = await Promise.all([
+    RobotFeedback.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+    RobotFeedback.countDocuments(filter)
+  ]);
+  return { items, total };
+}
+
+/** Aggregati di un robot a partire da tutti i suoi feedback. */
+function summarize(feedbacks) {
+  const distribution = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  let sum = 0;
+  let disputes = 0;
+
+  for (const f of feedbacks) {
+    distribution[f.rating] = (distribution[f.rating] || 0) + 1;
+    sum += f.rating;
+    if (f.disputed) disputes += 1;
+  }
+
+  return {
+    totalFeedback: feedbacks.length,
+    averageRating: feedbacks.length ? round(sum / feedbacks.length) : null,
+    ratingDistribution: distribution,
+    disputedFeedback: disputes
+  };
+}
+
+/** Job completati e dispute noti al robot_brain (stato in memoria). */
+function robotStats(robotId) {
+  const robot = robotBrain.getAllRobots().find(r => r.robotId === robotId);
+  if (!robot) return { known: false, jobsCompleted: 0, disputes: 0, name: null, status: null };
+  const disputes = (robot.history || []).filter(h => h.event === 'dispute_opened').length;
+  return {
+    known: true,
+    jobsCompleted: Number(robot.jobsCompleted) || 0,
+    disputes,
+    name: robot.name || null,
+    status: robot.status || 'idle'
+  };
+}
+
+/**
+ * Reputazione completa di un robot: punteggio, badge, aggregati e progresso.
+ */
+async function getReputation(robotId) {
+  if (!robotId) throw new ValidationError('robotId è obbligatorio');
+
+  const { items } = await findFeedback({ robotId }, { limit: 10000 });
+  const summary = summarize(items);
+  const stats = robotStats(robotId);
+
+  // Le dispute contano una sola volta anche se emergono da entrambe le fonti.
+  const disputes = Math.max(stats.disputes, summary.disputedFeedback);
+
+  const { score, components } = computeScore({
+    averageRating: summary.averageRating,
+    totalFeedback: summary.totalFeedback,
+    jobsCompleted: stats.jobsCompleted,
+    disputes
+  });
+
+  const badge = badgeFor(score, stats.jobsCompleted);
+
+  return {
+    robotId,
+    name: stats.name,
+    status: stats.status,
+    knownToGateway: stats.known,
+    score,
+    badge: badge.name,
+    components,
+    jobsCompleted: stats.jobsCompleted,
+    disputes,
+    ...summary,
+    nextBadge: nextBadge(score, stats.jobsCompleted)
+  };
+}
+
+/** Classifica dei robot per punteggio. */
+async function getLeaderboard({ limit = 20, badge = null } = {}) {
+  const ids = new Set(robotBrain.getAllRobots().map(r => r.robotId));
+  const { items } = await findFeedback({}, { limit: 10000 });
+  for (const f of items) ids.add(f.robotId);
+
+  const reputations = await Promise.all(Array.from(ids).map(id => getReputation(id)));
+  const filtered = badge ? reputations.filter(r => r.badge === badge) : reputations;
+
+  return filtered
+    .sort((a, b) => b.score - a.score || b.jobsCompleted - a.jobsCompleted)
+    .slice(0, Math.min(Math.max(1, limit), 100));
+}
+
+module.exports = {
+  BADGES,
+  ValidationError,
+  ConflictError,
+  badgeFor,
+  nextBadge,
+  computeScore,
+  validateFeedback,
+  submitFeedback,
+  findFeedback,
+  summarize,
+  getReputation,
+  getLeaderboard,
+  getMemoryFeedback,
+  clearMemoryFeedback
+};

--- a/tests/robotReputation.test.js
+++ b/tests/robotReputation.test.js
@@ -1,0 +1,387 @@
+/**
+ * Test per reputazione e feedback robot - Bounty BOT-6 (#343)
+ *
+ * Girano senza MongoDB: il servizio usa l'archivio in memoria, che è anche il
+ * percorso di degrado testato qui.
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+const reputation = require('../services/reputationService');
+const robotBrain = require('../robot_brain');
+const router = require('../routes/robotFeedback');
+
+// ------------------------------------------------------------------ utils
+
+let seq = 0;
+function uniqueId(prefix) {
+  seq += 1;
+  return `${prefix}-${process.pid}-${seq}`;
+}
+
+/** robot_brain tiene lo stato in un Map di modulo: servono id univoci. */
+function seedRobot({ jobsCompleted = 0, disputes = 0, status = 'idle' } = {}) {
+  const robotId = uniqueId('rep-robot');
+  const robot = robotBrain.createRobot(robotId, `Robot ${robotId}`, `wallet_${robotId}`);
+  robot.jobsCompleted = jobsCompleted;
+  robot.status = status;
+  robot.history = Array.from({ length: disputes }, () => ({ event: 'dispute_opened' }));
+  return robot;
+}
+
+function callRoute(method, path, { params = {}, query = {}, body = {} } = {}) {
+  const layer = router.stack.find(l => l.route && l.route.path === path && l.route.methods[method]);
+  assert.ok(layer, `route ${method.toUpperCase()} ${path} non registrata`);
+  const req = { method: method.toUpperCase(), params, query, body };
+  return new Promise((resolve, reject) => {
+    const res = {
+      statusCode: 200,
+      status(code) { this.statusCode = code; return this; },
+      json(payload) { resolve({ statusCode: this.statusCode, body: payload }); }
+    };
+    Promise.resolve(layer.route.stack[0].handle(req, res, reject)).catch(reject);
+  });
+}
+
+// -------------------------------------------------------------- computeScore
+
+describe('computeScore', () => {
+  it('dà 50 (neutro) a un robot senza feedback e senza job', () => {
+    const { score, components } = reputation.computeScore({});
+    assert.strictEqual(components.quality, 50, 'sconosciuto, non inaffidabile');
+    assert.strictEqual(components.experience, 0);
+    assert.strictEqual(components.reliability, 100);
+    assert.strictEqual(score, 50 * 0.6 + 0 * 0.25 + 100 * 0.15);
+  });
+
+  it('mappa la media voti 1-5 su 0-100', () => {
+    assert.strictEqual(reputation.computeScore({ averageRating: 5, totalFeedback: 1 }).components.quality, 100);
+    assert.strictEqual(reputation.computeScore({ averageRating: 1, totalFeedback: 1 }).components.quality, 0);
+    assert.strictEqual(reputation.computeScore({ averageRating: 3, totalFeedback: 1 }).components.quality, 50);
+  });
+
+  it('fa crescere l esperienza fino al plateau di 50 job', () => {
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 25 }).components.experience, 50);
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 50 }).components.experience, 100);
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 500 }).components.experience, 100, 'non supera 100');
+  });
+
+  it('abbassa l affidabilità in proporzione alle dispute', () => {
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 10, disputes: 0 }).components.reliability, 100);
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 10, disputes: 2 }).components.reliability, 80);
+    assert.strictEqual(reputation.computeScore({ jobsCompleted: 10, disputes: 10 }).components.reliability, 0);
+  });
+
+  it('non manda l affidabilità sotto zero con più dispute che job', () => {
+    const { components } = reputation.computeScore({ jobsCompleted: 1, disputes: 5 });
+    assert.strictEqual(components.reliability, 0);
+  });
+
+  it('tiene il punteggio dentro 0-100', () => {
+    const best = reputation.computeScore({ averageRating: 5, totalFeedback: 30, jobsCompleted: 100, disputes: 0 });
+    const worst = reputation.computeScore({ averageRating: 1, totalFeedback: 30, jobsCompleted: 5, disputes: 5 });
+    assert.strictEqual(best.score, 100);
+    assert.ok(worst.score >= 0 && worst.score < 20);
+  });
+
+  it('pesa la qualità più dell esperienza', () => {
+    const qualitySwing = reputation.computeScore({ averageRating: 5, totalFeedback: 1 }).score
+      - reputation.computeScore({ averageRating: 1, totalFeedback: 1 }).score;
+    const experienceSwing = reputation.computeScore({ jobsCompleted: 50 }).score
+      - reputation.computeScore({ jobsCompleted: 0 }).score;
+    assert.ok(qualitySwing > experienceSwing);
+  });
+});
+
+// --------------------------------------------------------------------- badge
+
+describe('badge', () => {
+  it('assegna i quattro livelli in base a punteggio e job', () => {
+    assert.strictEqual(reputation.badgeFor(95, 60).name, 'Platinum');
+    assert.strictEqual(reputation.badgeFor(80, 25).name, 'Gold');
+    assert.strictEqual(reputation.badgeFor(65, 10).name, 'Silver');
+    assert.strictEqual(reputation.badgeFor(30, 2).name, 'Bronze');
+  });
+
+  it('non promuove chi ha il punteggio ma non i job', () => {
+    assert.strictEqual(reputation.badgeFor(95, 3).name, 'Bronze', '95 punti ma solo 3 job');
+    assert.strictEqual(reputation.badgeFor(95, 10).name, 'Silver');
+    assert.strictEqual(reputation.badgeFor(95, 20).name, 'Gold');
+  });
+
+  it('nextBadge dice quanto manca', () => {
+    const next = reputation.nextBadge(65, 10);
+    assert.strictEqual(next.name, 'Gold');
+    assert.strictEqual(next.scoreNeeded, 10);
+    assert.strictEqual(next.jobsNeeded, 10);
+  });
+
+  it('nextBadge è null per Platinum', () => {
+    assert.strictEqual(reputation.nextBadge(95, 60), null);
+  });
+
+  it('nextBadge non restituisce valori negativi', () => {
+    const next = reputation.nextBadge(95, 25); // Gold, gli manca solo l'esperienza
+    assert.strictEqual(next.name, 'Platinum');
+    assert.strictEqual(next.scoreNeeded, 0);
+    assert.strictEqual(next.jobsNeeded, 25);
+  });
+});
+
+// ---------------------------------------------------------------- validazione
+
+describe('validateFeedback', () => {
+  const valid = { robotId: 'r1', clientId: 'c1', jobId: 'j1', rating: 4 };
+
+  it('accetta un payload valido e normalizza', () => {
+    const out = reputation.validateFeedback({ ...valid, rating: '5', disputed: 'true' });
+    assert.strictEqual(out.rating, 5);
+    assert.strictEqual(out.disputed, true);
+    assert.strictEqual(out.comment, null);
+    assert.ok(out.createdAt instanceof Date);
+  });
+
+  it('richiede i campi obbligatori', () => {
+    for (const field of ['robotId', 'clientId', 'jobId']) {
+      const payload = { ...valid };
+      delete payload[field];
+      assert.throws(() => reputation.validateFeedback(payload), new RegExp(`${field} è obbligatorio`));
+    }
+  });
+
+  it('rifiuta rating fuori scala, non interi e non numerici', () => {
+    assert.throws(() => reputation.validateFeedback({ ...valid, rating: 0 }), /fra 1 e 5/);
+    assert.throws(() => reputation.validateFeedback({ ...valid, rating: 6 }), /fra 1 e 5/);
+    assert.throws(() => reputation.validateFeedback({ ...valid, rating: 3.5 }), /intero/);
+    assert.throws(() => reputation.validateFeedback({ ...valid, rating: 'ottimo' }), /deve essere un numero/);
+    assert.throws(() => reputation.validateFeedback({ ...valid, rating: undefined }), /obbligatorio/);
+  });
+
+  it('rifiuta commenti non stringa o troppo lunghi', () => {
+    assert.throws(() => reputation.validateFeedback({ ...valid, comment: 42 }), /stringa/);
+    assert.throws(() => reputation.validateFeedback({ ...valid, comment: 'x'.repeat(1001) }), /1000 caratteri/);
+  });
+});
+
+// ------------------------------------------------------------------ scrittura
+
+describe('submitFeedback', () => {
+  beforeEach(() => reputation.clearMemoryFeedback());
+
+  it('registra un feedback', async () => {
+    const robot = seedRobot();
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5 });
+    assert.strictEqual(reputation.getMemoryFeedback().length, 1);
+  });
+
+  it('rifiuta un secondo feedback dello stesso cliente sullo stesso job', async () => {
+    const robot = seedRobot();
+    const payload = { robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5 };
+    await reputation.submitFeedback(payload);
+    await assert.rejects(() => reputation.submitFeedback({ ...payload, rating: 1 }), reputation.ConflictError);
+    assert.strictEqual(reputation.getMemoryFeedback().length, 1);
+  });
+
+  it('accetta clienti diversi sullo stesso job', async () => {
+    const robot = seedRobot();
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'bob', jobId: 'j1', rating: 4 });
+    assert.strictEqual(reputation.getMemoryFeedback().length, 2);
+  });
+
+  it('accetta job diversi dallo stesso cliente', async () => {
+    const robot = seedRobot();
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'alice', jobId: 'j2', rating: 3 });
+    assert.strictEqual(reputation.getMemoryFeedback().length, 2);
+  });
+});
+
+// -------------------------------------------------------------------- summary
+
+describe('summarize', () => {
+  it('calcola media, distribuzione e dispute', () => {
+    const s = reputation.summarize([
+      { rating: 5, disputed: false }, { rating: 4, disputed: false },
+      { rating: 5, disputed: false }, { rating: 2, disputed: true }
+    ]);
+    assert.strictEqual(s.totalFeedback, 4);
+    assert.strictEqual(s.averageRating, 4);
+    assert.strictEqual(s.disputedFeedback, 1);
+    assert.deepStrictEqual(s.ratingDistribution, { 1: 0, 2: 1, 3: 0, 4: 1, 5: 2 });
+  });
+
+  it('restituisce averageRating null senza feedback', () => {
+    const s = reputation.summarize([]);
+    assert.strictEqual(s.averageRating, null);
+    assert.strictEqual(s.totalFeedback, 0);
+  });
+});
+
+// ------------------------------------------------------------- getReputation
+
+describe('getReputation', () => {
+  beforeEach(() => reputation.clearMemoryFeedback());
+
+  it('combina feedback e statistiche del robot_brain', async () => {
+    const robot = seedRobot({ jobsCompleted: 25, disputes: 1 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'a', jobId: 'j1', rating: 5 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'b', jobId: 'j2', rating: 4 });
+
+    const rep = await reputation.getReputation(robot.robotId);
+    assert.strictEqual(rep.robotId, robot.robotId);
+    assert.strictEqual(rep.totalFeedback, 2);
+    assert.strictEqual(rep.averageRating, 4.5);
+    assert.strictEqual(rep.jobsCompleted, 25);
+    assert.strictEqual(rep.disputes, 1);
+    assert.strictEqual(rep.knownToGateway, true);
+    assert.ok(rep.score > 50);
+    assert.ok(['Bronze', 'Silver', 'Gold', 'Platinum'].includes(rep.badge));
+  });
+
+  it('non conta due volte la stessa disputa', async () => {
+    const robot = seedRobot({ jobsCompleted: 10, disputes: 2 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'a', jobId: 'j1', rating: 2, disputed: true });
+    const rep = await reputation.getReputation(robot.robotId);
+    assert.strictEqual(rep.disputes, 2, 'max(2 dal brain, 1 dai feedback)');
+  });
+
+  it('gestisce un robot sconosciuto al gateway', async () => {
+    const rep = await reputation.getReputation('mai-esistito');
+    assert.strictEqual(rep.knownToGateway, false);
+    assert.strictEqual(rep.jobsCompleted, 0);
+    assert.strictEqual(rep.totalFeedback, 0);
+    assert.strictEqual(rep.averageRating, null);
+    assert.strictEqual(rep.badge, 'Bronze');
+  });
+
+  it('richiede un robotId', async () => {
+    await assert.rejects(() => reputation.getReputation(''), reputation.ValidationError);
+  });
+
+  it('i voti bassi abbassano il punteggio', async () => {
+    const good = seedRobot({ jobsCompleted: 10 });
+    const bad = seedRobot({ jobsCompleted: 10 });
+    await reputation.submitFeedback({ robotId: good.robotId, clientId: 'a', jobId: 'j1', rating: 5 });
+    await reputation.submitFeedback({ robotId: bad.robotId, clientId: 'a', jobId: 'j1', rating: 1 });
+
+    const goodRep = await reputation.getReputation(good.robotId);
+    const badRep = await reputation.getReputation(bad.robotId);
+    assert.ok(goodRep.score > badRep.score);
+  });
+});
+
+// -------------------------------------------------------------- leaderboard
+
+describe('getLeaderboard', () => {
+  beforeEach(() => reputation.clearMemoryFeedback());
+
+  it('ordina per punteggio decrescente', async () => {
+    const top = seedRobot({ jobsCompleted: 40 });
+    const low = seedRobot({ jobsCompleted: 1 });
+    await reputation.submitFeedback({ robotId: top.robotId, clientId: 'a', jobId: 'j1', rating: 5 });
+    await reputation.submitFeedback({ robotId: low.robotId, clientId: 'a', jobId: 'j1', rating: 1 });
+
+    const board = await reputation.getLeaderboard({ limit: 100 });
+    const topIndex = board.findIndex(r => r.robotId === top.robotId);
+    const lowIndex = board.findIndex(r => r.robotId === low.robotId);
+    assert.ok(topIndex >= 0 && lowIndex >= 0);
+    assert.ok(topIndex < lowIndex, 'il robot migliore viene prima');
+  });
+
+  it('rispetta il limite', async () => {
+    seedRobot(); seedRobot(); seedRobot();
+    assert.strictEqual((await reputation.getLeaderboard({ limit: 2 })).length, 2);
+  });
+
+  it('filtra per badge', async () => {
+    seedRobot({ jobsCompleted: 1 });
+    const board = await reputation.getLeaderboard({ limit: 100, badge: 'Bronze' });
+    assert.ok(board.every(r => r.badge === 'Bronze'));
+  });
+
+  it('include anche robot noti solo dai feedback', async () => {
+    await reputation.submitFeedback({ robotId: 'robot-esterno', clientId: 'a', jobId: 'j1', rating: 4 });
+    const board = await reputation.getLeaderboard({ limit: 100 });
+    assert.ok(board.some(r => r.robotId === 'robot-esterno'));
+  });
+});
+
+// ---------------------------------------------------------------------- API
+
+describe('API feedback e reputazione', () => {
+  beforeEach(() => reputation.clearMemoryFeedback());
+
+  it('POST /feedback risponde 201 con feedback e reputazione aggiornata', async () => {
+    const robot = seedRobot({ jobsCompleted: 5 });
+    const { statusCode, body } = await callRoute('post', '/feedback', {
+      body: { robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5, comment: 'Ottimo lavoro' }
+    });
+
+    assert.strictEqual(statusCode, 201);
+    assert.strictEqual(body.success, true);
+    assert.strictEqual(body.data.feedback.rating, 5);
+    assert.strictEqual(body.data.feedback.comment, 'Ottimo lavoro');
+    assert.strictEqual(body.data.reputation.totalFeedback, 1);
+    assert.ok(body.data.reputation.badge);
+  });
+
+  it('POST /feedback risponde 400 su payload non valido', async () => {
+    const { statusCode, body } = await callRoute('post', '/feedback', {
+      body: { robotId: 'r1', clientId: 'c1', jobId: 'j1', rating: 9 }
+    });
+    assert.strictEqual(statusCode, 400);
+    assert.strictEqual(body.success, false);
+    assert.match(body.error, /fra 1 e 5/);
+  });
+
+  it('POST /feedback risponde 409 sul duplicato', async () => {
+    const robot = seedRobot();
+    const body = { robotId: robot.robotId, clientId: 'alice', jobId: 'j1', rating: 5 };
+    await callRoute('post', '/feedback', { body });
+    const second = await callRoute('post', '/feedback', { body });
+    assert.strictEqual(second.statusCode, 409);
+    assert.match(second.body.error, /già presente/);
+  });
+
+  it('GET /feedback/:robotId restituisce lo storico paginato', async () => {
+    const robot = seedRobot();
+    for (let i = 0; i < 5; i++) {
+      await reputation.submitFeedback({ robotId: robot.robotId, clientId: `c${i}`, jobId: `j${i}`, rating: 4 });
+    }
+    const { statusCode, body } = await callRoute('get', '/feedback/:robotId', {
+      params: { robotId: robot.robotId }, query: { limit: '2', page: '2' }
+    });
+    assert.strictEqual(statusCode, 200);
+    assert.strictEqual(body.data.length, 2);
+    assert.strictEqual(body.pagination.total, 5);
+    assert.strictEqual(body.pagination.pages, 3);
+  });
+
+  it('GET /reputation/:robotId restituisce punteggio e componenti', async () => {
+    const robot = seedRobot({ jobsCompleted: 30 });
+    await reputation.submitFeedback({ robotId: robot.robotId, clientId: 'a', jobId: 'j1', rating: 5 });
+    const { statusCode, body } = await callRoute('get', '/reputation/:robotId', {
+      params: { robotId: robot.robotId }
+    });
+    assert.strictEqual(statusCode, 200);
+    assert.strictEqual(typeof body.data.score, 'number');
+    assert.ok(body.data.components.quality >= 0);
+    assert.ok('nextBadge' in body.data);
+  });
+
+  it('GET /reputation restituisce la classifica', async () => {
+    seedRobot({ jobsCompleted: 3 });
+    const { statusCode, body } = await callRoute('get', '/reputation', { query: { limit: '5' } });
+    assert.strictEqual(statusCode, 200);
+    assert.ok(Array.isArray(body.data));
+    assert.strictEqual(body.count, body.data.length);
+  });
+
+  it('GET /badges elenca le quattro soglie', async () => {
+    const { body } = await callRoute('get', '/badges');
+    assert.strictEqual(body.data.length, 4);
+    assert.deepStrictEqual(body.data.map(b => b.name), ['Platinum', 'Gold', 'Silver', 'Bronze']);
+  });
+});


### PR DESCRIPTION
Closes #343

## 📌 Cosa fa

Sistema di reputazione per i robot basato su feedback dei clienti, job completati e dispute, con badge **Bronze / Silver / Gold / Platinum**.

## ✅ Criteri di accettazione

- [x] **Endpoint `POST /api/robot/feedback`**
- [x] **Calcolo reputazione basato su: job completati, valutazioni, dispute** — tutte e tre le fonti, con pesi espliciti
- [x] **Dashboard per visualizzare reputazione robot** — `frontend/dashboard-reputation.html`
- [x] **Sistema di badge (Bronze, Silver, Gold, Platinum)**
- [x] **Storico feedback per robot** — `GET /api/robot/feedback/:robotId`, paginato

## 🚀 Verificato end-to-end su un gateway in esecuzione

Robot con 6 job completati e 2 feedback (5★ e 4★):

```jsonc
{
  "robotId": "rb1", "name": "Logo Bot", "status": "idle",
  "score": 70.5, "badge": "Silver",
  "components": { "quality": 87.5, "experience": 12, "reliability": 100 },
  "jobsCompleted": 6, "disputes": 0,
  "totalFeedback": 2, "averageRating": 4.5,
  "ratingDistribution": { "1": 0, "2": 0, "3": 0, "4": 1, "5": 1 },
  "nextBadge": { "name": "Gold", "scoreNeeded": 4.5, "jobsNeeded": 14 }
}
```

Aprendo una disputa sullo stesso robot, il punteggio reagisce come previsto:

```
dopo la disputa → score: 68 (era 70.5) | affidabilità: 83.33 (era 100) | dispute: 1
```

Casi d'errore verificati live: feedback duplicato → **409**, `rating: 9` → **400**.

## 🧮 Come si calcola il punteggio

Punteggio 0-100 da tre componenti pesate:

| Componente | Peso | Da cosa deriva |
|---|---|---|
| **Qualità** | 60% | media dei voti 1-5, riportata su 0-100 |
| **Esperienza** | 25% | job completati, con plateau a 50 job |
| **Affidabilità** | 15% | percentuale di job senza disputa |

| Badge | Punteggio min. | Job min. |
|---|---|---|
| 🥉 Bronze | 0 | 0 |
| 🥈 Silver | 60 | 5 |
| 🥇 Gold | 75 | 20 |
| 💎 Platinum | 90 | 50 |

## 🧩 Tre scelte di progetto

**1. Il punteggio è sempre derivato, mai scritto.** Non esiste un campo `reputation` che qualcuno possa impostare direttamente: viene ricalcolato dai feedback a ogni lettura. Questo rende il sistema verificabile e impossibile da falsare senza lasciare traccia nei feedback stessi.

**2. Un robot senza feedback parte da un valore neutro, non da zero.** Un robot appena creato non è *inaffidabile*, è semplicemente *sconosciuto*: farlo partire da 0 lo avrebbe penalizzato per il solo fatto di essere nuovo.

**3. I badge richiedono anche un numero minimo di job.** Senza questo vincolo un robot con un solo job valutato 5★ scavalcherebbe uno con cento job ottimi. Con 95 punti ma 3 job si resta Bronze; servono 20 job per il Gold.

Inoltre l'indice unico su `(robotId, jobId, clientId)` impedisce di gonfiare o affossare la reputazione con voti ripetuti sullo stesso lavoro — il secondo tentativo riceve **409**.

## 📡 API

| Endpoint | |
|---|---|
| `POST /api/robot/feedback` | lascia un feedback (rating 1-5, commento, flag `disputed`) |
| `GET /api/robot/feedback/:robotId` | storico paginato |
| `GET /api/robot/reputation/:robotId` | punteggio, badge, componenti, progresso |
| `GET /api/robot/reputation?badge=Gold` | classifica, filtrabile per badge |
| `GET /api/robot/badges` | soglie dei badge |

Tutti con annotazioni `@openapi` per swagger-jsdoc.

## 🖥 Dashboard

`frontend/dashboard-reputation.html`, stessa palette e struttura di `dashboard-rewards.html`:

- classifica con barra di punteggio e badge colorati
- ricerca per `robotId`/nome e filtro per badge
- clic su una riga → dettaglio con le tre componenti, il progresso verso il badge successivo e gli ultimi 10 feedback
- responsive (mobile-first), auto-refresh ogni 30 s
- i commenti sono HTML-escaped prima di essere inseriti nel DOM

## 🧪 Test

```
$ node --test tests/robotReputation.test.js
# tests 38
# pass 38
# fail 0
```

Coperti: mappatura dei voti, plateau dell'esperienza, effetto delle dispute (incluso il caso con più dispute che job), clamping 0-100, il fatto che la qualità pesi più dell'esperienza, tutte le soglie dei badge, `nextBadge` senza valori negativi, validazione completa del payload, duplicati, deduplica delle dispute fra `robot_brain` e feedback, robot sconosciuti, classifica e ordinamento, e tutti gli endpoint.

**Nessuna nuova dipendenza npm.** Il router è montato su `/api/robot` dopo `routes/robot.js`, che non ha catch-all: nessun impatto sulle route esistenti.

## 📄 File

| File | |
|---|---|
| `models/RobotFeedback.js` | nuovo — schema e indice unico |
| `services/reputationService.js` | nuovo — punteggio, badge, aggregazioni |
| `routes/robotFeedback.js` | nuovo — API + OpenAPI |
| `frontend/dashboard-reputation.html` | nuovo — dashboard |
| `server.js` | 1 riga per montare il router |
| `tests/robotReputation.test.js` | nuovo — 38 test |