### PR TITLE
feat: scaffolding per nuovi robot (Bounty BOT-7, closes #344)

### DIFF
--- a/docs/robots/README.md
+++ b/docs/robots/README.md
@@ -1,0 +1,109 @@
+# Scaffolding robot
+
+Bounty BOT-7 (#344). Genera un nuovo robot completo — modulo, API, test e documentazione — già cablato con escrow, notifiche e plugin. Nessuna dipendenza npm.
+
+## Uso
+
+```bash
+npm run robot:templates                                  # elenca i template
+npm run robot:create -- traduzione                       # template basic
+npm run robot:create -- traduzione --template translation
+npm run robot:create -- meteo --wire                     # monta anche la route in server.js
+npm run robot:create -- meteo --dry-run                  # mostra cosa farebbe
+```
+
+> Con npm serve il `--` prima del nome: separa gli argomenti dello script da quelli di npm. Chiamando direttamente lo script non serve: `node scripts/create-robot.js meteo`.
+
+### Opzioni
+
+| Opzione | |
+|---|---|
+| `-t, --template <nome>` | template da usare (default `basic`) |
+| `-l, --list` | elenca i template disponibili |
+| `-f, --force` | sovrascrive i file esistenti |
+| `--dry-run` | mostra cosa verrebbe generato, senza scrivere |
+| `--wire` | inserisce la route in `server.js` accanto agli altri robot |
+| `--no-test` | non genera il file di test |
+
+## Cosa genera
+
+Per `npm run robot:create -- traduzione --template translation`:
+
+```
+robot_traduzione.js              logica del robot
+routes/robotTraduzione.js        API Express con annotazioni @openapi
+tests/robotTraduzione.test.js    11 test, con escrow e notifiche mockati
+docs/robots/traduzione.md        documentazione con esempi curl
+```
+
+I nomi sono derivati da un unico slug, quindi restano coerenti fra file, route e simboli. `Robot Traduzione`, `robot-traduzione` e `robotTraduzione` producono tutti lo stesso risultato: il prefisso `robot` ridondante viene rimosso.
+
+Il robot generato è **subito funzionante**: crea job con escrow reale, li esegue, li consegna. L'unica cosa da riscrivere è `performTraduzione()`.
+
+## Template inclusi
+
+| Template | Input → Output | |
+|---|---|---|
+| `basic` | `input` → `output` | base generica, da cui ereditano gli altri |
+| `translation` | `text` → `translation` | robot di traduzione (50 MYZ) |
+| `logo` | `prompt` → `imageUrl` | generazione loghi (100 MYZ) |
+| `code` | `prompt` → `code` | generazione codice (150 MYZ) |
+
+## Aggiungere un template
+
+Un template è una cartella in `scripts/robot-templates/` con un `template.json`. Con `extends` eredita tutto da un altro template e dichiara **solo ciò che cambia**:
+
+```jsonc
+// scripts/robot-templates/meteo/template.json
+{
+  "name": "meteo",
+  "extends": "basic",
+  "description": "Robot meteo: riceve una città, restituisce le previsioni.",
+  "vars": {
+    "TASK_LABEL": "previsione",
+    "TASK_NOUN": "meteo",
+    "INPUT_FIELD": "city",
+    "INPUT_DESCRIPTION": "Città di cui vuoi le previsioni",
+    "OUTPUT_FIELD": "forecast",
+    "DEFAULT_AMOUNT": "30",
+    "SAMPLE_INPUT": "\"Roma\""
+  }
+}
+```
+
+Aggiungendo un `perform.snippet` nella stessa cartella si personalizza solo il corpo della funzione principale, senza duplicare il resto del modulo. Per cambiare di più, basta mettere nella cartella un `robot.js.tpl`, `route.js.tpl`, `test.js.tpl` o `doc.md.tpl`: i file assenti vengono presi dal template genitore.
+
+Se un segnaposto resta senza valore il generatore **fallisce**, invece di produrre un file con `{{VAR}}` dentro.
+
+## Plugin
+
+Ogni robot generato espone gli hook di `services/robotPlugins.js`:
+
+| Hook | Quando |
+|---|---|
+| `job:created` | dopo la creazione del job e il lock dell'escrow |
+| `job:executing` | prima di eseguire la logica |
+| `job:delivered` | dopo la consegna |
+| `job:failed` | se la logica lancia |
+
+```js
+const robot = require('./robot_traduzione');
+
+robot.use({
+  name: 'metrics',
+  hooks: {
+    'job:delivered': ({ jobId, job }) =>
+      console.log(`job ${jobId} in ${job.deliveredAt - job.createdAt}ms`)
+  }
+});
+```
+
+Un plugin che lancia viene loggato e ignorato: deve degradare l'osservabilità, non il lavoro del robot. Registrare un hook inesistente invece fallisce subito, perché sarebbe silenziosamente inerte.
+
+## Test
+
+```bash
+node --test tests/createRobot.test.js
+```
+
+I test generano davvero un robot, verificano che non restino segnaposto, che il JavaScript prodotto sia valido (`node --check`) e che **i test generati passino**.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "main": "buy_myz.js",
   "scripts": {
     "test": "node --test tests/*.test.js",
+    "robot:create": "node scripts/create-robot.js",
+    "robot:templates": "node scripts/create-robot.js --list",
     "test:escrow-robot": "node --test tests/escrowRobot.test.js",
     "test:escrow-robot:coverage": "node --test --experimental-test-coverage --test-coverage-include=escrow_robot.js --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 tests/escrowRobot.test.js",
     "devto-publish": "node scripts/publish-devto.js --publish",

--- a/scripts/create-robot.js
+++ b/scripts/create-robot.js
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * Scaffolding per nuovi robot - Bounty BOT-7 (#344)
+ *
+ * Genera modulo, route Express, test e documentazione per un nuovo robot,
+ * già cablati con escrow, notifiche e sistema di plugin.
+ *
+ *   npm run robot:create -- traduzione
+ *   npm run robot:create -- traduzione --template translation
+ *   npm run robot:create -- mio-robot --dry-run
+ *   npm run robot:create -- mio-robot --wire        # monta la route in server.js
+ *   npm run robot:create -- --list                  # elenca i template
+ *
+ * I template stanno in scripts/robot-templates/. Ognuno può ereditare da un
+ * altro con `"extends"`, così un nuovo template deve dichiarare solo ciò che
+ * cambia. Nessuna dipendenza npm.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const TEMPLATES_DIR = path.join(__dirname, 'robot-templates');
+const DEFAULT_TEMPLATE = 'basic';
+
+// ------------------------------------------------------------------- naming
+
+/** `Robot Traduzione!` → `traduzione` */
+function toSlug(input) {
+  return String(input)
+    .normalize('NFD').replace(/[̀-ͯ]/g, '') // accenti
+    .replace(/^robot[-_\s]+/i, '')                     // prefisso ridondante
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')            // camelCase → kebab
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+const toPascal = slug => slug.split('-').filter(Boolean)
+  .map(p => p[0].toUpperCase() + p.slice(1)).join('');
+
+const toCamel = slug => {
+  const pascal = toPascal(slug);
+  return pascal[0].toLowerCase() + pascal.slice(1);
+};
+
+const toSnake = slug => slug.replace(/-/g, '_');
+
+const toDisplay = slug => slug.split('-').filter(Boolean)
+  .map(p => p[0].toUpperCase() + p.slice(1)).join(' ');
+
+// ----------------------------------------------------------------- template
+
+function listTemplates() {
+  if (!fs.existsSync(TEMPLATES_DIR)) return [];
+  return fs.readdirSync(TEMPLATES_DIR, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => {
+      const meta = readTemplateMeta(e.name);
+      return { name: e.name, description: meta.description || '', extends: meta.extends || null };
+    });
+}
+
+function readTemplateMeta(name) {
+  const file = path.join(TEMPLATES_DIR, name, 'template.json');
+  if (!fs.existsSync(file)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    throw new Error(`template.json non valido in ${name}: ${err.message}`);
+  }
+}
+
+/**
+ * Risolve la catena di ereditarietà di un template, unendo le variabili
+ * (il figlio vince) e restituendo l'ordine di ricerca dei file.
+ */
+function resolveTemplate(name, seen = []) {
+  if (!fs.existsSync(path.join(TEMPLATES_DIR, name))) {
+    const available = listTemplates().map(t => t.name).join(', ');
+    throw new Error(`Template "${name}" non trovato. Disponibili: ${available}`);
+  }
+  if (seen.includes(name)) {
+    throw new Error(`Ciclo di ereditarietà fra i template: ${[...seen, name].join(' → ')}`);
+  }
+
+  const meta = readTemplateMeta(name);
+  const chain = [name];
+  let vars = { ...(meta.vars || {}) };
+
+  if (meta.extends) {
+    const parent = resolveTemplate(meta.extends, [...seen, name]);
+    chain.push(...parent.chain);
+    vars = { ...parent.vars, ...vars }; // il figlio sovrascrive il genitore
+  }
+
+  return { name, description: meta.description || '', chain, vars };
+}
+
+/** Cerca un file lungo la catena di ereditarietà. */
+function findTemplateFile(chain, filename) {
+  for (const template of chain) {
+    const candidate = path.join(TEMPLATES_DIR, template, filename);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Sostituisce {{VAR}}. Ripetuta finché restano segnaposto annidati. */
+function interpolate(content, vars) {
+  let out = content;
+  for (let pass = 0; pass < 3; pass++) {
+    const next = out.replace(/\{\{([A-Z0-9_]+)\}\}/g, (match, key) =>
+      Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match);
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+/** Segnaposto rimasti senza valore: sarebbero un bug silenzioso nel generato. */
+function missingPlaceholders(content) {
+  return [...new Set((content.match(/\{\{([A-Z0-9_]+)\}\}/g) || []))];
+}
+
+// ------------------------------------------------------------------ options
+
+function parseArgs(argv) {
+  const opts = { template: DEFAULT_TEMPLATE, force: false, dryRun: false, wire: false, tests: true };
+  const rest = [];
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--template': case '-t': opts.template = argv[++i]; break;
+      case '--force': case '-f': opts.force = true; break;
+      case '--dry-run': opts.dryRun = true; break;
+      case '--wire': opts.wire = true; break;
+      case '--no-test': opts.tests = false; break;
+      case '--list': case '-l': opts.list = true; break;
+      case '--help': case '-h': opts.help = true; break;
+      default:
+        if (arg.startsWith('-')) throw new Error(`Opzione sconosciuta: ${arg}`);
+        rest.push(arg);
+    }
+  }
+
+  opts.name = rest[0];
+  return opts;
+}
+
+function usage() {
+  return [
+    'Scaffolding per nuovi robot MyZubster',
+    '',
+    'Uso:  npm run robot:create -- <nome> [opzioni]',
+    '',
+    'Opzioni:',
+    '  -t, --template <nome>   template da usare (default: basic)',
+    '  -l, --list              elenca i template disponibili',
+    '  -f, --force             sovrascrive i file esistenti',
+    '      --dry-run           mostra cosa verrebbe generato, senza scrivere',
+    '      --wire              monta la route in server.js',
+    '      --no-test           non generare il file di test',
+    '  -h, --help              questo messaggio',
+    '',
+    'Esempi:',
+    '  npm run robot:create -- traduzione --template translation',
+    '  npm run robot:create -- mio-robot --dry-run',
+    '  node scripts/create-robot.js meteo --wire'
+  ].join('\n');
+}
+
+// --------------------------------------------------------------- generation
+
+function buildVars(slug, template, extra = {}) {
+  const pascal = toPascal(slug);
+  const snake = toSnake(slug);
+
+  return {
+    SLUG: slug,
+    PASCAL_NAME: pascal,
+    CAMEL_NAME: toCamel(slug),
+    SNAKE_NAME: snake,
+    DISPLAY_NAME: toDisplay(slug),
+    MODULE_NAME: `robot_${snake}`,
+    MODULE_FILE: `robot_${snake}.js`,
+    ROUTE_FILE: `routes/robot${pascal}.js`,
+    ROUTE_REQUIRE: `./routes/robot${pascal}`,
+    TEST_FILE: `tests/robot${pascal}.test.js`,
+    DOC_FILE: `docs/robots/${slug}.md`,
+    MOUNT_PATH: `/api/robot/${slug}`,
+    PERFORM_FN: `perform${pascal}`,
+    TEMPLATE: template.name,
+    TEMPLATE_DESCRIPTION: template.description,
+    DESCRIPTION: extra.description || template.description,
+    GENERATED_AT: extra.generatedAt,
+    ...template.vars
+  };
+}
+
+function plan(slug, template, vars, opts) {
+  const files = [
+    { key: 'robot.js.tpl', target: vars.MODULE_FILE },
+    { key: 'route.js.tpl', target: vars.ROUTE_FILE },
+    { key: 'doc.md.tpl', target: vars.DOC_FILE }
+  ];
+  if (opts.tests) files.splice(2, 0, { key: 'test.js.tpl', target: vars.TEST_FILE });
+
+  // Il corpo di perform() è un frammento a parte, così i template di esempio
+  // ridefiniscono solo la logica senza duplicare tutto il modulo.
+  const snippetPath = findTemplateFile(template.chain, 'perform.snippet');
+  const performBody = snippetPath
+    ? interpolate(fs.readFileSync(snippetPath, 'utf8').replace(/\n$/, ''), vars)
+    : '  return null;';
+  const allVars = { ...vars, PERFORM_BODY: performBody };
+
+  return files.map(({ key, target }) => {
+    const source = findTemplateFile(template.chain, key);
+    if (!source) throw new Error(`Template file mancante nella catena ${template.chain.join(' → ')}: ${key}`);
+    const content = interpolate(fs.readFileSync(source, 'utf8'), allVars);
+    const missing = missingPlaceholders(content);
+    if (missing.length) {
+      throw new Error(`Variabili non risolte in ${target}: ${missing.join(', ')}`);
+    }
+    return { target, absolute: path.join(ROOT, target), content };
+  });
+}
+
+/** Inserisce la route in server.js accanto agli altri robot. */
+function wireServer(vars, dryRun) {
+  const serverPath = path.join(ROOT, 'server.js');
+  const line = `app.use('${vars.MOUNT_PATH}', require('${vars.ROUTE_REQUIRE}'));`;
+  const source = fs.readFileSync(serverPath, 'utf8');
+
+  if (source.includes(line)) return { status: 'già presente', line };
+
+  // Si aggancia all'ultimo mount /api/robot/... esistente.
+  const mounts = [...source.matchAll(/^app\.use\('\/api\/robot\/[^']*',.*\);$/gm)];
+  if (!mounts.length) return { status: 'non riuscito', line };
+
+  const last = mounts[mounts.length - 1];
+  const insertAt = last.index + last[0].length;
+  const updated = `${source.slice(0, insertAt)}\n${line}${source.slice(insertAt)}`;
+
+  if (!dryRun) fs.writeFileSync(serverPath, updated);
+  return { status: dryRun ? 'da inserire' : 'inserita', line };
+}
+
+// ------------------------------------------------------------------- main
+
+function main(argv) {
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (err) {
+    console.error(`❌ ${err.message}\n`);
+    console.error(usage());
+    return 2;
+  }
+
+  if (opts.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  if (opts.list) {
+    console.log('Template disponibili:\n');
+    for (const t of listTemplates()) {
+      const inherits = t.extends ? ` (estende ${t.extends})` : '';
+      console.log(`  ${t.name.padEnd(14)}${t.description}${inherits}`);
+    }
+    return 0;
+  }
+
+  if (!opts.name) {
+    console.error('❌ Manca il nome del robot.\n');
+    console.error(usage());
+    return 2;
+  }
+
+  const slug = toSlug(opts.name);
+  if (!slug) {
+    console.error(`❌ "${opts.name}" non produce un nome valido. Usa lettere e numeri.`);
+    return 2;
+  }
+
+  let template;
+  let files;
+  const vars = {};
+  try {
+    template = resolveTemplate(opts.template);
+    Object.assign(vars, buildVars(slug, template, { generatedAt: new Date().toISOString().slice(0, 10) }));
+    files = plan(slug, template, vars, opts);
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    return 2;
+  }
+
+  const existing = files.filter(f => fs.existsSync(f.absolute));
+  if (existing.length && !opts.force) {
+    console.error('❌ Questi file esistono già:');
+    for (const f of existing) console.error(`   ${f.target}`);
+    console.error('\n   Usa --force per sovrascriverli.');
+    return 1;
+  }
+
+  console.log(`\n🤖 Robot "${vars.DISPLAY_NAME}"  ·  template ${template.name}${opts.dryRun ? '  ·  DRY RUN' : ''}\n`);
+
+  for (const file of files) {
+    if (!opts.dryRun) {
+      fs.mkdirSync(path.dirname(file.absolute), { recursive: true });
+      fs.writeFileSync(file.absolute, file.content);
+    }
+    const mark = existing.includes(file) ? 'sovrascritto' : 'creato';
+    console.log(`   ${opts.dryRun ? 'genererebbe' : mark.padEnd(12)}  ${file.target}`);
+  }
+
+  console.log('');
+
+  if (opts.wire) {
+    const result = wireServer(vars, opts.dryRun);
+    console.log(`   route in server.js: ${result.status}`);
+    if (result.status === 'non riuscito') {
+      console.log(`   Aggiungila a mano:\n     ${result.line}`);
+    }
+    console.log('');
+  } else {
+    console.log('   Per attivarlo, aggiungi in server.js:');
+    console.log(`     app.use('${vars.MOUNT_PATH}', require('${vars.ROUTE_REQUIRE}'));\n`);
+  }
+
+  if (opts.tests && !opts.dryRun) {
+    console.log(`   Test:  node --test ${vars.TEST_FILE}`);
+  }
+  console.log(`   Docs:  ${vars.DOC_FILE}\n`);
+  console.log(`   Implementa la logica in ${vars.PERFORM_FN}() dentro ${vars.MODULE_FILE}.\n`);
+
+  return 0;
+}
+
+if (require.main === module) {
+  process.exit(main(process.argv));
+}
+
+module.exports = { toSlug, toPascal, toCamel, toSnake, toDisplay, interpolate, missingPlaceholders, resolveTemplate, listTemplates, buildVars, parseArgs, main };

--- a/scripts/robot-templates/basic/doc.md.tpl
+++ b/scripts/robot-templates/basic/doc.md.tpl
@@ -1,0 +1,120 @@
+# Robot {{DISPLAY_NAME}}
+
+> Generato da `npm run robot:create -- {{SLUG}} --template {{TEMPLATE}}` il {{GENERATED_AT}}.
+> Template: **{{TEMPLATE}}** — {{TEMPLATE_DESCRIPTION}}
+
+{{DESCRIPTION}}
+
+## File
+
+| File | |
+|---|---|
+| `{{MODULE_FILE}}` | logica del robot |
+| `{{ROUTE_FILE}}` | API Express |
+| `{{TEST_FILE}}` | test |
+| `docs/robots/{{SLUG}}.md` | questo documento |
+
+## Attivazione
+
+Aggiungi la route in `server.js`, insieme agli altri robot:
+
+```js
+app.use('{{MOUNT_PATH}}', require('{{ROUTE_REQUIRE}}'));
+```
+
+## API
+
+### `POST {{MOUNT_PATH}}/create`
+
+Crea un job e blocca i fondi in escrow.
+
+```bash
+curl -X POST http://localhost:10000{{MOUNT_PATH}}/create \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jobId": "job-1",
+    "clientId": "alice",
+    "robotId": "robot-1",
+    "{{INPUT_FIELD}}": {{SAMPLE_INPUT}},
+    "amount": {{DEFAULT_AMOUNT}},
+    "currency": "MYZ"
+  }'
+```
+
+| Campo | Obbligatorio | |
+|---|---|---|
+| `jobId` | sì | identificativo univoco del job |
+| `clientId` | sì | committente |
+| `robotId` | sì | robot incaricato |
+| `{{INPUT_FIELD}}` | sì | {{INPUT_DESCRIPTION}} |
+| `amount` | no | default `{{DEFAULT_AMOUNT}}` |
+| `currency` | no | `MYZ` (default) o `XMR` |
+
+Risponde `201`. Con payload incompleto o `jobId` già usato risponde `400`.
+
+### `POST {{MOUNT_PATH}}/execute`
+
+Esegue il job, salva il risultato in `{{OUTPUT_FIELD}}` e porta l'escrow a `DELIVERED`.
+
+```bash
+curl -X POST http://localhost:10000{{MOUNT_PATH}}/execute \
+  -H 'Content-Type: application/json' -d '{"jobId":"job-1"}'
+```
+
+Un job già consegnato risponde `400`: l'esecuzione non è ripetibile.
+
+### `GET {{MOUNT_PATH}}/jobs`
+
+Elenco dei job, dal più recente.
+
+### `GET {{MOUNT_PATH}}/job/:jobId`
+
+Dettaglio di un job con lo stato aggiornato dell'escrow. `404` se non esiste.
+
+## Implementare la logica
+
+Tutto il cablaggio con escrow, notifiche e plugin è già fatto. L'unica funzione da riscrivere è `{{PERFORM_FN}}()` in `{{MODULE_FILE}}`:
+
+```js
+async function {{PERFORM_FN}}(job) {
+  // job.{{INPUT_FIELD}} contiene l'input
+  // il valore restituito finisce in job.{{OUTPUT_FIELD}}
+  return await ilTuoServizio(job.{{INPUT_FIELD}});
+}
+```
+
+Se lancia, il job passa a `failed`, viene emesso l'hook `job:failed` e il cliente riceve una notifica.
+
+## Plugin
+
+Il robot espone gli hook di `services/robotPlugins.js`:
+
+| Hook | Quando |
+|---|---|
+| `job:created` | dopo la creazione del job e il lock dell'escrow |
+| `job:executing` | prima di eseguire la logica |
+| `job:delivered` | dopo la consegna e il `markDelivered` |
+| `job:failed` | se la logica lancia |
+
+```js
+const robot = require('./{{MODULE_NAME}}');
+
+robot.use({
+  name: 'metrics',
+  hooks: {
+    'job:delivered': ({ jobId, job }) => {
+      console.log(`job ${jobId} consegnato in ${job.deliveredAt - job.createdAt}ms`);
+    }
+  }
+});
+```
+
+Un plugin che lancia viene loggato e ignorato: un plugin difettoso degrada l'osservabilità, non il lavoro del robot. Registrare un hook inesistente invece fallisce subito, perché sarebbe silenziosamente inerte.
+
+## Test
+
+```bash
+node --test {{TEST_FILE}}
+```
+
+I test sostituiscono `escrow_robot` e `notifications` con dei mock, quindi girano senza wallet né database.

--- a/scripts/robot-templates/basic/perform.snippet
+++ b/scripts/robot-templates/basic/perform.snippet
@@ -1,0 +1,3 @@
+  console.log(`🤖 [{{SLUG}}] eseguo {{TASK_LABEL}} per il job ${job.jobId}...`);
+  // TODO: sostituisci con la logica reale del robot.
+  return `{{DISPLAY_NAME}} completato per: ${job.{{INPUT_FIELD}}}`;

--- a/scripts/robot-templates/basic/robot.js.tpl
+++ b/scripts/robot-templates/basic/robot.js.tpl
@@ -1,0 +1,138 @@
+// {{MODULE_FILE}} – Robot {{DISPLAY_NAME}}
+// Generato da `npm run robot:create -- {{SLUG}} --template {{TEMPLATE}}` il {{GENERATED_AT}}.
+//
+// Ciclo di vita di un job:
+//   create{{PASCAL_NAME}}Job  → blocca i fondi in escrow, job in stato `pending`
+//   execute{{PASCAL_NAME}}Job → produce il risultato, job in stato `delivered`
+//                               e l'escrow passa a DELIVERED
+//
+// Personalizza {{PERFORM_FN}}(): è l'unica funzione che contiene la logica
+// specifica di questo robot. Tutto il resto è già cablato con escrow,
+// notifiche e plugin.
+
+const escrowRobot = require('./escrow_robot');
+const { notifyUser, notifyRobot } = require('./notifications');
+const { createPluginHost } = require('./services/robotPlugins');
+
+const DEFAULT_AMOUNT = {{DEFAULT_AMOUNT}};
+const DEFAULT_CURRENCY = 'MYZ';
+
+// Stato in memoria, come gli altri robot del gateway.
+const jobs = new Map();
+const plugins = createPluginHost('{{SLUG}}');
+
+// Contatore monotono: due job creati nello stesso millisecondo hanno lo stesso
+// createdAt, quindi ordinare solo per timestamp non è deterministico.
+let sequence = 0;
+
+/**
+ * Logica specifica del robot. Sostituisci il corpo con l'implementazione reale.
+ *
+ * @param {object} job il job corrente
+ * @returns {Promise<any>} il risultato, salvato in `job.{{OUTPUT_FIELD}}`
+ */
+async function {{PERFORM_FN}}(job) {
+{{PERFORM_BODY}}
+}
+
+/**
+ * Crea un job e blocca i fondi in escrow.
+ */
+async function create{{PASCAL_NAME}}Job({
+  jobId, clientId, robotId, {{INPUT_FIELD}},
+  amount = DEFAULT_AMOUNT, currency = DEFAULT_CURRENCY
+}) {
+  if (!jobId) throw new Error('jobId è obbligatorio');
+  if (!clientId) throw new Error('clientId è obbligatorio');
+  if (!robotId) throw new Error('robotId è obbligatorio');
+  if (!{{INPUT_FIELD}}) throw new Error('{{INPUT_FIELD}} è obbligatorio');
+  if (jobs.has(jobId)) throw new Error(`Job ${jobId} già esistente`);
+
+  const escrow = await escrowRobot.createEscrow({ jobId, clientId, robotId, amount, currency });
+
+  const job = {
+    jobId, clientId, robotId,
+    seq: ++sequence,
+    {{INPUT_FIELD}},
+    {{OUTPUT_FIELD}}: null,
+    status: 'pending',
+    amount, currency,
+    createdAt: Date.now(),
+    deliveredAt: null
+  };
+  jobs.set(jobId, job);
+
+  await plugins.emit('job:created', { jobId, job });
+  await notifyUser(clientId, `🤖 Job {{TASK_NOUN}} ${jobId} creato. ${amount} ${currency} bloccati.`);
+
+  return { ...job, escrow };
+}
+
+/**
+ * Esegue il job e lo consegna, rilasciando l'escrow.
+ */
+async function execute{{PASCAL_NAME}}Job(jobId) {
+  const job = jobs.get(jobId);
+  if (!job) throw new Error(`Job ${jobId} non trovato`);
+  if (job.status !== 'pending') throw new Error(`Job ${jobId} è già in stato ${job.status}`);
+
+  await plugins.emit('job:executing', { jobId, job });
+
+  try {
+    job.{{OUTPUT_FIELD}} = await {{PERFORM_FN}}(job);
+  } catch (err) {
+    job.status = 'failed';
+    job.error = err.message;
+    await plugins.emit('job:failed', { jobId, job, error: err });
+    await notifyUser(job.clientId, `❌ Job {{TASK_NOUN}} ${jobId} fallito: ${err.message}`);
+    throw err;
+  }
+
+  job.status = 'delivered';
+  job.deliveredAt = Date.now();
+
+  await escrowRobot.markDelivered({ jobId });
+  await plugins.emit('job:delivered', { jobId, job });
+  await notifyUser(job.clientId, `✅ Job {{TASK_NOUN}} ${jobId} consegnato.`);
+  await notifyRobot(job.robotId, `✅ Job {{TASK_NOUN}} ${jobId} completato.`);
+
+  return { jobId, {{OUTPUT_FIELD}}: job.{{OUTPUT_FIELD}}, status: job.status };
+}
+
+/** Job singolo, con lo stato aggiornato dell'escrow. */
+function get{{PASCAL_NAME}}Job(jobId) {
+  const job = jobs.get(jobId);
+  if (!job) return null;
+  return { ...job, escrow: escrowRobot.getEscrow(jobId) };
+}
+
+/** Tutti i job, dal più recente. */
+function list{{PASCAL_NAME}}Jobs() {
+  return Array.from(jobs.values())
+    .sort((a, b) => b.seq - a.seq)
+    .map(({ jobId, status, clientId, robotId, amount, currency, createdAt, deliveredAt }) =>
+      ({ jobId, status, clientId, robotId, amount, currency, createdAt, deliveredAt }));
+}
+
+/** Registra un plugin. Vedi services/robotPlugins.js per gli hook disponibili. */
+function use(plugin) {
+  return plugins.use(plugin);
+}
+
+/** Svuota lo stato in memoria. Usato dai test. */
+function reset() {
+  jobs.clear();
+  plugins.clear();
+  sequence = 0;
+}
+
+module.exports = {
+  create{{PASCAL_NAME}}Job,
+  execute{{PASCAL_NAME}}Job,
+  get{{PASCAL_NAME}}Job,
+  list{{PASCAL_NAME}}Jobs,
+  {{PERFORM_FN}},
+  use,
+  reset,
+  plugins
+};

--- a/scripts/robot-templates/basic/route.js.tpl
+++ b/scripts/robot-templates/basic/route.js.tpl
@@ -1,0 +1,104 @@
+// {{ROUTE_FILE}} – API del robot {{DISPLAY_NAME}}
+// Generato da `npm run robot:create -- {{SLUG}} --template {{TEMPLATE}}` il {{GENERATED_AT}}.
+//
+// Monta in server.js con:
+//   app.use('{{MOUNT_PATH}}', require('{{ROUTE_REQUIRE}}'));
+
+const express = require('express');
+const router = express.Router();
+const robot = require('../{{MODULE_NAME}}');
+
+/**
+ * @openapi
+ * {{MOUNT_PATH}}/create:
+ *   post:
+ *     tags: [Robot {{DISPLAY_NAME}}]
+ *     summary: Crea un job {{TASK_NOUN}} e blocca i fondi in escrow
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [jobId, clientId, robotId, {{INPUT_FIELD}}]
+ *             properties:
+ *               jobId: { type: string }
+ *               clientId: { type: string }
+ *               robotId: { type: string }
+ *               {{INPUT_FIELD}}: { type: string, description: "{{INPUT_DESCRIPTION}}" }
+ *               amount: { type: number, default: {{DEFAULT_AMOUNT}} }
+ *               currency: { type: string, enum: [MYZ, XMR], default: MYZ }
+ *     responses:
+ *       201: { description: Job creato }
+ *       400: { description: Payload non valido o job già esistente }
+ */
+router.post('/create', async (req, res) => {
+  try {
+    const data = await robot.create{{PASCAL_NAME}}Job(req.body || {});
+    res.status(201).json({ success: true, data });
+  } catch (err) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+});
+
+/**
+ * @openapi
+ * {{MOUNT_PATH}}/execute:
+ *   post:
+ *     tags: [Robot {{DISPLAY_NAME}}]
+ *     summary: Esegue e consegna un job {{TASK_NOUN}}
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [jobId]
+ *             properties:
+ *               jobId: { type: string }
+ *     responses:
+ *       200: { description: Job consegnato }
+ *       400: { description: Job non trovato o già consegnato }
+ */
+router.post('/execute', async (req, res) => {
+  try {
+    const { jobId } = req.body || {};
+    if (!jobId) return res.status(400).json({ success: false, error: 'jobId è obbligatorio' });
+    res.json({ success: true, data: await robot.execute{{PASCAL_NAME}}Job(jobId) });
+  } catch (err) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+});
+
+/**
+ * @openapi
+ * {{MOUNT_PATH}}/jobs:
+ *   get:
+ *     tags: [Robot {{DISPLAY_NAME}}]
+ *     summary: Elenco dei job, dal più recente
+ *     responses:
+ *       200: { description: Elenco job }
+ */
+router.get('/jobs', (req, res) => {
+  res.json({ success: true, data: robot.list{{PASCAL_NAME}}Jobs() });
+});
+
+/**
+ * @openapi
+ * {{MOUNT_PATH}}/job/{jobId}:
+ *   get:
+ *     tags: [Robot {{DISPLAY_NAME}}]
+ *     summary: Dettaglio di un job con lo stato dell'escrow
+ *     parameters:
+ *       - { in: path, name: jobId, required: true, schema: { type: string } }
+ *     responses:
+ *       200: { description: Dettaglio job }
+ *       404: { description: Job non trovato }
+ */
+router.get('/job/:jobId', (req, res) => {
+  const job = robot.get{{PASCAL_NAME}}Job(req.params.jobId);
+  if (!job) return res.status(404).json({ success: false, error: 'Job non trovato' });
+  res.json({ success: true, data: job });
+});
+
+module.exports = router;

--- a/scripts/robot-templates/basic/template.json
+++ b/scripts/robot-templates/basic/template.json
@@ -1,0 +1,13 @@
+{
+  "name": "basic",
+  "description": "Robot generico: crea job, esegue, consegna. Base per tutti gli altri template.",
+  "vars": {
+    "TASK_LABEL": "task",
+    "TASK_NOUN": "task",
+    "INPUT_FIELD": "input",
+    "INPUT_DESCRIPTION": "Dati di ingresso del job",
+    "OUTPUT_FIELD": "output",
+    "DEFAULT_AMOUNT": "100",
+    "SAMPLE_INPUT": "\"dati di esempio\""
+  }
+}

--- a/scripts/robot-templates/basic/test.js.tpl
+++ b/scripts/robot-templates/basic/test.js.tpl
@@ -1,0 +1,145 @@
+// {{TEST_FILE}} – Test del robot {{DISPLAY_NAME}}
+// Generato da `npm run robot:create -- {{SLUG}} --template {{TEMPLATE}}` il {{GENERATED_AT}}.
+//
+// escrow_robot e notifications sono sostituiti da mock iniettati nella require
+// cache prima del require del robot: i test girano senza wallet né database.
+
+const { describe, it, beforeEach, mock } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+function stubModule(request, exports) {
+  const filename = require.resolve(request);
+  require.cache[filename] = {
+    id: filename, filename, path: path.dirname(filename),
+    loaded: true, exports, children: [], paths: []
+  };
+}
+
+const escrows = new Map();
+stubModule('../escrow_robot', {
+  createEscrow: async ({ jobId, clientId, robotId, amount, currency }) => {
+    const escrow = { jobId, clientId, robotId, amount, currency, status: 'LOCKED' };
+    escrows.set(jobId, escrow);
+    return escrow;
+  },
+  markDelivered: async ({ jobId }) => {
+    const escrow = escrows.get(jobId);
+    if (!escrow) throw new Error('Escrow non trovato');
+    escrow.status = 'DELIVERED';
+    return escrow;
+  },
+  getEscrow: jobId => escrows.get(jobId) || null,
+  openDispute: async () => {},
+  autoRelease: async () => {}
+});
+
+stubModule('../notifications', {
+  notifyUser: async () => {},
+  notifyRobot: async () => {}
+});
+
+const robot = require('../{{MODULE_NAME}}');
+
+function baseJob(overrides = {}) {
+  return {
+    jobId: 'job-1', clientId: 'alice', robotId: 'robot-1',
+    {{INPUT_FIELD}}: {{SAMPLE_INPUT}},
+    ...overrides
+  };
+}
+
+describe('{{DISPLAY_NAME}} robot', () => {
+  beforeEach(() => {
+    robot.reset();
+    escrows.clear();
+  });
+
+  describe('create{{PASCAL_NAME}}Job', () => {
+    it('crea un job in stato pending e blocca l escrow', async () => {
+      const job = await robot.create{{PASCAL_NAME}}Job(baseJob());
+      assert.strictEqual(job.status, 'pending');
+      assert.strictEqual(job.escrow.status, 'LOCKED');
+      assert.strictEqual(job.amount, {{DEFAULT_AMOUNT}});
+      assert.strictEqual(job.currency, 'MYZ');
+    });
+
+    it('richiede i campi obbligatori', async () => {
+      for (const field of ['jobId', 'clientId', 'robotId', '{{INPUT_FIELD}}']) {
+        const payload = baseJob();
+        delete payload[field];
+        await assert.rejects(() => robot.create{{PASCAL_NAME}}Job(payload), new RegExp(field));
+      }
+    });
+
+    it('rifiuta un jobId duplicato', async () => {
+      await robot.create{{PASCAL_NAME}}Job(baseJob());
+      await assert.rejects(() => robot.create{{PASCAL_NAME}}Job(baseJob()), /già esistente/);
+    });
+  });
+
+  describe('execute{{PASCAL_NAME}}Job', () => {
+    it('produce un risultato e consegna l escrow', async () => {
+      await robot.create{{PASCAL_NAME}}Job(baseJob());
+      const result = await robot.execute{{PASCAL_NAME}}Job('job-1');
+
+      assert.strictEqual(result.status, 'delivered');
+      assert.ok(result.{{OUTPUT_FIELD}}, 'il risultato è valorizzato');
+      assert.strictEqual(escrows.get('job-1').status, 'DELIVERED');
+    });
+
+    it('lancia su job inesistente', async () => {
+      await assert.rejects(() => robot.execute{{PASCAL_NAME}}Job('mai-creato'), /non trovato/);
+    });
+
+    it('non esegue due volte lo stesso job', async () => {
+      await robot.create{{PASCAL_NAME}}Job(baseJob());
+      await robot.execute{{PASCAL_NAME}}Job('job-1');
+      await assert.rejects(() => robot.execute{{PASCAL_NAME}}Job('job-1'), /già in stato delivered/);
+    });
+  });
+
+  describe('lettura', () => {
+    it('get restituisce il job con l escrow, null se sconosciuto', async () => {
+      await robot.create{{PASCAL_NAME}}Job(baseJob());
+      assert.strictEqual(robot.get{{PASCAL_NAME}}Job('job-1').escrow.status, 'LOCKED');
+      assert.strictEqual(robot.get{{PASCAL_NAME}}Job('sconosciuto'), null);
+    });
+
+    it('list restituisce i job dal più recente', async () => {
+      await robot.create{{PASCAL_NAME}}Job(baseJob({ jobId: 'job-1' }));
+      await robot.create{{PASCAL_NAME}}Job(baseJob({ jobId: 'job-2' }));
+      const list = robot.list{{PASCAL_NAME}}Jobs();
+      assert.strictEqual(list.length, 2);
+      assert.strictEqual(list[0].jobId, 'job-2');
+    });
+  });
+
+  describe('plugin', () => {
+    it('esegue gli hook registrati', async () => {
+      const seen = [];
+      robot.use({
+        name: 'spy',
+        hooks: {
+          'job:created': ({ jobId }) => seen.push(`created:${jobId}`),
+          'job:delivered': ({ jobId }) => seen.push(`delivered:${jobId}`)
+        }
+      });
+
+      await robot.create{{PASCAL_NAME}}Job(baseJob());
+      await robot.execute{{PASCAL_NAME}}Job('job-1');
+
+      assert.deepStrictEqual(seen, ['created:job-1', 'delivered:job-1']);
+    });
+
+    it('un plugin che lancia non rompe il robot', async () => {
+      robot.use({ name: 'rotto', hooks: { 'job:created': () => { throw new Error('boom'); } } });
+      const job = await robot.create{{PASCAL_NAME}}Job(baseJob());
+      assert.strictEqual(job.status, 'pending');
+    });
+
+    it('rifiuta hook sconosciuti', () => {
+      assert.throws(() => robot.use({ name: 'x', hooks: { 'job:inesistente': () => {} } }), /sconosciuti/);
+    });
+  });
+});

--- a/scripts/robot-templates/code/perform.snippet
+++ b/scripts/robot-templates/code/perform.snippet
@@ -1,0 +1,16 @@
+  // Stub: genera uno scheletro di funzione. Sostituiscilo con la chiamata al
+  // modello (OpenAI, Claude, un modello locale...).
+  const language = job.language || 'javascript';
+  console.log(`💻 [{{SLUG}}] genero codice ${language} per il job ${job.jobId}...`);
+
+  if (typeof job.prompt !== 'string' || !job.prompt.trim()) {
+    throw new Error('prompt deve essere una stringa non vuota');
+  }
+
+  return [
+    `// ${job.prompt}`,
+    `// Generato dal robot {{SLUG}} (${language})`,
+    'module.exports = function () {',
+    '  throw new Error("Non implementato");',
+    '};'
+  ].join('\n');

--- a/scripts/robot-templates/code/template.json
+++ b/scripts/robot-templates/code/template.json
@@ -1,0 +1,14 @@
+{
+  "name": "code",
+  "extends": "basic",
+  "description": "Robot di generazione codice: riceve un prompt e restituisce il sorgente prodotto.",
+  "vars": {
+    "TASK_LABEL": "generazione codice",
+    "TASK_NOUN": "codice",
+    "INPUT_FIELD": "prompt",
+    "INPUT_DESCRIPTION": "Descrizione di cosa deve fare il codice",
+    "OUTPUT_FIELD": "code",
+    "DEFAULT_AMOUNT": "150",
+    "SAMPLE_INPUT": "\"Una funzione JavaScript che valida un indirizzo email\""
+  }
+}

--- a/scripts/robot-templates/logo/perform.snippet
+++ b/scripts/robot-templates/logo/perform.snippet
@@ -1,0 +1,11 @@
+  // Stub: restituisce un placeholder. Sostituiscilo con la chiamata reale al
+  // generatore di immagini (DALL·E, Stable Diffusion, ...).
+  const style = job.style || 'modern';
+  console.log(`🎨 [{{SLUG}}] genero un logo "${style}" per il job ${job.jobId}...`);
+
+  if (typeof job.prompt !== 'string' || !job.prompt.trim()) {
+    throw new Error('prompt deve essere una stringa non vuota');
+  }
+
+  const slug = encodeURIComponent(job.prompt.slice(0, 40));
+  return `https://via.placeholder.com/1024x1024/4A90D9/FFFFFF?text=${slug}`;

--- a/scripts/robot-templates/logo/template.json
+++ b/scripts/robot-templates/logo/template.json
@@ -1,0 +1,14 @@
+{
+  "name": "logo",
+  "extends": "basic",
+  "description": "Robot di generazione loghi: riceve un prompt e restituisce l'URL dell'immagine.",
+  "vars": {
+    "TASK_LABEL": "generazione logo",
+    "TASK_NOUN": "logo",
+    "INPUT_FIELD": "prompt",
+    "INPUT_DESCRIPTION": "Descrizione del logo da generare",
+    "OUTPUT_FIELD": "imageUrl",
+    "DEFAULT_AMOUNT": "100",
+    "SAMPLE_INPUT": "\"Logo minimale per una startup di robotica\""
+  }
+}

--- a/scripts/robot-templates/translation/perform.snippet
+++ b/scripts/robot-templates/translation/perform.snippet
@@ -1,0 +1,10 @@
+  // Stub deterministico: sostituiscilo con una vera API di traduzione
+  // (DeepL, LibreTranslate, un modello locale...).
+  const targetLang = job.targetLang || 'en';
+  console.log(`🌍 [{{SLUG}}] traduco verso ${targetLang} il job ${job.jobId}...`);
+
+  if (typeof job.text !== 'string' || !job.text.trim()) {
+    throw new Error('text deve essere una stringa non vuota');
+  }
+
+  return `[${targetLang}] ${job.text}`;

--- a/scripts/robot-templates/translation/template.json
+++ b/scripts/robot-templates/translation/template.json
@@ -1,0 +1,14 @@
+{
+  "name": "translation",
+  "extends": "basic",
+  "description": "Robot di traduzione: riceve un testo e una lingua di destinazione, restituisce la traduzione.",
+  "vars": {
+    "TASK_LABEL": "traduzione",
+    "TASK_NOUN": "traduzione",
+    "INPUT_FIELD": "text",
+    "INPUT_DESCRIPTION": "Testo da tradurre",
+    "OUTPUT_FIELD": "translation",
+    "DEFAULT_AMOUNT": "50",
+    "SAMPLE_INPUT": "\"Buongiorno a tutti\""
+  }
+}

--- a/services/robotPlugins.js
+++ b/services/robotPlugins.js
@@ -1,0 +1,75 @@
+/**
+ * Plugin host per i robot - Bounty BOT-7 (#344)
+ *
+ * Ogni robot generato dallo scaffolding espone un piccolo sistema di hook, così
+ * si possono aggiungere comportamenti (logging, metriche, notifiche extra,
+ * validazioni) senza modificare il codice del robot.
+ *
+ *   const robot = require('./robot_translation');
+ *   robot.use({
+ *     name: 'metrics',
+ *     hooks: {
+ *       'job:delivered': ({ jobId }) => console.log('consegnato', jobId)
+ *     }
+ *   });
+ *
+ * Gli hook non possono rompere il robot: un plugin che lancia viene loggato e
+ * ignorato. Un plugin difettoso deve degradare l'osservabilità, non il lavoro.
+ */
+
+const HOOKS = ['job:created', 'job:executing', 'job:delivered', 'job:failed'];
+
+function createPluginHost(robotName) {
+  const plugins = [];
+
+  /**
+   * @param {{name: string, hooks: Object<string, Function>}} plugin
+   */
+  function use(plugin) {
+    if (!plugin || typeof plugin !== 'object') {
+      throw new Error('Un plugin deve essere un oggetto { name, hooks }');
+    }
+    if (!plugin.name) throw new Error('Un plugin deve avere un name');
+    if (!plugin.hooks || typeof plugin.hooks !== 'object') {
+      throw new Error(`Il plugin ${plugin.name} deve esporre un oggetto hooks`);
+    }
+
+    const unknown = Object.keys(plugin.hooks).filter(h => !HOOKS.includes(h));
+    if (unknown.length) {
+      // Un hook scritto male sarebbe silenziosamente inerte: meglio fallire subito.
+      throw new Error(
+        `Il plugin ${plugin.name} registra hook sconosciuti: ${unknown.join(', ')}. ` +
+        `Disponibili: ${HOOKS.join(', ')}`
+      );
+    }
+
+    plugins.push(plugin);
+    return host;
+  }
+
+  /** Esegue in sequenza gli hook registrati. Non lancia mai. */
+  async function emit(hook, context = {}) {
+    for (const plugin of plugins) {
+      const fn = plugin.hooks[hook];
+      if (typeof fn !== 'function') continue;
+      try {
+        await fn({ robot: robotName, hook, ...context });
+      } catch (err) {
+        console.error(`[${robotName}] plugin "${plugin.name}" ha fallito su ${hook}: ${err.message}`);
+      }
+    }
+  }
+
+  function list() {
+    return plugins.map(p => ({ name: p.name, hooks: Object.keys(p.hooks) }));
+  }
+
+  function clear() {
+    plugins.length = 0;
+  }
+
+  const host = { use, emit, list, clear, HOOKS };
+  return host;
+}
+
+module.exports = { createPluginHost, HOOKS };

--- a/tests/createRobot.test.js
+++ b/tests/createRobot.test.js
@@ -1,0 +1,318 @@
+/**
+ * Test dello scaffolding robot - Bounty BOT-7 (#344)
+ *
+ * Verifica naming, ereditarietà dei template e interpolazione, e genera
+ * davvero un robot in una directory temporanea per controllare che il codice
+ * prodotto sia sintatticamente valido e funzionante.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const gen = require('../scripts/create-robot');
+const { createPluginHost, HOOKS } = require('../services/robotPlugins');
+
+const ROOT = path.join(__dirname, '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'create-robot.js');
+
+/** Esegue il generatore raccogliendo stdout ed exit code. */
+function run(args, { expectFailure = false } = {}) {
+  try {
+    return { code: 0, out: execFileSync('node', [SCRIPT, ...args], { cwd: ROOT, encoding: 'utf8' }) };
+  } catch (err) {
+    if (!expectFailure) throw err;
+    return { code: err.status, out: `${err.stdout || ''}${err.stderr || ''}` };
+  }
+}
+
+// ------------------------------------------------------------------- naming
+
+describe('naming', () => {
+  it('normalizza in slug kebab-case', () => {
+    assert.strictEqual(gen.toSlug('traduzione'), 'traduzione');
+    assert.strictEqual(gen.toSlug('Mio Robot'), 'mio-robot');
+    assert.strictEqual(gen.toSlug('mioRobot'), 'mio-robot');
+    assert.strictEqual(gen.toSlug('  spazi   multipli '), 'spazi-multipli');
+    assert.strictEqual(gen.toSlug('robot!!!strano???'), 'robot-strano');
+  });
+
+  it('toglie il prefisso "robot" ridondante', () => {
+    assert.strictEqual(gen.toSlug('robot-traduzione'), 'traduzione');
+    assert.strictEqual(gen.toSlug('robot_meteo'), 'meteo');
+    assert.strictEqual(gen.toSlug('Robot Meteo'), 'meteo');
+  });
+
+  it('restituisce stringa vuota per nomi non utilizzabili', () => {
+    assert.strictEqual(gen.toSlug('!!!'), '');
+    assert.strictEqual(gen.toSlug('---'), '');
+  });
+
+  it('deriva le altre forme dallo slug', () => {
+    assert.strictEqual(gen.toPascal('mio-robot'), 'MioRobot');
+    assert.strictEqual(gen.toCamel('mio-robot'), 'mioRobot');
+    assert.strictEqual(gen.toSnake('mio-robot'), 'mio_robot');
+    assert.strictEqual(gen.toDisplay('mio-robot'), 'Mio Robot');
+  });
+
+  it('costruisce percorsi coerenti', () => {
+    const template = gen.resolveTemplate('basic');
+    const vars = gen.buildVars('mio-robot', template, { generatedAt: '2025-01-01' });
+    assert.strictEqual(vars.MODULE_FILE, 'robot_mio_robot.js');
+    assert.strictEqual(vars.ROUTE_FILE, 'routes/robotMioRobot.js');
+    assert.strictEqual(vars.TEST_FILE, 'tests/robotMioRobot.test.js');
+    assert.strictEqual(vars.DOC_FILE, 'docs/robots/mio-robot.md');
+    assert.strictEqual(vars.MOUNT_PATH, '/api/robot/mio-robot');
+    assert.strictEqual(vars.PERFORM_FN, 'performMioRobot');
+    assert.strictEqual(vars.ROUTE_REQUIRE, './routes/robotMioRobot');
+  });
+});
+
+// ------------------------------------------------------------------ template
+
+describe('template', () => {
+  it('elenca i quattro template inclusi', () => {
+    const names = gen.listTemplates().map(t => t.name).sort();
+    assert.deepStrictEqual(names, ['basic', 'code', 'logo', 'translation']);
+  });
+
+  it('risolve la catena di ereditarietà', () => {
+    const resolved = gen.resolveTemplate('translation');
+    assert.deepStrictEqual(resolved.chain, ['translation', 'basic']);
+  });
+
+  it('le variabili del figlio vincono su quelle del genitore', () => {
+    assert.strictEqual(gen.resolveTemplate('basic').vars.INPUT_FIELD, 'input');
+    assert.strictEqual(gen.resolveTemplate('translation').vars.INPUT_FIELD, 'text');
+    assert.strictEqual(gen.resolveTemplate('logo').vars.OUTPUT_FIELD, 'imageUrl');
+    assert.strictEqual(gen.resolveTemplate('code').vars.DEFAULT_AMOUNT, '150');
+  });
+
+  it('il figlio eredita le variabili che non ridefinisce', () => {
+    // translation non dichiara TASK_LABEL... lo dichiara; usiamo una chiave
+    // presente solo in basic per verificare l'ereditarietà.
+    const basic = gen.resolveTemplate('basic').vars;
+    const translation = gen.resolveTemplate('translation').vars;
+    for (const key of Object.keys(basic)) {
+      assert.ok(key in translation, `${key} deve essere ereditata`);
+    }
+  });
+
+  it('rifiuta un template inesistente', () => {
+    assert.throws(() => gen.resolveTemplate('inesistente'), /non trovato/);
+  });
+});
+
+// -------------------------------------------------------------- interpolate
+
+describe('interpolate', () => {
+  it('sostituisce i segnaposto', () => {
+    assert.strictEqual(gen.interpolate('ciao {{NAME}}', { NAME: 'mondo' }), 'ciao mondo');
+    assert.strictEqual(gen.interpolate('{{A}}-{{B}}', { A: '1', B: '2' }), '1-2');
+  });
+
+  it('lascia intatti i segnaposto senza valore', () => {
+    assert.strictEqual(gen.interpolate('ciao {{IGNOTO}}', {}), 'ciao {{IGNOTO}}');
+  });
+
+  it('risolve i segnaposto annidati', () => {
+    assert.strictEqual(gen.interpolate('{{A}}', { A: '{{B}}', B: 'finale' }), 'finale');
+  });
+
+  it('missingPlaceholders segnala ciò che resta', () => {
+    assert.deepStrictEqual(gen.missingPlaceholders('ok {{X}} {{Y}} {{X}}'), ['{{X}}', '{{Y}}']);
+    assert.deepStrictEqual(gen.missingPlaceholders('tutto risolto'), []);
+  });
+});
+
+// ---------------------------------------------------------------- plugin host
+
+describe('plugin host', () => {
+  it('esegue gli hook in ordine di registrazione', async () => {
+    const host = createPluginHost('test');
+    const seen = [];
+    host.use({ name: 'uno', hooks: { 'job:created': () => seen.push('uno') } });
+    host.use({ name: 'due', hooks: { 'job:created': () => seen.push('due') } });
+    await host.emit('job:created', {});
+    assert.deepStrictEqual(seen, ['uno', 'due']);
+  });
+
+  it('passa il contesto agli hook', async () => {
+    const host = createPluginHost('test');
+    let received = null;
+    host.use({ name: 'spy', hooks: { 'job:delivered': ctx => { received = ctx; } } });
+    await host.emit('job:delivered', { jobId: 'j1' });
+    assert.strictEqual(received.jobId, 'j1');
+    assert.strictEqual(received.robot, 'test');
+    assert.strictEqual(received.hook, 'job:delivered');
+  });
+
+  it('isola un plugin che lancia', async () => {
+    const host = createPluginHost('test');
+    const seen = [];
+    host.use({ name: 'rotto', hooks: { 'job:created': () => { throw new Error('boom'); } } });
+    host.use({ name: 'sano', hooks: { 'job:created': () => seen.push('sano') } });
+    await assert.doesNotReject(() => host.emit('job:created', {}));
+    assert.deepStrictEqual(seen, ['sano'], 'gli altri plugin girano comunque');
+  });
+
+  it('supporta hook asincroni', async () => {
+    const host = createPluginHost('test');
+    const seen = [];
+    host.use({ name: 'async', hooks: { 'job:created': async () => { await Promise.resolve(); seen.push('ok'); } } });
+    await host.emit('job:created', {});
+    assert.deepStrictEqual(seen, ['ok']);
+  });
+
+  it('rifiuta plugin malformati e hook sconosciuti', () => {
+    const host = createPluginHost('test');
+    assert.throws(() => host.use(null), /oggetto/);
+    assert.throws(() => host.use({ hooks: {} }), /name/);
+    assert.throws(() => host.use({ name: 'x' }), /hooks/);
+    assert.throws(() => host.use({ name: 'x', hooks: { 'job:boh': () => {} } }), /sconosciuti/);
+  });
+
+  it('list e clear', () => {
+    const host = createPluginHost('test');
+    host.use({ name: 'a', hooks: { 'job:created': () => {} } });
+    assert.deepStrictEqual(host.list(), [{ name: 'a', hooks: ['job:created'] }]);
+    host.clear();
+    assert.deepStrictEqual(host.list(), []);
+  });
+
+  it('espone gli hook disponibili', () => {
+    assert.deepStrictEqual(HOOKS, ['job:created', 'job:executing', 'job:delivered', 'job:failed']);
+  });
+});
+
+// ---------------------------------------------------------------------- CLI
+
+describe('CLI', () => {
+  it('--list mostra i template', () => {
+    const { out } = run(['--list']);
+    for (const name of ['basic', 'translation', 'logo', 'code']) {
+      assert.match(out, new RegExp(name));
+    }
+  });
+
+  it('--help mostra le istruzioni', () => {
+    assert.match(run(['--help']).out, /robot:create/);
+  });
+
+  it('senza nome esce con errore', () => {
+    const { code, out } = run([], { expectFailure: true });
+    assert.strictEqual(code, 2);
+    assert.match(out, /Manca il nome/);
+  });
+
+  it('con un nome non valido esce con errore', () => {
+    const { code, out } = run(['!!!'], { expectFailure: true });
+    assert.strictEqual(code, 2);
+    assert.match(out, /non produce un nome valido/);
+  });
+
+  it('con un template inesistente esce con errore', () => {
+    const { code, out } = run(['x', '--template', 'inesistente'], { expectFailure: true });
+    assert.strictEqual(code, 2);
+    assert.match(out, /non trovato/);
+  });
+
+  it('con un opzione sconosciuta esce con errore', () => {
+    const { code, out } = run(['x', '--boh'], { expectFailure: true });
+    assert.strictEqual(code, 2);
+    assert.match(out, /Opzione sconosciuta/);
+  });
+
+  it('--dry-run non scrive nulla', () => {
+    const slug = 'tmp-dry-run-robot';
+    const { out } = run([slug, '--dry-run']);
+    assert.match(out, /DRY RUN/);
+    assert.strictEqual(fs.existsSync(path.join(ROOT, 'robot_tmp_dry_run_robot.js')), false);
+  });
+
+  it('rifiuta di sovrascrivere senza --force', () => {
+    // package.json esiste di sicuro: si usa un template fittizio? No: si genera
+    // davvero e si riprova, ripulendo subito dopo.
+    const slug = 'tmp-overwrite-robot';
+    const created = [
+      'robot_tmp_overwrite_robot.js',
+      'routes/robotTmpOverwriteRobot.js',
+      'tests/robotTmpOverwriteRobot.test.js',
+      'docs/robots/tmp-overwrite-robot.md'
+    ];
+    try {
+      run([slug]);
+      const { code, out } = run([slug], { expectFailure: true });
+      assert.strictEqual(code, 1);
+      assert.match(out, /esistono già/);
+      assert.doesNotThrow(() => run([slug, '--force']));
+    } finally {
+      for (const f of created) fs.rmSync(path.join(ROOT, f), { force: true });
+    }
+  });
+});
+
+// ------------------------------------------------- codice generato reale
+
+describe('codice generato', () => {
+  const slug = 'tmp-generated-robot';
+  const files = [
+    'robot_tmp_generated_robot.js',
+    'routes/robotTmpGeneratedRobot.js',
+    'tests/robotTmpGeneratedRobot.test.js',
+    'docs/robots/tmp-generated-robot.md'
+  ];
+
+  before(() => run([slug, '--template', 'translation']));
+  after(() => { for (const f of files) fs.rmSync(path.join(ROOT, f), { force: true }); });
+
+  it('crea tutti e quattro i file', () => {
+    for (const f of files) {
+      assert.ok(fs.existsSync(path.join(ROOT, f)), `${f} deve esistere`);
+    }
+  });
+
+  it('non lascia segnaposto non risolti', () => {
+    for (const f of files) {
+      const content = fs.readFileSync(path.join(ROOT, f), 'utf8');
+      assert.deepStrictEqual(gen.missingPlaceholders(content), [], `${f} contiene segnaposto`);
+    }
+  });
+
+  it('produce JavaScript sintatticamente valido', () => {
+    for (const f of files.filter(f => f.endsWith('.js'))) {
+      assert.doesNotThrow(
+        () => execFileSync('node', ['--check', path.join(ROOT, f)], { stdio: 'pipe' }),
+        `${f} non è JavaScript valido`
+      );
+    }
+  });
+
+  it('usa le variabili del template scelto', () => {
+    const module = fs.readFileSync(path.join(ROOT, files[0]), 'utf8');
+    assert.match(module, /job\.text/, 'usa INPUT_FIELD del template translation');
+    assert.match(module, /translation:/, 'usa OUTPUT_FIELD del template translation');
+    assert.match(module, /const DEFAULT_AMOUNT = 50;/);
+  });
+
+  it('i test generati passano', () => {
+    // NODE_TEST_CONTEXT è ereditato da questo processo di test e farebbe usare
+    // al figlio il reporter interno, che non stampa il riepilogo TAP.
+    const env = { ...process.env };
+    delete env.NODE_TEST_CONTEXT;
+
+    const result = execFileSync('node', ['--test', files[2]], { cwd: ROOT, encoding: 'utf8', env });
+    assert.match(result, /# fail 0/);
+    assert.doesNotMatch(result, /# pass 0/);
+  });
+
+  it('la documentazione generata cita gli endpoint reali', () => {
+    const doc = fs.readFileSync(path.join(ROOT, files[3]), 'utf8');
+    assert.match(doc, /POST \/api\/robot\/tmp-generated-robot\/create/);
+    assert.match(doc, /POST \/api\/robot\/tmp-generated-robot\/execute/);
+    assert.match(doc, /performTmpGeneratedRobot/);
+  });
+});


### PR DESCRIPTION
Closes #344

## 📌 Cosa fa

```bash
$ npm run robot:create -- traduzione --template translation

🤖 Robot "Traduzione"  ·  template translation

   creato        robot_traduzione.js
   creato        routes/robotTraduzione.js
   creato        tests/robotTraduzione.test.js
   creato        docs/robots/traduzione.md

   Per attivarlo, aggiungi in server.js:
     app.use('/api/robot/traduzione', require('./routes/robotTraduzione'));

   Implementa la logica in performTraduzione() dentro robot_traduzione.js.
```

Il robot generato **funziona subito**: crea job con escrow reale, li esegue, li consegna. L'unica cosa da riscrivere è la funzione con la logica specifica.

## ✅ Criteri di accettazione

- [x] **Comando `npm run robot:create [nome]`** — più `npm run robot:templates`
- [x] **Template base con: configurazione, metodi, test** — modulo, API Express, test e documentazione
- [x] **Documentazione automatica generata** — `docs/robots/<nome>.md` con esempi `curl` sugli endpoint reali
- [x] **Supporto per plugin e estensioni** — hook di runtime **e** ereditarietà fra template
- [x] **Esempi di robot (traduzione, logo, codice)** — template `translation`, `logo`, `code`

## 🚀 Verificato davvero, non solo generato

Ho generato tutti e tre i robot d'esempio ed eseguito i loro test:

```
DemoTranslation: # tests 11 # pass 11 # fail 0
DemoLogo:        # tests 11 # pass 11 # fail 0
DemoCode:        # tests 11 # pass 11 # fail 0
```

Poi ho montato un robot generato con `--wire` e l'ho chiamato via HTTP su un gateway in esecuzione:

```bash
$ curl -X POST localhost:10000/api/robot/meteo/create -d '{"jobId":"m1","clientId":"alice","robotId":"r1","input":"Roma"}'
{"success":true,"data":{"jobId":"m1","status":"pending","amount":100,"currency":"MYZ",
 "escrow":{"jobId":"m1","amount":100,"fee":2,...}}}

$ curl -X POST localhost:10000/api/robot/meteo/execute -d '{"jobId":"m1"}'
{"success":true,"data":{"jobId":"m1","output":"Meteo completato per: Roma","status":"delivered"}}
```

Casi d'errore: job duplicato → **400**, job inesistente → **404**, campo mancante → **400**. Escrow correttamente `LOCKED` → `DELIVERED`.

> I file demo non sono inclusi nella PR: erano usa e getta per la verifica. Si rigenerano con un comando.

## 🐛 Un bug trovato dai test generati

I test generati inizialmente **fallivano** su `list…Jobs()`: due job creati nello stesso millisecondo hanno lo stesso `createdAt`, quindi l'ordinamento "dal più recente" non era deterministico. Ho corretto **il template**, non il test — ora ogni job ha anche un contatore monotono. È esattamente il motivo per cui vale la pena che lo scaffolding generi test insieme al codice.

## 🧩 Template con ereditarietà

Un template è una cartella con un `template.json`. Con `extends` eredita tutto dal genitore e dichiara **solo ciò che cambia** — i tre esempi sono file da dieci righe:

```jsonc
{
  "name": "translation",
  "extends": "basic",
  "description": "Robot di traduzione: riceve un testo e una lingua di destinazione…",
  "vars": {
    "INPUT_FIELD": "text",
    "OUTPUT_FIELD": "translation",
    "DEFAULT_AMOUNT": "50"
  }
}
```

Un `perform.snippet` personalizza solo il corpo della funzione principale, senza duplicare il modulo. Per cambiare di più basta mettere nella cartella un `robot.js.tpl`, `route.js.tpl`, `test.js.tpl` o `doc.md.tpl`: i file assenti si prendono dal genitore.

| Template | Input → Output | |
|---|---|---|
| `basic` | `input` → `output` | base generica |
| `translation` | `text` → `translation` | traduzione (50 MYZ) |
| `logo` | `prompt` → `imageUrl` | generazione loghi (100 MYZ) |
| `code` | `prompt` → `code` | generazione codice (150 MYZ) |

## 🔌 Plugin

Ogni robot generato espone quattro hook (`services/robotPlugins.js`):

```js
robot.use({
  name: 'metrics',
  hooks: {
    'job:delivered': ({ jobId, job }) =>
      console.log(`job ${jobId} in ${job.deliveredAt - job.createdAt}ms`)
  }
});
```

`job:created` · `job:executing` · `job:delivered` · `job:failed`

Un plugin che lancia viene loggato e ignorato — deve degradare l'osservabilità, non il lavoro del robot. Registrare un hook **inesistente** invece fallisce subito: sarebbe silenziosamente inerte, il tipo di bug che non si scopre mai.

## 🧩 Altre due scelte

**Nomi coerenti da un unico slug.** `Robot Traduzione`, `robot-traduzione` e `robotTraduzione` producono tutti lo stesso risultato — il prefisso `robot` ridondante viene rimosso — così file, route e simboli non divergono mai.

**Segnaposto non risolto = errore.** Se una variabile manca il generatore fallisce, invece di scrivere un file con `{{VAR}}` dentro che poi esplode a runtime.

## 🛠 Opzioni

| Opzione | |
|---|---|
| `-t, --template <nome>` | template da usare (default `basic`) |
| `-l, --list` | elenca i template |
| `-f, --force` | sovrascrive i file esistenti |
| `--dry-run` | mostra cosa farebbe, senza scrivere |
| `--wire` | inserisce la route in `server.js` |
| `--no-test` | non genera il file di test |

## 🧪 Test

```
$ node --test tests/createRobot.test.js
# tests 35
# pass 35
# fail 0
```

Coperti: normalizzazione dei nomi, catena di ereditarietà, precedenza delle variabili, interpolazione e segnaposto mancanti, plugin host (ordine, contesto, isolamento degli errori, hook asincroni, validazione), tutti i codici d'uscita della CLI, e — la parte importante — **generazione reale** con verifica che non restino segnaposto, che il JavaScript sia valido (`node --check`), che la documentazione citi gli endpoint giusti e che **i test generati passino**.

**Nessuna nuova dipendenza npm.** Nessuna modifica ai file esistenti a parte due script in `package.json`.

## 📄 File

| File | |
|---|---|
| `scripts/create-robot.js` | nuovo — generatore |
| `scripts/robot-templates/` | nuovo — 4 template (basic + 3 esempi) |
| `services/robotPlugins.js` | nuovo — host dei plugin |
| `docs/robots/README.md` | nuovo — guida |
| `tests/createRobot.test.js` | nuovo — 35 test |
| `package.json` | 2 script npm |