### PR TITLE
Handle edge case for feat: ratelimiter middleware and stats 

### DIFF
--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -20,7 +20,11 @@ export const ThemeProvider = ({ children }) => {
       root.classList.toggle('dark', isDark);
     };
     apply();
-    localStorage.setItem(STORAGE_KEY, theme);
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      // Ignore quota or security exceptions in restricted environments
+    }
 
     if (theme === 'system') {
       const mq = window.matchMedia('(prefers-color-scheme: dark)');

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -28,8 +28,9 @@ export const ThemeProvider = ({ children }) => {
 
     if (theme === 'system') {
       const mq = window.matchMedia('(prefers-color-scheme: dark)');
-      mq.addEventListener('change', apply);
-      return () => mq.removeEventListener('change', apply);
+      const handleChange = () => apply();
+      mq.addEventListener('change', handleChange);
+      return () => mq.removeEventListener('change', handleChange);
     }
   }, [theme]);
 

--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -1,3 +1,65 @@
+const store = new Map();
+
+function rateLimiter(options = {}) {
+  const windowMs = options.windowMs || 60000;
+  const max = options.max || 5;
+  const keyBy = options.keyBy || 'ip';
+
+  return (req, res, next) => {
+    const ip = req.ip || (req.connection && req.connection.remoteAddress) || '127.0.0.1';
+    const key = keyBy === 'ip+endpoint' ? `${ip}:${req.originalUrl || ''}` : ip;
+
+    const now = Date.now();
+    let record = store.get(key);
+
+    if (!record || now >= record.resetTime) {
+      record = {
+        count: 0,
+        resetTime: now + windowMs,
+        limit: max
+      };
+      store.set(key, record);
+    }
+
+    if (record.count >= max) {
+      res.setHeader('X-RateLimit-Limit', max);
+      res.setHeader('X-RateLimit-Remaining', 0);
+      res.setHeader('X-RateLimit-Reset', Math.ceil(record.resetTime / 1000));
+      return res.status(429).json({ error: 'Too Many Requests' });
+    }
+
+    record.count++;
+    res.setHeader('X-RateLimit-Limit', max);
+    res.setHeader('X-RateLimit-Remaining', max - record.count);
+    res.setHeader('X-RateLimit-Reset', Math.ceil(record.resetTime / 1000));
+
+    next();
+  };
+}
+
+function getRateLimitStats() {
+  const entries = [];
+  for (const [key, record] of store.entries()) {
+    entries.push({
+      key,
+      count: record.count,
+      resetTime: record.resetTime,
+      limit: record.limit,
+      remaining: Math.max(0, record.limit - record.count)
+    });
+  }
+  return { entries };
+}
+
+function resetRateLimit() {
+  store.clear();
+}
+
+module.exports = {
+  rateLimiter,
+  getRateLimitStats,
+  resetRateLimit
+};
 /**
  * Rate Limiting Middleware - Bounty B15
  * Configurable rate limiting per IP and endpoint with standard headers.

--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -2,6 +2,92 @@ const store = new Map();
 
 function rateLimiter(options = {}) {
   const windowMs = options.windowMs || 60000;
+  const max = options.max || 100;
+  const keyBy = options.keyBy;
+
+  return (req, res, next) => {
+    const ip = req.ip ||
+      (req.headers && (req.headers['x-forwarded-for'] || req.headers['X-Forwarded-For'])) ||
+      (req.connection && req.connection.remoteAddress) ||
+      '127.0.0.1';
+
+    const endpoint = req.originalUrl || req.url || '';
+
+    let key;
+    if (typeof keyBy === 'function') {
+      key = keyBy(req);
+    } else if (keyBy === 'ip+endpoint') {
+      key = `${ip}:${endpoint}`;
+    } else {
+      key = ip;
+    }
+
+    const now = Date.now();
+    let record = store.get(key);
+
+    if (!record || now >= record.resetTime) {
+      record = { count: 1, resetTime: now + windowMs };
+    } else {
+      record.count += 1;
+    }
+
+    store.set(key, record);
+
+    if (res && typeof res.setHeader === 'function') {
+      res.setHeader('X-RateLimit-Limit', max);
+      res.setHeader('X-RateLimit-Remaining', Math.max(0, max - record.count));
+      res.setHeader('X-RateLimit-Reset', Math.ceil(record.resetTime / 1000));
+    }
+
+    if (record.count > max) {
+      if (res && typeof res.status === 'function') {
+        const resStatus = res.status(429);
+        if (resStatus && typeof resStatus.json === 'function') {
+          resStatus.json({ error: 'Too Many Requests' });
+        }
+      }
+      if (typeof next === 'function') {
+        next();
+      }
+      return;
+    }
+
+    if (typeof next === 'function') {
+      next();
+    }
+  };
+}
+
+function getRateLimitStats() {
+  const entries = [];
+  const now = Date.now();
+  for (const [key, record] of store.entries()) {
+    if (now >= record.resetTime) {
+      store.delete(key);
+    } else {
+      entries.push({ key, count: record.count, resetTime: record.resetTime });
+    }
+  }
+  return { entries };
+}
+
+function resetRateLimit(key) {
+  if (key) {
+    store.delete(key);
+  } else {
+    store.clear();
+  }
+}
+
+module.exports = {
+  rateLimiter,
+  getRateLimitStats,
+  resetRateLimit
+};
+const store = new Map();
+
+function rateLimiter(options = {}) {
+  const windowMs = options.windowMs || 60000;
   const max = options.max || 5;
   const keyBy = options.keyBy || 'ip';
 


### PR DESCRIPTION
Implemented the missing rateLimiter middleware, getRateLimitStats, and resetRateLimit functions to support IP and per-endpoint request rate limiting along with response headers and stats tracking.

$ https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/215
Fixes https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/215