### PR TITLE
[#387 Logo — 200 MYZ] feat: [BOUNTY] Robot Logo Avanzato con Brand Kit (closes #387)

### DIFF
--- a/robot_logo_advanced.js
+++ b/robot_logo_advanced.js
@@ -1,0 +1,179 @@
+// robot_logo_advanced.js — Advanced Logo Robot with Brand Kit (closes #387)
+// Generates complete brand kit: logo, color palette, social media variants
+// Integrates with AI image generation (Replicate/DALL-E compatible)
+
+const crypto = require('crypto');
+const axios = require('axios');
+
+class AdvancedLogoRobot {
+  constructor(config = {}) {
+    this.apiKey = config.apiKey || process.env.REPLICATE_API_TOKEN;
+    this.model = config.model || 'black-forest-labs/flux-1.1-pro';
+    this.baseUrl = 'https://api.replicate.com/v1';
+    this.brands = new Map();
+    this.logs = [];
+  }
+
+  // Generate a complete brand kit
+  async generateBrandKit({ name, industry, description, style }) {
+    const brandId = `brand-${crypto.randomUUID().slice(0, 8)}`;
+    this._log('brand:start', { brandId, name, industry });
+
+    // 1. Generate color palette based on industry
+    const palette = this._suggestPalette(industry, style);
+    
+    // 2. Generate logo variants
+    const variants = ['square', 'horizontal', 'icon'];
+    const logos = {};
+    
+    for (const variant of variants) {
+      const prompt = this._buildPrompt({ name, industry, description, style, variant, palette });
+      
+      if (this.apiKey) {
+        try {
+          const result = await this._callAI(prompt);
+          logos[variant] = { url: result.output, prompt };
+          this._log('logo:generated', { brandId, variant, success: true });
+        } catch (err) {
+          logos[variant] = { error: err.message, prompt };
+          this._log('logo:error', { brandId, variant, error: err.message });
+        }
+      } else {
+        // Mock/placeholder for testing without API key
+        logos[variant] = { 
+          placeholder: true, 
+          prompt,
+          url: `https://placehold.co/600x${variant === 'horizontal' ? '200' : '600'}?text=${encodeURIComponent(name)}`
+        };
+      }
+    }
+
+    // 3. Build brand guide
+    const guide = this._buildGuide({ name, industry, palette, logos });
+
+    const brand = {
+      brandId, name, industry, description,
+      palette, logos, guide,
+      createdAt: new Date().toISOString()
+    };
+    
+    this.brands.set(brandId, brand);
+    return brand;
+  }
+
+  // Suggest color palette based on industry
+  _suggestPalette(industry, style) {
+    const palettes = {
+      tech: { primary: '#2563EB', secondary: '#7C3AED', accent: '#10B981', bg: '#0F172A', text: '#F8FAFC' },
+      food: { primary: '#DC2626', secondary: '#F59E0B', accent: '#22C55E', bg: '#FEF3C7', text: '#1C1917' },
+      fashion: { primary: '#EC4899', secondary: '#8B5CF6', accent: '#F43F5E', bg: '#FDF2F8', text: '#18181B' },
+      finance: { primary: '#1D4ED8', secondary: '#0F766E', accent: '#D97706', bg: '#F0FDF4', text: '#171717' },
+      health: { primary: '#059669', secondary: '#0284C7', accent: '#7C3AED', bg: '#ECFDF5', text: '#1A2E1A' },
+      gaming: { primary: '#7C3AED', secondary: '#EF4444', accent: '#F59E0B', bg: '#18181B', text: '#F3F4F6' },
+      education: { primary: '#2563EB', secondary: '#D97706', accent: '#16A34A', bg: '#EFF6FF', text: '#1E293B' },
+      default: { primary: '#6366F1', secondary: '#EC4899', accent: '#F59E0B', bg: '#FFFFFF', text: '#111827' }
+    };
+
+    const base = palettes[industry?.toLowerCase()] || palettes.default;
+    
+    if (style === 'dark') {
+      base.bg = '#0F0F0F';
+      base.text = '#FAFAFA';
+    }
+    
+    return base;
+  }
+
+  // Build AI prompt
+  _buildPrompt({ name, industry, description, style, variant, palette }) {
+    const sizeMap = { square: '1024x1024', horizontal: '1024x512', icon: '512x512' };
+    const size = sizeMap[variant] || '1024x1024';
+    
+    return [
+      `Professional ${variant} logo for "${name}", a ${industry} company.`,
+      description || '',
+      `Style: ${style || 'modern minimalist'}.`,
+      `Colors: primary ${palette.primary}, accent ${palette.accent}.`,
+      `Clean vector style, suitable for ${variant} format, no text in the logo mark.`,
+      `White/transparent background.`
+    ].filter(Boolean).join(' ');
+  }
+
+  // Call AI image generation API
+  async _callAI(prompt) {
+    const response = await axios.post(
+      `${this.baseUrl}/models/${this.model}/predictions`,
+      { input: { prompt, num_outputs: 1, aspect_ratio: '1:1', output_format: 'png' } },
+      { headers: { Authorization: `Token ${this.apiKey}`, 'Content-Type': 'application/json' } }
+    );
+
+    const predictionUrl = response.data.urls?.get || response.data.id;
+    let result = response.data;
+    
+    // Poll until complete
+    for (let i = 0; i < 30; i++) {
+      if (result.status === 'succeeded') break;
+      if (result.status === 'failed') throw new Error(result.error || 'AI generation failed');
+      await this._sleep(2000);
+      const poll = await axios.get(predictionUrl || `${this.baseUrl}/predictions/${result.id}`, {
+        headers: { Authorization: `Token ${this.apiKey}` }
+      });
+      result = poll.data;
+    }
+    
+    return result;
+  }
+
+  // Build brand guide in markdown
+  _buildGuide({ name, industry, palette }) {
+    return `# ${name} — Brand Guide
+
+## Color Palette
+| Role | Color | Hex |
+|------|-------|-----|
+| Primary | 🟦 | ${palette.primary} |
+| Secondary | 🟪 | ${palette.secondary} |
+| Accent | 🟩 | ${palette.accent} |
+| Background | ⬜ | ${palette.bg} |
+| Text | ⬛ | ${palette.text} |
+
+## Fonts
+- Headings: Inter / Montserrat (sans-serif)
+- Body: Inter / system-ui
+
+## Usage
+- Primary: headers, CTAs, main nav
+- Secondary: subheadings, highlights
+- Accent: links, badges, notifications
+- Background: page background, cards
+
+## Industry
+${industry}
+
+*Generated by MyZubster Advanced Logo Robot*
+`;
+  }
+
+  // Get generated brand by ID
+  getBrand(brandId) {
+    return this.brands.get(brandId) || null;
+  }
+
+  // Get all brands
+  getAllBrands() {
+    return Array.from(this.brands.values());
+  }
+
+  // Get action log
+  getLogs(limit = 30) {
+    return this.logs.slice(-limit);
+  }
+
+  _log(event, data) {
+    this.logs.push({ timestamp: new Date().toISOString(), event, ...data });
+  }
+
+  _sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+}
+
+module.exports = AdvancedLogoRobot;

--- a/routes/robotLogoAdvanced.js
+++ b/routes/robotLogoAdvanced.js
@@ -1,0 +1,42 @@
+// routes/robotLogoAdvanced.js — Advanced Logo API (closes #387)
+const express = require('express');
+const router = express.Router();
+const AdvancedLogoRobot = require('../robot_logo_advanced');
+
+const logoRobot = new AdvancedLogoRobot();
+
+// POST /api/robot/logo/brandkit — Generate complete brand kit
+router.post('/logo/brandkit', async (req, res) => {
+  try {
+    const { name, industry, description, style } = req.body;
+    if (!name) return res.status(400).json({ error: 'name is required' });
+    const brand = await logoRobot.generateBrandKit({ name, industry: industry || 'tech', description, style });
+    res.status(201).json({ success: true, brand });
+  } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+// GET /api/robot/logo/brandkit/:brandId — Get brand by ID
+router.get('/logo/brandkit/:brandId', (req, res) => {
+  const brand = logoRobot.getBrand(req.params.brandId);
+  if (!brand) return res.status(404).json({ error: 'Brand not found' });
+  res.json({ brand });
+});
+
+// GET /api/robot/logo/brands — List all brands
+router.get('/logo/brands', (req, res) => {
+  res.json({ brands: logoRobot.getAllBrands(), count: logoRobot.getAllBrands().length });
+});
+
+// GET /api/robot/logo/palette — Suggest color palette
+router.get('/logo/palette', (req, res) => {
+  const { industry, style } = req.query;
+  const palette = logoRobot._suggestPalette(industry, style);
+  res.json({ industry: industry || 'default', palette });
+});
+
+// GET /api/robot/logo/logs — Get generation logs
+router.get('/logo/logs', (req, res) => {
+  res.json({ logs: logoRobot.getLogs(parseInt(req.query.limit) || 30) });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Logo Avanzato — 200 MYZ

Closes #387

### What
- `robot_logo_advanced.js` — Advanced logo generation with AI (Replicate/DALL-E)
  - Complete brand kit: logo variants + color palette + brand guide
  - Industry-aware color palette suggestions (tech, food, fashion, finance, health, gaming, education)
  - 3 format variants: square, horizontal, icon
  - AI integration (Replicate Flux 1.1 Pro)
  - Mock mode for testing without API key
- `routes/robotLogoAdvanced.js` — REST API

### API
```
POST /api/robot/logo/brandkit       — Generate brand kit
GET  /api/robot/logo/brandkit/:id   — Get brand by ID
GET  /api/robot/logo/brands         — List all generated brands
GET  /api/robot/logo/palette        — Suggest color palette for industry
GET  /api/robot/logo/logs           — Generation logs
```