### PR TITLE
feat: MYZ payout/withdrawal API — transfer rewards to Tari wallet

### DIFF
--- a/gateway/tari_payout.js
+++ b/gateway/tari_payout.js
@@ -1,0 +1,88 @@
+// gateway/tari_payout.js — Tari network payout service for MYZ withdrawals
+const axios = require('axios');
+
+const TARI_WALLET_URL = process.env.TARI_WALLET_URL || 'http://localhost:18089';
+const TARI_NODE_URL = process.env.TARI_NODE_URL || 'http://localhost:18142';
+
+class TariPayout {
+  constructor() {
+    this.pendingTransfers = new Map();
+    this.minConfirmations = parseInt(process.env.TARI_MIN_CONFIRMATIONS || '3');
+  }
+
+  // Transfer MYZ from platform wallet to user's Tari address
+  async transferToAddress(userId, address, amount) {
+    if (!address || amount <= 0) {
+      throw new Error('Invalid address or amount');
+    }
+
+    const transferId = `payout_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    this.pendingTransfers.set(transferId, { userId, address, amount, status: 'pending', createdAt: new Date().toISOString() });
+
+    try {
+      // Attempt real Tari transfer if wallet is configured
+      if (TARI_WALLET_URL !== 'http://localhost:18089') {
+        const response = await axios.post(`${TARI_WALLET_URL}/transfer`, {
+          address,
+          amount: amount * 1_000_000, // Convert MYZ to microTari
+          fee: 100, // 100 microTari fee
+          message: `MyZubster payout to ${userId}`
+        }, { timeout: 30000 });
+
+        const txId = response.data?.transaction_id || response.data?.txId;
+        const transfer = this.pendingTransfers.get(transferId);
+        transfer.status = 'sent';
+        transfer.txId = txId;
+        transfer.networkTxId = txId;
+        this.pendingTransfers.set(transferId, transfer);
+        return { transferId, txId, status: 'sent' };
+      }
+
+      // Simulation mode (dev/test)
+      const simTxId = `tari_tx_sim_${Date.now()}`;
+      const transfer = this.pendingTransfers.get(transferId);
+      transfer.status = 'sent';
+      transfer.txId = simTxId;
+      transfer.networkTxId = simTxId;
+      transfer.note = 'simulated — real Tari wallet not configured';
+      this.pendingTransfers.set(transferId, transfer);
+
+      console.log(`💸 [TariPayout] SIMULATED: ${amount} MYZ → ${address.slice(0,12)}... (tx: ${simTxId})`);
+      return { transferId, txId: simTxId, status: 'sent', simulated: true };
+
+    } catch (err) {
+      const transfer = this.pendingTransfers.get(transferId);
+      transfer.status = 'failed';
+      transfer.error = err.message;
+      this.pendingTransfers.set(transferId, transfer);
+      throw new Error(`Tari transfer failed: ${err.message}`);
+    }
+  }
+
+  // Check transfer status
+  getTransferStatus(transferId) {
+    const transfer = this.pendingTransfers.get(transferId);
+    if (!transfer) return null;
+    return {
+      transferId,
+      status: transfer.status,
+      amount: transfer.amount,
+      address: transfer.address,
+      txId: transfer.txId,
+      createdAt: transfer.createdAt
+    };
+  }
+
+  // Get all pending transfers for a user
+  getUserTransfers(userId) {
+    const transfers = [];
+    this.pendingTransfers.forEach((t, id) => {
+      if (t.userId === userId) {
+        transfers.push({ transferId: id, ...t });
+      }
+    });
+    return transfers.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }
+}
+
+module.exports = new TariPayout();

--- a/routes/payout.js
+++ b/routes/payout.js
@@ -1,0 +1,150 @@
+// routes/payout.js — Payout/Withdraw API for MYZ → Tari wallet
+const express = require('express');
+const router = express.Router();
+const Reward = require('../models/Reward');
+const tariPayout = require('../gateway/tari_payout');
+
+// GET /api/payout/balance — Get available balance for withdrawal
+router.get('/balance', async (req, res) => {
+  try {
+    const { userId } = req.query;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    // Sum all completed rewards
+    const completed = await Reward.aggregate([
+      { $match: { userId, status: 'completed' } },
+      { $group: { _id: null, total: { $sum: '$amount' } } }
+    ]);
+
+    // Sum all already withdrawn
+    const withdrawn = await Reward.aggregate([
+      { $match: { userId, status: 'withdrawn' } },
+      { $group: { _id: null, total: { $sum: '$amount' } } }
+    ]);
+
+    const totalEarned = completed[0]?.total || 0;
+    const totalWithdrawn = withdrawn[0]?.total || 0;
+    const available = totalEarned - totalWithdrawn;
+
+    res.json({
+      success: true,
+      balance: {
+        totalEarned,
+        totalWithdrawn,
+        available,
+        currency: 'MYZ'
+      }
+    });
+  } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+// POST /api/payout/withdraw — Request withdrawal to Tari address
+router.post('/withdraw', async (req, res) => {
+  try {
+    const { userId, address, amount } = req.body;
+    if (!userId || !address || !amount) {
+      return res.status(400).json({ error: 'userId, address, and amount are required' });
+    }
+
+    if (amount <= 0) {
+      return res.status(400).json({ error: 'amount must be positive' });
+    }
+
+    // Check available balance
+    const completed = await Reward.aggregate([
+      { $match: { userId, status: 'completed' } },
+      { $group: { _id: null, total: { $sum: '$amount' } } }
+    ]);
+    const withdrawn = await Reward.aggregate([
+      { $match: { userId, status: 'withdrawn' } },
+      { $group: { _id: null, total: { $sum: '$amount' } } }
+    ]);
+    const available = (completed[0]?.total || 0) - (withdrawn[0]?.total || 0);
+
+    if (amount > available) {
+      return res.status(400).json({
+        error: 'Insufficient balance',
+        available,
+        requested: amount,
+        shortfall: amount - available
+      });
+    }
+
+    // Create withdrawal record
+    const withdrawal = new Reward({
+      userId,
+      amount: -amount, // negative = withdrawal
+      reason: `Withdrawal to Tari: ${address.slice(0, 12)}...`,
+      source: 'payout',
+      status: 'pending'
+    });
+    await withdrawal.save();
+
+    // Execute Tari transfer
+    try {
+      const result = await tariPayout.transferToAddress(userId, address, amount);
+
+      withdrawal.txId = result.txId;
+      withdrawal.status = 'withdrawn';
+      withdrawal.metadata = {
+        transferId: result.transferId,
+        networkTxId: result.networkTxId,
+        simulated: result.simulated || false
+      };
+      await withdrawal.save();
+
+      res.json({
+        success: true,
+        withdrawal: {
+          id: withdrawal._id,
+          userId,
+          amount,
+          address,
+          txId: result.txId,
+          status: 'withdrawn',
+          simulated: result.simulated || false,
+          createdAt: withdrawal.createdAt
+        }
+      });
+    } catch (txErr) {
+      withdrawal.status = 'failed';
+      withdrawal.metadata = { error: txErr.message };
+      await withdrawal.save();
+      throw txErr;
+    }
+  } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+// GET /api/payout/history — Get withdrawal history
+router.get('/history', async (req, res) => {
+  try {
+    const { userId, limit = 20 } = req.query;
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+    
+    const history = await Reward.find({
+      userId,
+      status: { $in: ['withdrawn', 'pending'] }
+    }).sort({ createdAt: -1 }).limit(parseInt(limit));
+
+    res.json({
+      success: true,
+      withdrawals: history.map(h => ({
+        id: h._id,
+        amount: Math.abs(h.amount),
+        txId: h.txId,
+        status: h.status,
+        reason: h.reason,
+        createdAt: h.createdAt
+      }))
+    });
+  } catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+// GET /api/payout/status/:transferId — Check transfer status
+router.get('/status/:transferId', (req, res) => {
+  const status = tariPayout.getTransferStatus(req.params.transferId);
+  if (!status) return res.status(404).json({ error: 'Transfer not found' });
+  res.json({ success: true, transfer: status });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Payout API — Transfer MYZ to Tari Wallet

Enables users to withdraw their earned MYZ to any Tari address.

### What
- `gateway/tari_payout.js` — Tari network transfer service (real + simulation mode)
- `routes/payout.js` — REST API for balance and withdrawals

### API
```
GET  /api/payout/balance          — Available balance for withdrawal
POST /api/payout/withdraw         — Request withdrawal to Tari address
GET  /api/payout/history          — Withdrawal history
GET  /api/payout/status/:id       — Check transfer status
```

### Usage
```bash
# Check balance
curl https://gateway/api/payout/balance?userId=laurentketterle-hub

# Withdraw
curl -X POST https://gateway/api/payout/withdraw \
  -H 'Content-Type: application/json' \
  -d '{"userId":"laurentketterle-hub","address":"12Nbmmm5g...","amount":2040}'
```

### How it works
1. Calculates available balance (rewards - withdrawals)
2. Validates sufficient funds
3. Transfers MYZ to Tari address via wallet RPC
4. Records withdrawal in database
5. Falls back to simulation in dev mode