### PR TITLE
feat: add robot performance analytics

### DIFF
--- a/frontend/public/robot-analytics.css
+++ b/frontend/public/robot-analytics.css
@@ -1,0 +1,30 @@
+* { box-sizing: border-box; }
+body { margin: 0; background: #f4f6f7; color: #172127; font-family: "Segoe UI", Arial, sans-serif; }
+header { height: 62px; padding: 0 28px; display: flex; align-items: center; gap: 22px; border-bottom: 1px solid #d9e0e3; background: #fff; font-size: 14px; }
+header a { color: #127c6b; font-size: 19px; font-weight: 700; text-decoration: none; }
+header .export { margin-left: auto; font-size: 14px; }
+main { width: min(1160px, calc(100% - 36px)); margin: 0 auto; padding: 42px 0 70px; }
+.title { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; }
+.title p { margin: 0 0 6px; color: #b4551b; font-size: 12px; font-weight: 700; }
+h1 { margin: 0 0 28px; font-size: 36px; letter-spacing: 0; }
+h2 { margin: 0 0 18px; font-size: 19px; letter-spacing: 0; }
+button { height: 42px; margin-bottom: 28px; padding: 0 18px; border: 0; border-radius: 6px; background: #127c6b; color: #fff; font: inherit; font-weight: 700; cursor: pointer; }
+.metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; border: 1px solid #d9e0e3; background: #d9e0e3; }
+.metrics article { padding: 21px; background: #fff; }
+.metrics span { display: block; margin-bottom: 7px; color: #66747b; font-size: 13px; }
+.metrics strong { font-size: 27px; }
+.chart-band { margin-top: 28px; padding: 24px; border: 1px solid #d9e0e3; background: #fff; }
+.chart-wrap { height: 280px; }
+.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; margin-top: 28px; }
+.grid > section { min-width: 0; }
+.table-wrap { overflow-x: auto; border: 1px solid #d9e0e3; background: #fff; }
+table { width: 100%; border-collapse: collapse; font-size: 14px; }
+th, td { padding: 13px; border-bottom: 1px solid #e5eaec; text-align: left; }
+th { color: #66747b; font-size: 12px; text-transform: uppercase; }
+#status { color: #66747b; font-size: 13px; }
+@media (max-width: 720px) {
+  header { padding: 0 16px; }
+  main { width: calc(100% - 24px); padding-top: 28px; }
+  h1 { font-size: 30px; }
+  .metrics, .grid { grid-template-columns: 1fr; }
+}

--- a/frontend/public/robot-analytics.html
+++ b/frontend/public/robot-analytics.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="google-analytics-id" content="">
+    <title>Robot analytics | MyZubster</title>
+    <link rel="stylesheet" href="/robot-analytics.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js" defer></script>
+    <script src="/robot-analytics.js" defer></script>
+  </head>
+  <body>
+    <header><a href="/">MyZubster</a><span>Robot analytics</span><a class="export" href="/api/robot/analytics/report.csv">Export CSV</a></header>
+    <main>
+      <div class="title"><div><p>PERFORMANCE</p><h1>Robot analytics</h1></div><button id="refresh">Refresh</button></div>
+      <section class="metrics">
+        <article><span>Tracked robots</span><strong id="robots">0</strong></article>
+        <article><span>Completed jobs</span><strong id="jobs">0</strong></article>
+        <article><span>Tracked events</span><strong id="events">0</strong></article>
+      </section>
+      <section class="chart-band"><h2>Revenue by robot</h2><div class="chart-wrap"><canvas id="revenue-chart"></canvas></div></section>
+      <div class="grid">
+        <section><h2>Category ROI</h2><div id="categories" class="table-wrap"></div></section>
+        <section><h2>Top posts</h2><div id="posts" class="table-wrap"></div></section>
+      </div>
+      <p id="status" role="status"></p>
+    </main>
+  </body>
+</html>

--- a/frontend/public/robot-analytics.js
+++ b/frontend/public/robot-analytics.js
@@ -1,0 +1,54 @@
+let revenueChart;
+
+function initGoogleAnalytics() {
+  const params = new URLSearchParams(window.location.search);
+  const measurementId = params.get('ga') || document.querySelector('meta[name="google-analytics-id"]').content;
+  if (!measurementId || !/^G-[A-Z0-9]+$/i.test(measurementId)) return;
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+  document.head.appendChild(script);
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag() { window.dataLayer.push(arguments); };
+  window.gtag('js', new Date());
+  window.gtag('config', measurementId);
+}
+
+function table(headers, rows) {
+  const head = `<thead><tr>${headers.map(item => `<th>${item}</th>`).join('')}</tr></thead>`;
+  const body = `<tbody>${rows.map(row => `<tr>${row.map(item => `<td>${item}</td>`).join('')}</tr>`).join('')}</tbody>`;
+  return `<table>${head}${body}</table>`;
+}
+
+async function load() {
+  const status = document.getElementById('status');
+  status.textContent = 'Loading...';
+  try {
+    const response = await fetch('/api/robot/analytics/summary');
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || 'Request failed');
+    const data = payload.data;
+    document.getElementById('robots').textContent = data.byRobot.length;
+    document.getElementById('jobs').textContent = data.byRobot.reduce((sum, item) => sum + item.jobsCompleted, 0);
+    document.getElementById('events').textContent = data.totalEvents;
+    document.getElementById('categories').innerHTML = table(
+      ['Category', 'Revenue', 'Cost', 'ROI'],
+      data.byCategory.map(item => [item.key, `${item.revenueMYZ} MYZ`, `${item.costMYZ} MYZ`, item.roiPercent === null ? 'n/a' : `${item.roiPercent}%`])
+    );
+    document.getElementById('posts').innerHTML = table(
+      ['Post', 'Robot', 'Engagement', 'Rate'],
+      data.topPosts.map(item => [item.postId, item.robotId, item.engagement, `${item.engagementRate}%`])
+    );
+    if (revenueChart) revenueChart.destroy();
+    revenueChart = new Chart(document.getElementById('revenue-chart'), {
+      type: 'bar',
+      data: { labels: data.byRobot.map(item => item.key), datasets: [{ label: 'MYZ revenue', data: data.byRobot.map(item => item.revenueMYZ), backgroundColor: '#138675' }] },
+      options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } }
+    });
+    status.textContent = `Updated ${new Date(data.generatedAt).toLocaleString()}`;
+  } catch (error) { status.textContent = error.message; }
+}
+
+initGoogleAnalytics();
+document.getElementById('refresh').addEventListener('click', load);
+load();

--- a/models/RobotAnalyticsEvent.js
+++ b/models/RobotAnalyticsEvent.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+const RobotAnalyticsEventSchema = new mongoose.Schema({
+  robotId: { type: String, required: true, index: true },
+  category: { type: String, required: true, index: true },
+  eventType: {
+    type: String,
+    required: true,
+    enum: ['job_completed', 'cost', 'revenue', 'post_engagement'],
+    index: true
+  },
+  amountMYZ: { type: Number, default: 0 },
+  postId: { type: String, default: null },
+  impressions: { type: Number, default: 0, min: 0 },
+  likes: { type: Number, default: 0, min: 0 },
+  comments: { type: Number, default: 0, min: 0 },
+  shares: { type: Number, default: 0, min: 0 },
+  occurredAt: { type: Date, default: Date.now, index: true }
+}, { timestamps: true });
+
+RobotAnalyticsEventSchema.index({ robotId: 1, occurredAt: -1 });
+
+module.exports = mongoose.model('RobotAnalyticsEvent', RobotAnalyticsEventSchema);

--- a/routes/robot.js
+++ b/routes/robot.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const robotBrain = require('../robot_brain');
 const { getRobotStats } = require('../services/robotStatsService');
 
+router.use('/analytics', require('./robotAnalytics'));
+
 router.post('/create', (req, res) => {
   try {
     const { robotId, name, walletAddress } = req.body;

--- a/routes/robotAnalytics.js
+++ b/routes/robotAnalytics.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const { AnalyticsValidationError, createRobotAnalyticsService } = require('../services/robotAnalyticsService');
+
+function createRobotAnalyticsRouter(service = createRobotAnalyticsService()) {
+  const router = express.Router();
+
+  router.post('/events', async (req, res) => {
+    try {
+      res.status(201).json({ success: true, data: await service.record(req.body || {}) });
+    } catch (error) {
+      res.status(error instanceof AnalyticsValidationError ? 400 : 500).json({ success: false, error: error.message });
+    }
+  });
+
+  router.get('/summary', async (req, res) => {
+    try {
+      res.json({ success: true, data: await service.report(req.query) });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  router.get('/report.csv', async (req, res) => {
+    try {
+      const csv = await service.csv(req.query);
+      res.set('Content-Type', 'text/csv; charset=utf-8');
+      res.set('Content-Disposition', 'attachment; filename="robot-analytics.csv"');
+      res.send(csv);
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createRobotAnalyticsRouter();
+module.exports.createRobotAnalyticsRouter = createRobotAnalyticsRouter;

--- a/services/robotAnalyticsService.js
+++ b/services/robotAnalyticsService.js
@@ -1,0 +1,128 @@
+const RobotAnalyticsEvent = require('../models/RobotAnalyticsEvent');
+
+class AnalyticsValidationError extends Error {}
+
+function required(value, field) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new AnalyticsValidationError(`${field} is required`);
+  }
+  return value.trim();
+}
+
+function nonNegative(value, field) {
+  const number = Number(value || 0);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new AnalyticsValidationError(`${field} must be a non-negative number`);
+  }
+  return number;
+}
+
+function normalizeEvent(input) {
+  const eventType = required(input.eventType, 'eventType');
+  if (!['job_completed', 'cost', 'revenue', 'post_engagement'].includes(eventType)) {
+    throw new AnalyticsValidationError('eventType is invalid');
+  }
+  return {
+    robotId: required(input.robotId, 'robotId'),
+    category: required(input.category, 'category'),
+    eventType,
+    amountMYZ: nonNegative(input.amountMYZ, 'amountMYZ'),
+    postId: input.postId ? String(input.postId).trim() : null,
+    impressions: nonNegative(input.impressions, 'impressions'),
+    likes: nonNegative(input.likes, 'likes'),
+    comments: nonNegative(input.comments, 'comments'),
+    shares: nonNegative(input.shares, 'shares'),
+    occurredAt: input.occurredAt ? new Date(input.occurredAt) : new Date()
+  };
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function addMetric(target, event) {
+  target.revenueMYZ += event.eventType === 'revenue' ? event.amountMYZ : 0;
+  target.costMYZ += event.eventType === 'cost' ? event.amountMYZ : 0;
+  target.jobsCompleted += event.eventType === 'job_completed' ? 1 : 0;
+  target.impressions += event.impressions;
+  target.engagement += event.likes + (event.comments * 2) + (event.shares * 3);
+}
+
+function finalize(metric) {
+  const roiPercent = metric.costMYZ > 0
+    ? ((metric.revenueMYZ - metric.costMYZ) / metric.costMYZ) * 100
+    : null;
+  return {
+    ...metric,
+    revenueMYZ: round(metric.revenueMYZ),
+    costMYZ: round(metric.costMYZ),
+    roiPercent: roiPercent === null ? null : round(roiPercent),
+    engagementRate: metric.impressions > 0 ? round((metric.engagement / metric.impressions) * 100) : 0
+  };
+}
+
+function aggregate(events) {
+  const robots = new Map();
+  const categories = new Map();
+  const posts = new Map();
+  const seed = key => ({ key, revenueMYZ: 0, costMYZ: 0, jobsCompleted: 0, impressions: 0, engagement: 0 });
+
+  for (const event of events) {
+    if (!robots.has(event.robotId)) robots.set(event.robotId, seed(event.robotId));
+    if (!categories.has(event.category)) categories.set(event.category, seed(event.category));
+    addMetric(robots.get(event.robotId), event);
+    addMetric(categories.get(event.category), event);
+
+    if (event.postId) {
+      if (!posts.has(event.postId)) {
+        posts.set(event.postId, { postId: event.postId, robotId: event.robotId, category: event.category, impressions: 0, engagement: 0 });
+      }
+      const post = posts.get(event.postId);
+      post.impressions += event.impressions;
+      post.engagement += event.likes + (event.comments * 2) + (event.shares * 3);
+    }
+  }
+
+  const byRobot = [...robots.values()].map(finalize)
+    .sort((a, b) => b.revenueMYZ - a.revenueMYZ || b.engagement - a.engagement);
+  const byCategory = [...categories.values()].map(finalize)
+    .sort((a, b) => (b.roiPercent ?? -Infinity) - (a.roiPercent ?? -Infinity));
+  const topPosts = [...posts.values()].map(post => ({
+    ...post,
+    engagementRate: post.impressions ? round((post.engagement / post.impressions) * 100) : 0
+  })).sort((a, b) => b.engagement - a.engagement).slice(0, 10);
+
+  return { byRobot, byCategory, topPosts, totalEvents: events.length, generatedAt: new Date().toISOString() };
+}
+
+function createRobotAnalyticsService(store = {
+  create: data => RobotAnalyticsEvent.create(data).then(doc => doc.toObject()),
+  find: query => RobotAnalyticsEvent.find(query).sort({ occurredAt: -1 }).lean()
+}) {
+  async function record(input) {
+    return store.create(normalizeEvent(input));
+  }
+
+  async function report({ from, to } = {}) {
+    const query = {};
+    if (from || to) {
+      query.occurredAt = {};
+      if (from) query.occurredAt.$gte = new Date(from);
+      if (to) query.occurredAt.$lte = new Date(to);
+    }
+    return aggregate(await store.find(query));
+  }
+
+  async function csv(filters) {
+    const data = await report(filters);
+    const rows = [['robotId', 'revenueMYZ', 'costMYZ', 'roiPercent', 'jobsCompleted', 'engagement', 'engagementRate']];
+    for (const item of data.byRobot) {
+      rows.push([item.key, item.revenueMYZ, item.costMYZ, item.roiPercent ?? '', item.jobsCompleted, item.engagement, item.engagementRate]);
+    }
+    return rows.map(row => row.map(value => `"${String(value).replaceAll('"', '""')}"`).join(',')).join('\n');
+  }
+
+  return { record, report, csv };
+}
+
+module.exports = { AnalyticsValidationError, aggregate, createRobotAnalyticsService };

--- a/tests/robotAnalytics.test.js
+++ b/tests/robotAnalytics.test.js
@@ -1,0 +1,69 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { aggregate, createRobotAnalyticsService } = require('../services/robotAnalyticsService');
+const { createRobotAnalyticsRouter } = require('../routes/robotAnalytics');
+
+function memoryStore() {
+  const events = [];
+  return {
+    async create(event) { events.push(structuredClone(event)); return structuredClone(event); },
+    async find() { return structuredClone(events); }
+  };
+}
+
+function route(router, method, path, { body = {}, query = {} } = {}) {
+  const layer = router.stack.find(item => item.route?.path === path && item.route.methods[method]);
+  assert.ok(layer, `missing ${method} ${path}`);
+  return new Promise((resolve, reject) => {
+    const headers = {};
+    const res = {
+      statusCode: 200,
+      status(code) { this.statusCode = code; return this; },
+      set(key, value) { headers[key] = value; return this; },
+      json(payload) { resolve({ statusCode: this.statusCode, payload, headers }); },
+      send(payload) { resolve({ statusCode: this.statusCode, payload, headers }); }
+    };
+    Promise.resolve(layer.route.stack[0].handle({ body, query }, res, reject)).catch(reject);
+  });
+}
+
+describe('robot analytics', () => {
+  let service;
+
+  beforeEach(() => { service = createRobotAnalyticsService(memoryStore()); });
+
+  it('calculates robot and category ROI', async () => {
+    await service.record({ robotId: 'r1', category: 'logo', eventType: 'cost', amountMYZ: 20 });
+    await service.record({ robotId: 'r1', category: 'logo', eventType: 'revenue', amountMYZ: 50 });
+    await service.record({ robotId: 'r1', category: 'logo', eventType: 'job_completed' });
+    const report = await service.report();
+    assert.equal(report.byRobot[0].roiPercent, 150);
+    assert.equal(report.byCategory[0].jobsCompleted, 1);
+  });
+
+  it('ranks posts by weighted engagement', () => {
+    const report = aggregate([
+      { robotId: 'r1', category: 'social', eventType: 'post_engagement', amountMYZ: 0, postId: 'a', impressions: 100, likes: 5, comments: 1, shares: 0 },
+      { robotId: 'r2', category: 'social', eventType: 'post_engagement', amountMYZ: 0, postId: 'b', impressions: 100, likes: 2, comments: 2, shares: 2 }
+    ]);
+    assert.equal(report.topPosts[0].postId, 'b');
+    assert.equal(report.topPosts[0].engagement, 12);
+  });
+
+  it('exports a CSV report', async () => {
+    await service.record({ robotId: 'r1', category: 'code', eventType: 'revenue', amountMYZ: 12 });
+    const csv = await service.csv();
+    assert.match(csv, /robotId/);
+    assert.match(csv, /"r1","12"/);
+  });
+
+  it('exposes event, summary, and CSV routes', async () => {
+    const router = createRobotAnalyticsRouter(service);
+    const created = await route(router, 'post', '/events', { body: { robotId: 'r1', category: 'code', eventType: 'revenue', amountMYZ: 9 } });
+    assert.equal(created.statusCode, 201);
+    const summary = await route(router, 'get', '/summary');
+    assert.equal(summary.payload.data.totalEvents, 1);
+    const csv = await route(router, 'get', '/report.csv');
+    assert.equal(csv.headers['Content-Type'], 'text/csv; charset=utf-8');
+  });
+});


### PR DESCRIPTION
Closes #386

Adds persisted robot metric events, per-robot and category ROI, weighted post engagement rankings, CSV export, a responsive Chart.js dashboard, and configurable Google Analytics loading.

Validation: node --test tests/robotAnalytics.test.js (4 passed); frontend npm run build; syntax and diff checks passed.