### PR TITLE
Wire ErrorPage routes + add ErrorBoundary (Issue #149)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,16 +1,30 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Bounty from './pages/Bounty';
+import { ThemeProvider } from './contexts/ThemeContext';
+import ErrorBoundary from './components/ErrorBoundary';
 import Home from './pages/Home';
+import Bounty from './pages/Bounty';
+import ErrorPage from './pages/ErrorPage';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/bounty" element={<Bounty />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/bounty" element={<Bounty />} />
+            <Route path="/404" element={<ErrorPage type="404" />} />
+            <Route path="/500" element={<ErrorPage type="500" />} />
+            <Route path="/403" element={<ErrorPage type="403" />} />
+            <Route path="/rate-limit" element={<ErrorPage type="rate" />} />
+            <Route path="/maintenance" element={<ErrorPage type="maintenance" />} />
+            <Route path="/offline" element={<ErrorPage type="offline" />} />
+            <Route path="*" element={<ErrorPage type="404" />} />
+          </Routes>
+        </ErrorBoundary>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ErrorPage from '../pages/ErrorPage';
+
+/**
+ * Catches render-time errors anywhere in the route tree and shows the
+ * branded 500 error page instead of a blank white screen.
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error caught by ErrorBoundary:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorPage type="500" />;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

Implements **#149 — Error Pages Design** by making the already-present branded error pages actually reachable and resilient.

`frontend/src/pages/ErrorPage.jsx` already shipped high-fidelity, theme-aware error screens (404 / 500 / 403 / 429 rate-limit / 503 maintenance / offline) with SVG illustrations, glass-morphism, light/dark/system toggle and responsive layout. The gap was that nothing wired them in, so they could never be shown. This PR closes that gap:

### Changes
- **`frontend/src/App.jsx`**
  - Wrap the app in `ThemeProvider` (required — `ErrorPage` consumes `ThemeContext`, and without a provider it would crash on render).
  - Add dedicated routes: `/404`, `/500`, `/403`, `/rate-limit`, `/maintenance`, `/offline` → `<ErrorPage type="…" />`.
  - Add a catch-all `*` route that renders the 404 page for any unknown path.
- **`frontend/src/components/ErrorBoundary.jsx`** (new)
  - Class-based error boundary that catches uncaught render errors in the route tree and falls back to the branded **500** page instead of a blank screen — so the "Internal server error" page is actually functional, not just static.

### Notes
- Error pages meet the issue checklist: 404 / 500 / 403 / rate-limit / maintenance / offline, each with illustrations and responsive design.
- No visual redesign of `ErrorPage.jsx` itself was needed — it already satisfies the design deliverables; this PR is the functional wiring that makes it usable.
- Verified both files parse cleanly with `esbuild` (JSX → JS transform). Full `vite build` not run here (the 272 MB monorepo isn't cloned in this environment), but the changes are standard React Router v7 + Context wiring.

Closes #149

**XMR payout address (if any reward applies):** `44kLzNXHV9EDxHN948HsvhhEQpQY6iyE6LfgCbFz463JM1bpz3UtWwUTPuQJ25nMzuQmfjYiDcqYvN9uYkTp3v5J2E1hisp`
