### PR TITLE
Wire /api-docs route (Issue #147)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,16 +1,30 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Bounty from './pages/Bounty';
+import { ThemeProvider } from './contexts/ThemeContext';
+import ErrorBoundary from './components/ErrorBoundary';
 import Home from './pages/Home';
+import Bounty from './pages/Bounty';
+import ErrorPage from './pages/ErrorPage';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/bounty" element={<Bounty />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <ErrorBoundary>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/bounty" element={<Bounty />} />
+            <Route path="/404" element={<ErrorPage type="404" />} />
+            <Route path="/500" element={<ErrorPage type="500" />} />
+            <Route path="/403" element={<ErrorPage type="403" />} />
+            <Route path="/rate-limit" element={<ErrorPage type="rate" />} />
+            <Route path="/maintenance" element={<ErrorPage type="maintenance" />} />
+            <Route path="/offline" element={<ErrorPage type="offline" />} />
+            <Route path="*" element={<ErrorPage type="404" />} />
+          </Routes>
+        </ErrorBoundary>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import ErrorBoundary from './components/ErrorBoundary';
 import Home from './pages/Home';
 import Bounty from './pages/Bounty';
+import ApiDocs from './pages/ApiDocs';
 import ErrorPage from './pages/ErrorPage';
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/bounty" element={<Bounty />} />
+            <Route path="/api-docs" element={<ApiDocs />} />
             <Route path="/404" element={<ErrorPage type="404" />} />
             <Route path="/500" element={<ErrorPage type="500" />} />
             <Route path="/403" element={<ErrorPage type="403" />} />

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ErrorPage from '../pages/ErrorPage';
+
+/**
+ * Catches render-time errors anywhere in the route tree and shows the
+ * branded 500 error page instead of a blank white screen.
+ */
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught error caught by ErrorBoundary:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorPage type="500" />;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

Implements **#147 — API Documentation UI** by wiring the already-present, fully-featured API docs page into the router.

`frontend/src/pages/ApiDocs.jsx` already satisfies the issue checklist end-to-end:
- **Layout**: sidebar with endpoint groups + a main content column, clean and readable.
- **Endpoints**: each shown with a colour-coded method badge (GET/POST/PUT/PATCH/DELETE), path, description, and `auth`/`admin` flags.
- **Interactive examples**: expandable cards with `cURL` / `JavaScript` / `Python` tabs and a one-click copy button.
- **Search**: live filter across method + path + description + group.
- **Responsive**: collapsible sidebar with a mobile scrim.
- **Dark mode**: built-in light/dark/system theme toggle (uses the shared `ThemeContext`/`ThemeProvider`).

### Change
- **`frontend/src/App.jsx`**: add `import ApiDocs` and a `<Route path="/api-docs" element={<ApiDocs />} />`.

> Note: this branch is stacked on top of the #149 branch (PR #416), which adds the `ThemeProvider` wrapper that `ApiDocs` requires (it consumes `ThemeContext`). Until #416 is merged, this PR's diff vs `main` will also include the #149 changes; after #416 lands, the diff collapses to just the `/api-docs` route. No new UI code is needed — the page was already complete.
>
> Build sanity: `ApiDocs.jsx` imports `../data/apiEndpoints` and `../components/admin/admin.css`, both confirmed present in `main`, so the route resolves cleanly. Verified the JSX parses with `esbuild`.

Closes #147

**XMR payout address (if any reward applies):** `44kLzNXHV9EDxHN948HsvhhEQpQY6iyE6LfgCbFz463JM1bpz3UtWwUTPuQJ25nMzuQmfjYiDcqYvN9uYkTp3v5J2E1hisp`
