### PR TITLE
feat: add interbank CBDC settlement simulator

### DIFF
--- a/docs/interbank-settlement-simulator.md
+++ b/docs/interbank-settlement-simulator.md
@@ -1,0 +1,46 @@
+# Interbank Settlement Simulator
+
+The simulator models tokenized settlement with a Singapore-dollar CBDC. It is
+intended for local and integration testing; generated transaction hashes are
+deterministic simulation records and are not real on-chain transactions.
+
+## Flow
+
+1. Register participating banks with `POST /api/settlement/banks`.
+2. Issue CBDC with `POST /api/settlement/issue`.
+3. Create a transfer with `POST /api/settlement/transfers`.
+4. Settle it atomically with `POST /api/settlement/transfers/:id/settle`.
+5. Inspect balances, transfers, and contract calls with
+   `GET /api/settlement/report`.
+6. Redeem CBDC with `POST /api/settlement/redeem`.
+
+## Example
+
+```sh
+curl -X POST http://localhost:10000/api/settlement/banks \
+  -H "Content-Type: application/json" \
+  -d '{"bankId":"DBS","name":"DBS Bank"}'
+
+curl -X POST http://localhost:10000/api/settlement/issue \
+  -H "Content-Type: application/json" \
+  -d '{"bankId":"DBS","amount":1000000}'
+```
+
+Register a second bank, create a transfer, then send its `transferId` to the
+settlement endpoint. A failed settlement never changes either balance.
+
+## Smart-contract adapter
+
+By default the service uses `SimulatedContractAdapter`, which records issuance,
+redemption, and settlement calls with a contract address and transaction hash.
+Set `SETTLEMENT_CONTRACT_ADDRESS` to identify a deployed test contract. A real
+adapter can implement the same asynchronous `record(action, payload)` method
+and be injected into `SettlementSimulator` for testnet integration.
+
+## Validation
+
+```sh
+node --test tests/settlementSimulator.test.js
+node --check services/settlementSimulator.js
+node --check routes/settlement.js
+```

--- a/routes/settlement.js
+++ b/routes/settlement.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { SettlementSimulator } = require('../services/settlementSimulator');
+
+const router = express.Router();
+const simulator = new SettlementSimulator({ contractAddress: process.env.SETTLEMENT_CONTRACT_ADDRESS });
+
+function action(handler) {
+  return async (req, res) => {
+    try {
+      const data = await handler(req);
+      res.json({ success: true, data });
+    } catch (error) {
+      res.status(400).json({ success: false, error: error.message });
+    }
+  };
+}
+
+router.post('/banks', action(req => simulator.registerBank(req.body)));
+router.post('/issue', action(req => simulator.issue(req.body)));
+router.post('/redeem', action(req => simulator.redeem(req.body)));
+router.post('/transfers', action(req => simulator.createTransfer(req.body)));
+router.post('/transfers/:transferId/settle', action(req => simulator.settle(req.params.transferId)));
+router.get('/report', action(() => simulator.report()));
+
+router.simulator = simulator;
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ const contributorsRoutes = require('./routes/contributors');
 const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
-const xmrRoutes = require('./routes/xmr');
+const settlementRoutes = require('./routes/settlement');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -66,7 +66,7 @@ app.use('/api/contributors', contributorsRoutes);
 app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
-app.use('/api/xmr', xmrRoutes);
+app.use('/api/settlement', settlementRoutes);
 
 // Robot routes
 try {

--- a/services/settlementSimulator.js
+++ b/services/settlementSimulator.js
@@ -1,0 +1,173 @@
+const crypto = require('node:crypto');
+
+const DEFAULT_CURRENCY = 'SGD-CBDC';
+
+function positiveAmount(value) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error('amount must be a positive number');
+  }
+  return amount;
+}
+
+class SimulatedContractAdapter {
+  constructor(address = '0x000000000000000000000000000000000000CBDC') {
+    this.address = address;
+    this.calls = [];
+  }
+
+  async record(action, payload) {
+    const call = {
+      action,
+      payload,
+      contractAddress: this.address,
+      txHash: `0x${crypto.createHash('sha256')
+        .update(`${action}:${JSON.stringify(payload)}:${this.calls.length}`)
+        .digest('hex')}`,
+      recordedAt: new Date().toISOString()
+    };
+    this.calls.push(call);
+    return call;
+  }
+}
+
+class SettlementSimulator {
+  constructor(options = {}) {
+    this.currency = options.currency || DEFAULT_CURRENCY;
+    this.contract = options.contract || new SimulatedContractAdapter(options.contractAddress);
+    this.banks = new Map();
+    this.transfers = new Map();
+    this.ledger = [];
+    this.sequence = 0;
+  }
+
+  registerBank({ bankId, name, initialBalance = 0 }) {
+    if (!bankId || !name) throw new Error('bankId and name are required');
+    if (this.banks.has(bankId)) throw new Error('bank already registered');
+    const balance = Number(initialBalance);
+    if (!Number.isFinite(balance) || balance < 0) throw new Error('initialBalance must be non-negative');
+    const bank = { bankId, name, balance, currency: this.currency };
+    this.banks.set(bankId, bank);
+    return { ...bank };
+  }
+
+  async issue({ bankId, amount, reference }) {
+    const bank = this.requireBank(bankId);
+    const value = positiveAmount(amount);
+    bank.balance += value;
+    return this.recordLedger('ISSUE', { bankId, amount: value, reference },
+      await this.contract.record('issue', { bankId, amount: value, currency: this.currency }));
+  }
+
+  async redeem({ bankId, amount, reference }) {
+    const bank = this.requireBank(bankId);
+    const value = positiveAmount(amount);
+    if (bank.balance < value) throw new Error('insufficient CBDC balance');
+    bank.balance -= value;
+    return this.recordLedger('REDEEM', { bankId, amount: value, reference },
+      await this.contract.record('redeem', { bankId, amount: value, currency: this.currency }));
+  }
+
+  createTransfer({ fromBankId, toBankId, amount, assetId, reference }) {
+    if (fromBankId === toBankId) throw new Error('banks must be different');
+    this.requireBank(fromBankId);
+    this.requireBank(toBankId);
+    const value = positiveAmount(amount);
+    const transferId = `stl-${Date.now()}-${++this.sequence}`;
+    const transfer = {
+      transferId,
+      fromBankId,
+      toBankId,
+      amount: value,
+      currency: this.currency,
+      assetId: assetId || null,
+      reference: reference || null,
+      status: 'PENDING',
+      createdAt: new Date().toISOString()
+    };
+    this.transfers.set(transferId, transfer);
+    return { ...transfer };
+  }
+
+  async settle(transferId) {
+    const transfer = this.transfers.get(transferId);
+    if (!transfer) throw new Error('transfer not found');
+    if (transfer.status !== 'PENDING') throw new Error('transfer is not pending');
+    const sender = this.requireBank(transfer.fromBankId);
+    const receiver = this.requireBank(transfer.toBankId);
+    if (sender.balance < transfer.amount) {
+      transfer.status = 'FAILED';
+      transfer.failureReason = 'insufficient CBDC balance';
+      throw new Error(transfer.failureReason);
+    }
+
+    const contractCall = await this.contract.record('settle', {
+      transferId,
+      fromBankId: transfer.fromBankId,
+      toBankId: transfer.toBankId,
+      amount: transfer.amount,
+      assetId: transfer.assetId,
+      currency: this.currency
+    });
+
+    sender.balance -= transfer.amount;
+    receiver.balance += transfer.amount;
+    Object.assign(transfer, {
+      status: 'SETTLED',
+      settledAt: new Date().toISOString(),
+      contractAddress: contractCall.contractAddress,
+      txHash: contractCall.txHash
+    });
+    this.recordLedger('SETTLEMENT', { ...transfer }, contractCall);
+    return { ...transfer };
+  }
+
+  report() {
+    const settled = [...this.transfers.values()].filter(item => item.status === 'SETTLED');
+    const pending = [...this.transfers.values()].filter(item => item.status === 'PENDING');
+    const failed = [...this.transfers.values()].filter(item => item.status === 'FAILED');
+    return {
+      currency: this.currency,
+      generatedAt: new Date().toISOString(),
+      totals: {
+        banks: this.banks.size,
+        issued: this.totalFor('ISSUE'),
+        redeemed: this.totalFor('REDEEM'),
+        settled: settled.reduce((sum, item) => sum + item.amount, 0),
+        settledCount: settled.length,
+        pendingCount: pending.length,
+        failedCount: failed.length
+      },
+      balances: [...this.banks.values()].map(bank => ({ ...bank })),
+      transfers: [...this.transfers.values()].map(item => ({ ...item })),
+      contractCalls: this.contract.calls.map(call => ({ ...call }))
+    };
+  }
+
+  requireBank(bankId) {
+    const bank = this.banks.get(bankId);
+    if (!bank) throw new Error('bank not found');
+    return bank;
+  }
+
+  totalFor(type) {
+    return this.ledger
+      .filter(entry => entry.type === type)
+      .reduce((sum, entry) => sum + entry.amount, 0);
+  }
+
+  recordLedger(type, data, contractCall) {
+    const entry = {
+      ledgerId: `ledger-${++this.sequence}`,
+      type,
+      ...data,
+      txHash: contractCall.txHash,
+      contractAddress: contractCall.contractAddress,
+      createdAt: new Date().toISOString()
+    };
+    this.ledger.push(entry);
+    return { ...entry };
+  }
+}
+
+module.exports = { SettlementSimulator, SimulatedContractAdapter, DEFAULT_CURRENCY };

--- a/tests/settlementSimulator.test.js
+++ b/tests/settlementSimulator.test.js
@@ -1,0 +1,78 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { SettlementSimulator } = require('../services/settlementSimulator');
+
+describe('interbank settlement simulator', () => {
+  let simulator;
+
+  beforeEach(() => {
+    simulator = new SettlementSimulator();
+    simulator.registerBank({ bankId: 'MAS', name: 'Monetary Authority of Singapore' });
+    simulator.registerBank({ bankId: 'DBS', name: 'DBS Bank' });
+    simulator.registerBank({ bankId: 'OCBC', name: 'OCBC Bank' });
+  });
+
+  it('issues and redeems CBDC through the central-bank ledger', async () => {
+    const issue = await simulator.issue({ bankId: 'DBS', amount: 1000 });
+    const redeem = await simulator.redeem({ bankId: 'DBS', amount: 250 });
+
+    assert.equal(issue.type, 'ISSUE');
+    assert.equal(redeem.type, 'REDEEM');
+    assert.equal(simulator.report().balances.find(bank => bank.bankId === 'DBS').balance, 750);
+    assert.match(issue.txHash, /^0x[0-9a-f]{64}$/);
+  });
+
+  it('settles a bank transfer atomically and records the contract call', async () => {
+    await simulator.issue({ bankId: 'DBS', amount: 500 });
+    const transfer = simulator.createTransfer({
+      fromBankId: 'DBS', toBankId: 'OCBC', amount: 125, assetId: 'bond-sg-1'
+    });
+    const settled = await simulator.settle(transfer.transferId);
+    const report = simulator.report();
+
+    assert.equal(settled.status, 'SETTLED');
+    assert.equal(report.balances.find(bank => bank.bankId === 'DBS').balance, 375);
+    assert.equal(report.balances.find(bank => bank.bankId === 'OCBC').balance, 125);
+    assert.equal(report.totals.settled, 125);
+    assert.equal(report.totals.settledCount, 1);
+    assert.equal(report.contractCalls.at(-1).action, 'settle');
+  });
+
+  it('does not move funds when settlement fails', async () => {
+    const transfer = simulator.createTransfer({ fromBankId: 'DBS', toBankId: 'OCBC', amount: 1 });
+    await assert.rejects(() => simulator.settle(transfer.transferId), /insufficient/);
+    const report = simulator.report();
+
+    assert.equal(report.balances.find(bank => bank.bankId === 'DBS').balance, 0);
+    assert.equal(report.balances.find(bank => bank.bankId === 'OCBC').balance, 0);
+    assert.equal(report.totals.failedCount, 1);
+  });
+
+  it('rejects duplicate settlement and invalid redemption', async () => {
+    await simulator.issue({ bankId: 'DBS', amount: 10 });
+    const transfer = simulator.createTransfer({ fromBankId: 'DBS', toBankId: 'OCBC', amount: 5 });
+    await simulator.settle(transfer.transferId);
+
+    await assert.rejects(() => simulator.settle(transfer.transferId), /not pending/);
+    await assert.rejects(() => simulator.redeem({ bankId: 'DBS', amount: 6 }), /insufficient/);
+  });
+
+  it('produces a complete settlement report', async () => {
+    await simulator.issue({ bankId: 'DBS', amount: 200 });
+    await simulator.redeem({ bankId: 'DBS', amount: 20 });
+    const transfer = simulator.createTransfer({ fromBankId: 'DBS', toBankId: 'OCBC', amount: 50 });
+    await simulator.settle(transfer.transferId);
+    const report = simulator.report();
+
+    assert.deepEqual(report.totals, {
+      banks: 3,
+      issued: 200,
+      redeemed: 20,
+      settled: 50,
+      settledCount: 1,
+      pendingCount: 0,
+      failedCount: 0
+    });
+    assert.equal(report.currency, 'SGD-CBDC');
+  });
+});


### PR DESCRIPTION
Closes #375

Adds central-bank CBDC issuance/redemption, simulated interbank transfers with atomic settlement, a pluggable smart-contract adapter, settlement reporting, and test documentation.

Validation: node --test tests/settlementSimulator.test.js (5/5 passed); Node syntax checks and git diff check passed.