### PR TITLE
feat: add compliance oracle

### DIFF
--- a/docs/COMPLIANCE_ORACLE.md
+++ b/docs/COMPLIANCE_ORACLE.md
@@ -1,0 +1,35 @@
+# Compliance Oracle
+
+The compliance oracle aggregates sanctions, KYC and transaction-limit feeds, creates a deterministic snapshot root, and publishes it through a configurable relay to `ComplianceOracle.sol`.
+
+## Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `COMPLIANCE_SANCTIONS_URL` | JSON feed containing a `sanctions` address array |
+| `COMPLIANCE_KYC_URL` | JSON feed containing a `wallets` array |
+| `COMPLIANCE_LIMITS_URL` | JSON feed containing `transactionLimit` |
+| `COMPLIANCE_ORACLE_RELAY_URL` | Authenticated relay that submits the snapshot on-chain |
+| `COMPLIANCE_ORACLE_RELAY_TOKEN` | Bearer token for the relay |
+| `COMPLIANCE_REFRESH_MS` | Refresh interval; defaults to 15 minutes |
+
+Feed payloads may include all three fields. Wallet records use `{ "address", "kycApproved", "validUntil" }`. Amounts are decimal strings to avoid floating-point conversion.
+
+## API
+
+- `GET /api/compliance-oracle/status` returns freshness, root and publication status.
+- `GET /api/compliance-oracle/snapshot` returns the latest normalized snapshot.
+- `POST /api/compliance-oracle/refresh` triggers an immediate refresh.
+- `GET /api/compliance-oracle/verify/:address?amount=100` verifies a wallet and amount.
+
+The service rejects partial refreshes when any configured source fails. With no relay URL it runs in dry-run mode; a dry-run root is not an on-chain transaction and must never be presented as payment or settlement proof.
+
+## Smart-contract integration
+
+Deploy `gateway/contracts/ComplianceOracle.sol`, retain the deployer as the authorized oracle owner, and configure the relay to call `publishSnapshot` and `updateWallet`. Consumer contracts can call `verify(wallet, amount)` and receive an approval flag plus a stable rejection reason.
+
+Run the integration tests with:
+
+```bash
+node --test tests/complianceOracle.test.js
+```

--- a/gateway/contracts/ComplianceOracle.sol
+++ b/gateway/contracts/ComplianceOracle.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ComplianceOracle {
+    address public owner;
+    bytes32 public dataRoot;
+    uint256 public transactionLimit;
+    uint256 public updatedAt;
+
+    mapping(address => bool) public sanctioned;
+    mapping(address => uint256) public kycValidUntil;
+
+    event SnapshotPublished(bytes32 indexed dataRoot, uint256 transactionLimit, uint256 updatedAt);
+    event WalletComplianceUpdated(address indexed wallet, bool sanctioned, uint256 kycValidUntil);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not oracle owner");
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function publishSnapshot(bytes32 root, uint256 limit) external onlyOwner {
+        dataRoot = root;
+        transactionLimit = limit;
+        updatedAt = block.timestamp;
+        emit SnapshotPublished(root, limit, block.timestamp);
+    }
+
+    function updateWallet(address wallet, bool isSanctioned, uint256 validUntil) external onlyOwner {
+        sanctioned[wallet] = isSanctioned;
+        kycValidUntil[wallet] = validUntil;
+        emit WalletComplianceUpdated(wallet, isSanctioned, validUntil);
+    }
+
+    function verify(address wallet, uint256 amount) external view returns (bool, string memory) {
+        if (sanctioned[wallet]) return (false, "SANCTIONED");
+        if (kycValidUntil[wallet] < block.timestamp) return (false, "KYC_REQUIRED");
+        if (amount > transactionLimit) return (false, "TRANSACTION_LIMIT_EXCEEDED");
+        return (true, "APPROVED");
+    }
+}

--- a/routes/complianceOracle.js
+++ b/routes/complianceOracle.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const {
+  ComplianceOracle,
+  createHttpSource,
+  startComplianceOracleScheduler,
+} = require('../services/complianceOracleService');
+
+const router = express.Router();
+
+function jsonSource(name, envName) {
+  const url = process.env[envName];
+  return url ? createHttpSource({ name, url, mapResponse: (data) => data }) : null;
+}
+
+const sources = [
+  jsonSource('sanctions', 'COMPLIANCE_SANCTIONS_URL'),
+  jsonSource('kyc', 'COMPLIANCE_KYC_URL'),
+  jsonSource('limits', 'COMPLIANCE_LIMITS_URL'),
+].filter(Boolean);
+
+const publisher = {
+  async publish(snapshot) {
+    const relayUrl = process.env.COMPLIANCE_ORACLE_RELAY_URL;
+    if (!relayUrl) return { mode: 'dry-run', root: snapshot.root };
+    const response = await require('axios').post(relayUrl, {
+      root: snapshot.root,
+      transactionLimit: snapshot.transactionLimit,
+      wallets: snapshot.wallets,
+      sanctions: snapshot.sanctions,
+    }, {
+      headers: { authorization: `Bearer ${process.env.COMPLIANCE_ORACLE_RELAY_TOKEN || ''}` },
+      timeout: 15000,
+    });
+    return { mode: 'relay', transactionHash: response.data.transactionHash };
+  },
+};
+
+const oracle = new ComplianceOracle({ sources, publisher });
+if (sources.length) {
+  startComplianceOracleScheduler(oracle, Number(process.env.COMPLIANCE_REFRESH_MS) || 15 * 60 * 1000);
+}
+
+router.get('/status', (_req, res) => res.json({ success: true, data: oracle.status() }));
+
+router.get('/snapshot', (_req, res) => {
+  if (!oracle.snapshot) return res.status(503).json({ success: false, error: 'Oracle data is not available yet' });
+  return res.json({ success: true, data: oracle.snapshot });
+});
+
+router.post('/refresh', async (_req, res) => {
+  if (!sources.length) return res.status(503).json({ success: false, error: 'No compliance sources configured' });
+  try {
+    return res.json({ success: true, data: await oracle.refresh() });
+  } catch (error) {
+    return res.status(502).json({ success: false, error: error.message });
+  }
+});
+
+router.get('/verify/:address', (req, res) => {
+  try {
+    return res.json({ success: true, data: oracle.verify({ address: req.params.address, amount: req.query.amount || '0' }) });
+  } catch (error) {
+    return res.status(error.message.includes('not available') ? 503 : 400).json({ success: false, error: error.message });
+  }
+});
+
+module.exports = router;
+module.exports.oracle = oracle;

--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ const contributorsRoutes = require('./routes/contributors');
 const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
-const xmrRoutes = require('./routes/xmr');
+const complianceOracleRoutes = require('./routes/complianceOracle');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -66,7 +66,7 @@ app.use('/api/contributors', contributorsRoutes);
 app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
-app.use('/api/xmr', xmrRoutes);
+app.use('/api/compliance-oracle', complianceOracleRoutes);
 
 // Robot routes
 try {

--- a/services/complianceOracleService.js
+++ b/services/complianceOracleService.js
@@ -1,0 +1,147 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const DEFAULT_LIMIT = '10000';
+
+function stableHash(value) {
+  const normalize = (input) => {
+    if (Array.isArray(input)) return input.map(normalize);
+    if (input && typeof input === 'object') {
+      return Object.keys(input).sort().reduce((out, key) => {
+        out[key] = normalize(input[key]);
+        return out;
+      }, {});
+    }
+    return input;
+  };
+  return `0x${crypto.createHash('sha256').update(JSON.stringify(normalize(value))).digest('hex')}`;
+}
+
+function normalizeAddress(address) {
+  if (typeof address !== 'string' || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new Error(`Invalid wallet address: ${address}`);
+  }
+  return address.toLowerCase();
+}
+
+function createHttpSource({ name, url, mapResponse, headers = {} }) {
+  if (!name || !url || typeof mapResponse !== 'function') {
+    throw new Error('HTTP sources require name, url and mapResponse');
+  }
+  return {
+    name,
+    async fetch() {
+      const response = await axios.get(url, { headers, timeout: 15000 });
+      return mapResponse(response.data);
+    },
+  };
+}
+
+class ComplianceOracle {
+  constructor({ sources = [], publisher, clock = () => new Date(), defaultLimit = DEFAULT_LIMIT } = {}) {
+    if (!publisher || typeof publisher.publish !== 'function') {
+      throw new Error('A publisher with a publish(snapshot) method is required');
+    }
+    this.sources = sources;
+    this.publisher = publisher;
+    this.clock = clock;
+    this.defaultLimit = String(defaultLimit);
+    this.snapshot = null;
+    this.lastError = null;
+  }
+
+  async refresh() {
+    const results = await Promise.allSettled(this.sources.map(async (source) => ({
+      name: source.name,
+      data: await source.fetch(),
+    })));
+    const failures = results.filter((result) => result.status === 'rejected');
+    if (failures.length) {
+      const message = failures.map((failure) => failure.reason.message).join('; ');
+      this.lastError = message;
+      throw new Error(`Compliance source refresh failed: ${message}`);
+    }
+
+    const sanctions = new Set();
+    const wallets = new Map();
+    let transactionLimit = this.defaultLimit;
+    for (const result of results) {
+      const data = result.value.data || {};
+      for (const address of data.sanctions || []) sanctions.add(normalizeAddress(address));
+      for (const wallet of data.wallets || []) {
+        const address = normalizeAddress(wallet.address);
+        wallets.set(address, {
+          address,
+          kycApproved: Boolean(wallet.kycApproved),
+          validUntil: wallet.validUntil || null,
+        });
+      }
+      if (data.transactionLimit != null) transactionLimit = String(data.transactionLimit);
+    }
+
+    const generatedAt = this.clock().toISOString();
+    const snapshot = {
+      generatedAt,
+      sanctions: [...sanctions].sort(),
+      wallets: [...wallets.values()].sort((a, b) => a.address.localeCompare(b.address)),
+      transactionLimit,
+      sources: results.map((result) => result.value.name),
+    };
+    snapshot.root = stableHash(snapshot);
+    const publication = await this.publisher.publish(snapshot);
+    this.snapshot = { ...snapshot, publication };
+    this.lastError = null;
+    return this.snapshot;
+  }
+
+  verify({ address, amount = '0', at = this.clock() }) {
+    if (!this.snapshot) throw new Error('Oracle data is not available yet');
+    const normalized = normalizeAddress(address);
+    const wallet = this.snapshot.wallets.find((entry) => entry.address === normalized);
+    const sanctioned = this.snapshot.sanctions.includes(normalized);
+    const kycValid = Boolean(wallet && wallet.kycApproved && (!wallet.validUntil || new Date(wallet.validUntil) > at));
+    const withinLimit = Number(amount) <= Number(this.snapshot.transactionLimit);
+    const reasons = [];
+    if (sanctioned) reasons.push('SANCTIONED');
+    if (!kycValid) reasons.push('KYC_REQUIRED');
+    if (!withinLimit) reasons.push('TRANSACTION_LIMIT_EXCEEDED');
+    return {
+      address: normalized,
+      compliant: reasons.length === 0,
+      sanctioned,
+      kycValid,
+      withinLimit,
+      transactionLimit: this.snapshot.transactionLimit,
+      reasons,
+      oracleRoot: this.snapshot.root,
+      oracleUpdatedAt: this.snapshot.generatedAt,
+    };
+  }
+
+  status() {
+    return {
+      ready: Boolean(this.snapshot),
+      lastUpdatedAt: this.snapshot?.generatedAt || null,
+      root: this.snapshot?.root || null,
+      publication: this.snapshot?.publication || null,
+      lastError: this.lastError,
+    };
+  }
+}
+
+function startComplianceOracleScheduler(oracle, intervalMs = 15 * 60 * 1000) {
+  if (!Number.isFinite(intervalMs) || intervalMs < 1000) throw new Error('intervalMs must be at least 1000');
+  const run = () => oracle.refresh().catch((error) => console.error('Compliance oracle refresh failed:', error.message));
+  run();
+  const timer = setInterval(run, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
+module.exports = {
+  ComplianceOracle,
+  createHttpSource,
+  normalizeAddress,
+  stableHash,
+  startComplianceOracleScheduler,
+};

--- a/tests/complianceOracle.test.js
+++ b/tests/complianceOracle.test.js
@@ -1,0 +1,67 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { ComplianceOracle, stableHash } = require('../services/complianceOracleService');
+
+const APPROVED = '0x1111111111111111111111111111111111111111';
+const BLOCKED = '0x2222222222222222222222222222222222222222';
+
+function buildOracle(overrides = {}) {
+  const publications = [];
+  const oracle = new ComplianceOracle({
+    clock: () => new Date('2026-08-06T00:00:00.000Z'),
+    sources: [{
+      name: 'integration-fixture',
+      async fetch() {
+        return {
+          sanctions: [BLOCKED],
+          wallets: [
+            { address: APPROVED, kycApproved: true, validUntil: '2027-01-01T00:00:00.000Z' },
+            { address: BLOCKED, kycApproved: true, validUntil: '2027-01-01T00:00:00.000Z' },
+          ],
+          transactionLimit: '5000',
+        };
+      },
+    }],
+    publisher: { async publish(snapshot) { publications.push(snapshot); return { transactionHash: '0xtest' }; } },
+    ...overrides,
+  });
+  return { oracle, publications };
+}
+
+describe('ComplianceOracle integration', () => {
+  it('aggregates external data and publishes a deterministic root', async () => {
+    const { oracle, publications } = buildOracle();
+    const snapshot = await oracle.refresh();
+    assert.equal(publications.length, 1);
+    assert.equal(snapshot.root, publications[0].root);
+    assert.equal(snapshot.publication.transactionHash, '0xtest');
+    assert.match(snapshot.root, /^0x[a-f0-9]{64}$/);
+  });
+
+  it('approves a KYC wallet within its transaction limit', async () => {
+    const { oracle } = buildOracle();
+    await oracle.refresh();
+    assert.deepEqual(oracle.verify({ address: APPROVED, amount: '2500' }).reasons, []);
+  });
+
+  it('rejects sanctioned, unknown and over-limit wallets with explicit reasons', async () => {
+    const { oracle } = buildOracle();
+    await oracle.refresh();
+    assert.deepEqual(oracle.verify({ address: BLOCKED }).reasons, ['SANCTIONED']);
+    assert.deepEqual(oracle.verify({ address: '0x3333333333333333333333333333333333333333' }).reasons, ['KYC_REQUIRED']);
+    assert.deepEqual(oracle.verify({ address: APPROVED, amount: '5001' }).reasons, ['TRANSACTION_LIMIT_EXCEEDED']);
+  });
+
+  it('does not publish partial data when a source fails', async () => {
+    const { oracle, publications } = buildOracle({
+      sources: [{ name: 'broken', async fetch() { throw new Error('upstream unavailable'); } }],
+    });
+    await assert.rejects(oracle.refresh(), /upstream unavailable/);
+    assert.equal(publications.length, 0);
+    assert.equal(oracle.status().ready, false);
+  });
+
+  it('hashes equivalent objects consistently', () => {
+    assert.equal(stableHash({ b: 2, a: 1 }), stableHash({ a: 1, b: 2 }));
+  });
+});


### PR DESCRIPTION
Closes #373

Adds sanctions, KYC, and transaction-limit feed aggregation; scheduled refreshes; deterministic snapshot publication through a configurable on-chain relay; a Solidity verification contract; API endpoints; integration tests; and developer documentation.

Validation: node --test tests/complianceOracle.test.js (5 passed); syntax checks; git diff --check.