### PR TITLE
feat: add MYZ and XMR robot payments

### DIFF
--- a/docs/ROBOT_PAYMENTS.md
+++ b/docs/ROBOT_PAYMENTS.md
@@ -1,0 +1,27 @@
+# MYZ/XMR robot payments
+
+The robot payment API creates a unique wallet address for every order, waits for chain confirmations, holds funds in escrow, and releases or refunds them after the service outcome is known.
+
+## Wallet configuration
+
+| Variable | Description |
+| --- | --- |
+| `TARI_WALLET_URL` / `TARI_WALLET_TOKEN` | MYZ/Tari wallet RPC bridge |
+| `MONERO_WALLET_URL` / `MONERO_WALLET_TOKEN` | Monero wallet RPC bridge |
+| `MYZ_WEBHOOK_SECRET` / `XMR_WEBHOOK_SECRET` | HMAC secrets for confirmation webhooks |
+
+Wallet bridges implement `POST /addresses` and `POST /refunds`. They must keep private spend keys outside the gateway process. Production deployments should replace the in-memory store with a durable database-backed implementation of the same `save/get/list` interface.
+
+## Flow
+
+1. `POST /api/robot-payments` with `customerId`, `robotId`, `asset`, `amount`, and `refundAddress`.
+2. Send funds to the returned `paymentAddress`.
+3. The wallet bridge posts a signed confirmation to `/api/robot-payments/webhooks/MYZ` or `/XMR`.
+4. MYZ enters escrow after 3 confirmations; XMR enters escrow after 10.
+5. `POST /:id/release`, `/:id/dispute`, or `/:id/refund` completes the escrow flow.
+
+Webhook bodies contain `paymentId`, `transactionHash`, `confirmations`, and `amount`. The `x-webhook-signature` header is `sha256=` plus the hex HMAC-SHA256 of the raw JSON body.
+
+The dashboard is available at `/payments-dashboard.html`. Simulated hashes, API records and escrow states are not proof of an on-chain transfer or payment.
+
+Run integration tests with `node --test tests/robotPayments.test.js`.

--- a/frontend/public/payments-dashboard.html
+++ b/frontend/public/payments-dashboard.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Robot Payments</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, system-ui, sans-serif; color: #17202a; background: #f5f7f8; }
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+    header { background: #fff; border-bottom: 1px solid #dfe5e8; padding: 18px clamp(16px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; }
+    h1 { font-size: 20px; margin: 0; letter-spacing: 0; }
+    button { border: 1px solid #aeb9bf; background: #fff; width: 38px; height: 38px; cursor: pointer; font-size: 19px; }
+    main { padding: 24px clamp(16px, 4vw, 48px); overflow-x: auto; }
+    table { width: 100%; min-width: 760px; border-collapse: collapse; background: #fff; border: 1px solid #dfe5e8; }
+    th, td { padding: 12px 14px; border-bottom: 1px solid #e9edef; text-align: left; font-size: 14px; }
+    th { background: #eef2f3; font-size: 12px; text-transform: uppercase; color: #52616a; }
+    code { font-size: 12px; }
+    .empty { text-align: center; padding: 48px; color: #65747c; }
+    .status { font-weight: 700; }
+    .error { color: #a52828; }
+  </style>
+</head>
+<body>
+  <header><h1>Robot Payments</h1><button id="refresh" title="Refresh payments" aria-label="Refresh payments">↻</button></header>
+  <main><table><thead><tr><th>Created</th><th>Customer</th><th>Robot</th><th>Asset</th><th>Amount</th><th>Status</th><th>Transaction</th></tr></thead><tbody id="rows"><tr><td class="empty" colspan="7">Loading payments...</td></tr></tbody></table></main>
+  <script>
+    const rows = document.getElementById('rows');
+    const short = (value) => value ? `${value.slice(0, 10)}…${value.slice(-6)}` : '—';
+    const escapeHtml = (value) => String(value).replace(/[&<>"']/g, (character) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[character]));
+    async function load() {
+      try {
+        const response = await fetch('/api/robot-payments');
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.error || 'Request failed');
+        rows.innerHTML = payload.data.length ? payload.data.map((payment) => `<tr><td>${escapeHtml(new Date(payment.createdAt).toLocaleString())}</td><td>${escapeHtml(payment.customerId)}</td><td>${escapeHtml(payment.robotId)}</td><td>${escapeHtml(payment.asset)}</td><td>${escapeHtml(payment.amount)}</td><td class="status">${escapeHtml(payment.status)}</td><td><code title="${escapeHtml(payment.transactionHash || '')}">${escapeHtml(short(payment.transactionHash))}</code></td></tr>`).join('') : '<tr><td class="empty" colspan="7">No payments yet</td></tr>';
+      } catch (error) {
+        rows.innerHTML = `<tr><td class="empty error" colspan="7">${escapeHtml(error.message)}</td></tr>`;
+      }
+    }
+    document.getElementById('refresh').addEventListener('click', load);
+    load();
+  </script>
+</body>
+</html>

--- a/routes/robotPayments.js
+++ b/routes/robotPayments.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const {
+  MemoryPaymentStore,
+  RobotPaymentService,
+  createRpcWalletAdapter,
+  verifyWebhookSignature,
+} = require('../services/robotPaymentService');
+
+const router = express.Router();
+const store = new MemoryPaymentStore();
+const adapters = {};
+if (process.env.TARI_WALLET_URL) adapters.MYZ = createRpcWalletAdapter({ asset: 'MYZ', baseUrl: process.env.TARI_WALLET_URL, token: process.env.TARI_WALLET_TOKEN });
+if (process.env.MONERO_WALLET_URL) adapters.XMR = createRpcWalletAdapter({ asset: 'XMR', baseUrl: process.env.MONERO_WALLET_URL, token: process.env.MONERO_WALLET_TOKEN });
+const service = new RobotPaymentService({ adapters, store });
+
+function handle(res, action, successStatus = 200) {
+  return action.then((data) => res.status(successStatus).json({ success: true, data })).catch((error) => {
+    const status = error.message === 'Payment not found' ? 404 : 400;
+    return res.status(status).json({ success: false, error: error.message });
+  });
+}
+
+router.post('/', (req, res) => handle(res, service.createPayment(req.body), 201));
+router.get('/', (_req, res) => handle(res, store.list()));
+router.get('/:id', (req, res) => handle(res, service.requirePayment(req.params.id)));
+router.post('/:id/release', (req, res) => handle(res, service.release(req.params.id)));
+router.post('/:id/dispute', (req, res) => handle(res, service.dispute(req.params.id, req.body.reason)));
+router.post('/:id/refund', (req, res) => handle(res, service.refund(req.params.id, req.body.reason)));
+
+router.post('/webhooks/:asset', (req, res) => {
+  const asset = req.params.asset.toUpperCase();
+  const secret = process.env[`${asset}_WEBHOOK_SECRET`];
+  const rawBody = req.rawBody || Buffer.from(JSON.stringify(req.body));
+  if (!verifyWebhookSignature(rawBody, req.get('x-webhook-signature'), secret)) {
+    return res.status(401).json({ success: false, error: 'Invalid webhook signature' });
+  }
+  const payload = JSON.parse(rawBody.toString('utf8'));
+  return handle(res, service.recordConfirmation(payload));
+});
+
+module.exports = router;
+module.exports.service = service;

--- a/server.js
+++ b/server.js
@@ -32,7 +32,12 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(express.json());
+app.use(express.json({
+  verify: (req, _res, buffer) => {
+    req.rawBody = buffer;
+  }
+}));
+
 app.use(limiter);
 
 // Import routes - UNA SOLA VOLTA
@@ -44,7 +49,7 @@ const contributorsRoutes = require('./routes/contributors');
 const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
-const xmrRoutes = require('./routes/xmr');
+const robotPaymentRoutes = require('./routes/robotPayments');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -66,7 +71,7 @@ app.use('/api/contributors', contributorsRoutes);
 app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
-app.use('/api/xmr', xmrRoutes);
+app.use('/api/robot-payments', robotPaymentRoutes);
 
 // Robot routes
 try {

--- a/services/robotPaymentService.js
+++ b/services/robotPaymentService.js
@@ -1,0 +1,151 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const ASSETS = Object.freeze({
+  MYZ: { confirmations: 3 },
+  XMR: { confirmations: 10 },
+});
+
+class MemoryPaymentStore {
+  constructor() {
+    this.payments = new Map();
+  }
+  async save(payment) {
+    this.payments.set(payment.id, structuredClone(payment));
+    return structuredClone(payment);
+  }
+  async get(id) {
+    const payment = this.payments.get(id);
+    return payment ? structuredClone(payment) : null;
+  }
+  async list() {
+    return [...this.payments.values()].map((payment) => structuredClone(payment)).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+}
+
+function createRpcWalletAdapter({ asset, baseUrl, token }) {
+  if (!ASSETS[asset]) throw new Error(`Unsupported asset: ${asset}`);
+  if (!baseUrl) throw new Error(`${asset} wallet URL is required`);
+  const client = axios.create({
+    baseURL: baseUrl,
+    timeout: 15000,
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  return {
+    asset,
+    async createAddress(reference) {
+      const response = await client.post('/addresses', { reference });
+      if (!response.data?.address) throw new Error(`${asset} wallet did not return an address`);
+      return { address: response.data.address, walletReference: response.data.reference || reference };
+    },
+    async refund({ address, amount, reference }) {
+      const response = await client.post('/refunds', { address, amount, reference });
+      if (!response.data?.transactionHash) throw new Error(`${asset} wallet did not return a transaction hash`);
+      return { transactionHash: response.data.transactionHash };
+    },
+  };
+}
+
+function verifyWebhookSignature(rawBody, signature, secret) {
+  if (!secret || !signature) return false;
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  const provided = signature.replace(/^sha256=/, '');
+  if (provided.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+}
+
+class RobotPaymentService {
+  constructor({ adapters, store = new MemoryPaymentStore(), clock = () => new Date() }) {
+    this.adapters = adapters || {};
+    this.store = store;
+    this.clock = clock;
+  }
+
+  async createPayment({ customerId, robotId, asset, amount, refundAddress }) {
+    asset = String(asset || '').toUpperCase();
+    if (!customerId || !robotId) throw new Error('customerId and robotId are required');
+    if (!ASSETS[asset] || !this.adapters[asset]) throw new Error(`Unsupported asset: ${asset}`);
+    if (!Number.isFinite(Number(amount)) || Number(amount) <= 0) throw new Error('amount must be positive');
+    if (!refundAddress) throw new Error('refundAddress is required');
+
+    const id = crypto.randomUUID();
+    const wallet = await this.adapters[asset].createAddress(id);
+    return this.store.save({
+      id,
+      customerId,
+      robotId,
+      asset,
+      amount: String(amount),
+      refundAddress,
+      paymentAddress: wallet.address,
+      walletReference: wallet.walletReference,
+      status: 'AWAITING_PAYMENT',
+      confirmations: 0,
+      requiredConfirmations: ASSETS[asset].confirmations,
+      transactionHash: null,
+      refundTransactionHash: null,
+      createdAt: this.clock().toISOString(),
+      updatedAt: this.clock().toISOString(),
+    });
+  }
+
+  async recordConfirmation({ paymentId, transactionHash, confirmations, amount }) {
+    const payment = await this.requirePayment(paymentId);
+    if (!['AWAITING_PAYMENT', 'CONFIRMING'].includes(payment.status)) return payment;
+    if (!transactionHash) throw new Error('transactionHash is required');
+    if (Number(amount) < Number(payment.amount)) throw new Error('Payment amount is below the requested amount');
+
+    payment.transactionHash = transactionHash;
+    payment.confirmations = Math.max(payment.confirmations, Number(confirmations) || 0);
+    payment.status = payment.confirmations >= payment.requiredConfirmations ? 'IN_ESCROW' : 'CONFIRMING';
+    payment.updatedAt = this.clock().toISOString();
+    return this.store.save(payment);
+  }
+
+  async release(paymentId) {
+    const payment = await this.requirePayment(paymentId);
+    if (payment.status !== 'IN_ESCROW') throw new Error('Only escrowed payments can be released');
+    payment.status = 'RELEASED';
+    payment.releasedAt = this.clock().toISOString();
+    payment.updatedAt = payment.releasedAt;
+    return this.store.save(payment);
+  }
+
+  async refund(paymentId, reason) {
+    const payment = await this.requirePayment(paymentId);
+    if (!['IN_ESCROW', 'DISPUTED'].includes(payment.status)) throw new Error('Only escrowed or disputed payments can be refunded');
+    const result = await this.adapters[payment.asset].refund({
+      address: payment.refundAddress,
+      amount: payment.amount,
+      reference: payment.id,
+    });
+    payment.status = 'REFUNDED';
+    payment.refundReason = reason || 'dispute resolved in customer favour';
+    payment.refundTransactionHash = result.transactionHash;
+    payment.updatedAt = this.clock().toISOString();
+    return this.store.save(payment);
+  }
+
+  async dispute(paymentId, reason) {
+    const payment = await this.requirePayment(paymentId);
+    if (payment.status !== 'IN_ESCROW') throw new Error('Only escrowed payments can be disputed');
+    payment.status = 'DISPUTED';
+    payment.disputeReason = reason || 'not specified';
+    payment.updatedAt = this.clock().toISOString();
+    return this.store.save(payment);
+  }
+
+  async requirePayment(id) {
+    const payment = await this.store.get(id);
+    if (!payment) throw new Error('Payment not found');
+    return payment;
+  }
+}
+
+module.exports = {
+  ASSETS,
+  MemoryPaymentStore,
+  RobotPaymentService,
+  createRpcWalletAdapter,
+  verifyWebhookSignature,
+};

--- a/tests/robotPayments.test.js
+++ b/tests/robotPayments.test.js
@@ -1,0 +1,72 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const {
+  MemoryPaymentStore,
+  RobotPaymentService,
+  verifyWebhookSignature,
+} = require('../services/robotPaymentService');
+
+function fixture() {
+  const refunds = [];
+  const adapter = {
+    async createAddress(reference) { return { address: `wallet-${reference}`, walletReference: reference }; },
+    async refund(request) { refunds.push(request); return { transactionHash: 'refund-tx' }; },
+  };
+  const service = new RobotPaymentService({
+    adapters: { MYZ: adapter, XMR: adapter },
+    store: new MemoryPaymentStore(),
+    clock: () => new Date('2026-08-06T00:00:00.000Z'),
+  });
+  return { service, refunds };
+}
+
+async function create(service, asset = 'MYZ') {
+  return service.createPayment({ customerId: 'customer-1', robotId: 'robot-1', asset, amount: '25', refundAddress: 'refund-address' });
+}
+
+describe('robot payment integration', () => {
+  it('creates a unique temporary address', async () => {
+    const { service } = fixture();
+    const payment = await create(service);
+    assert.equal(payment.status, 'AWAITING_PAYMENT');
+    assert.match(payment.paymentAddress, /^wallet-/);
+  });
+
+  it('holds confirmed MYZ in escrow and releases it', async () => {
+    const { service } = fixture();
+    const payment = await create(service);
+    const confirming = await service.recordConfirmation({ paymentId: payment.id, transactionHash: 'myz-tx', confirmations: 2, amount: '25' });
+    assert.equal(confirming.status, 'CONFIRMING');
+    const escrowed = await service.recordConfirmation({ paymentId: payment.id, transactionHash: 'myz-tx', confirmations: 3, amount: '25' });
+    assert.equal(escrowed.status, 'IN_ESCROW');
+    assert.equal((await service.release(payment.id)).status, 'RELEASED');
+  });
+
+  it('requires ten confirmations for XMR', async () => {
+    const { service } = fixture();
+    const payment = await create(service, 'XMR');
+    assert.equal((await service.recordConfirmation({ paymentId: payment.id, transactionHash: 'xmr-tx', confirmations: 9, amount: '25' })).status, 'CONFIRMING');
+    assert.equal((await service.recordConfirmation({ paymentId: payment.id, transactionHash: 'xmr-tx', confirmations: 10, amount: '25' })).status, 'IN_ESCROW');
+  });
+
+  it('refunds a disputed escrow payment through its wallet adapter', async () => {
+    const { service, refunds } = fixture();
+    const payment = await create(service);
+    await service.recordConfirmation({ paymentId: payment.id, transactionHash: 'myz-tx', confirmations: 3, amount: '25' });
+    await service.dispute(payment.id, 'service not delivered');
+    const refunded = await service.refund(payment.id, 'approved');
+    assert.equal(refunded.refundTransactionHash, 'refund-tx');
+    assert.equal(refunds.length, 1);
+  });
+
+  it('rejects underpayments and forged webhooks', async () => {
+    const { service } = fixture();
+    const payment = await create(service);
+    await assert.rejects(service.recordConfirmation({ paymentId: payment.id, transactionHash: 'tx', confirmations: 3, amount: '24' }), /below/);
+    const body = Buffer.from('{"paymentId":"1"}');
+    const valid = crypto.createHmac('sha256', 'secret').update(body).digest('hex');
+    assert.equal(verifyWebhookSignature(body, `sha256=${valid}`, 'secret'), true);
+    assert.equal(verifyWebhookSignature(body, `sha256=${'0'.repeat(64)}`, 'secret'), false);
+  });
+});


### PR DESCRIPTION
Closes #382

Adds pluggable MYZ/XMR wallet adapters, unique order addresses, signed confirmation webhooks, asset-specific confirmation thresholds, escrow release/dispute/refund flows, transaction APIs, a responsive dashboard, tests, and deployment documentation.

Validation: node --test tests/robotPayments.test.js (5 passed); frontend production build; syntax checks; git diff --check.