### PR TITLE
feat: add GL1 cross-border bridge

### DIFF
--- a/docs/GL1_BRIDGE.md
+++ b/docs/GL1_BRIDGE.md
@@ -1,0 +1,19 @@
+# GL1 cross-border bridge
+
+The GL1 bridge converts between MYZ and configured GL1 assets through expiring quotes and an auditable lock/issue state machine. Source funds are unlocked automatically if destination issuance fails.
+
+## API
+
+- `POST /api/gl1/quotes` accepts `direction`, `amount`, and `gl1Asset`.
+- `POST /api/gl1/transfers` accepts the quote, `sender`, `beneficiary`, and an `idempotencyKey`.
+- `GET /api/gl1/transfers` and `/api/gl1/transfers/:id` expose status and audit events.
+
+Directions are `MYZ_TO_GL1` and `GL1_TO_MYZ`. Amounts are transported as decimal strings. Idempotency keys must be stable per customer order.
+
+## Configuration
+
+Set `GL1_API_URL` and `GL1_API_TOKEN` for the institutional GL1 endpoint. Set `GL1_SIMULATOR=true` for local integration tests. Production deployments must replace `MyzLedgerSimulator` and the in-memory transfer store with authenticated Tari and durable database adapters before handling funds.
+
+The GL1 client expects `/v1/quotes`, `/v1/locks`, `/v1/mints`, and `/v1/unlocks`. Every successful lock and issuance must return a unique identifier. A simulated identifier is not an on-chain transaction or proof of settlement.
+
+Run the integration suite with `node --test tests/gl1Bridge.test.js`.

--- a/routes/gl1Bridge.js
+++ b/routes/gl1Bridge.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { Gl1BridgeService, MemoryTransferStore, createGl1Client } = require('../services/gl1BridgeService');
+const { Gl1Simulator, MyzLedgerSimulator } = require('../services/gl1Simulator');
+
+const router = express.Router();
+const simulated = process.env.GL1_SIMULATOR === 'true' || !process.env.GL1_API_URL;
+const gl1 = simulated ? new Gl1Simulator() : createGl1Client({ baseUrl: process.env.GL1_API_URL, token: process.env.GL1_API_TOKEN });
+const myzLedger = new MyzLedgerSimulator();
+const store = new MemoryTransferStore();
+const service = new Gl1BridgeService({ gl1, myzLedger, store });
+
+router.post('/quotes', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.quote(req.body) }); }
+  catch (error) { return res.status(400).json({ success: false, error: error.message }); }
+});
+router.post('/transfers', async (req, res) => {
+  try { return res.status(201).json({ success: true, simulated, data: await service.createTransfer(req.body) }); }
+  catch (error) { return res.status(502).json({ success: false, error: error.message }); }
+});
+router.get('/transfers', async (_req, res) => res.json({ success: true, simulated, data: await store.list() }));
+router.get('/transfers/:id', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.requireTransfer(req.params.id) }); }
+  catch (error) { return res.status(404).json({ success: false, error: error.message }); }
+});
+
+module.exports = router;
+module.exports.service = service;

--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ const contributorsRoutes = require('./routes/contributors');
 const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
-const xmrRoutes = require('./routes/xmr');
+const gl1BridgeRoutes = require('./routes/gl1Bridge');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -66,7 +66,7 @@ app.use('/api/contributors', contributorsRoutes);
 app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
-app.use('/api/xmr', xmrRoutes);
+app.use('/api/gl1', gl1BridgeRoutes);
 
 // Robot routes
 try {

--- a/services/gl1BridgeService.js
+++ b/services/gl1BridgeService.js
@@ -1,0 +1,142 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const TERMINAL_STATES = new Set(['COMPLETED', 'REFUNDED', 'FAILED']);
+
+class MemoryTransferStore {
+  constructor() { this.items = new Map(); }
+  async save(transfer) { this.items.set(transfer.id, structuredClone(transfer)); return structuredClone(transfer); }
+  async get(id) { const item = this.items.get(id); return item ? structuredClone(item) : null; }
+  async list() { return [...this.items.values()].map((item) => structuredClone(item)); }
+}
+
+function createGl1Client({ baseUrl, token }) {
+  if (!baseUrl) throw new Error('GL1_API_URL is required');
+  const client = axios.create({
+    baseURL: baseUrl,
+    timeout: 15000,
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  return {
+    async quote(request) { return (await client.post('/v1/quotes', request)).data; },
+    async lock(request) { return (await client.post('/v1/locks', request)).data; },
+    async mint(request) { return (await client.post('/v1/mints', request)).data; },
+    async unlock(request) { return (await client.post('/v1/unlocks', request)).data; },
+  };
+}
+
+class Gl1BridgeService {
+  constructor({ gl1, myzLedger, store = new MemoryTransferStore(), clock = () => new Date() }) {
+    if (!gl1 || !myzLedger) throw new Error('GL1 and MYZ ledger adapters are required');
+    this.gl1 = gl1;
+    this.myzLedger = myzLedger;
+    this.store = store;
+    this.clock = clock;
+  }
+
+  async quote({ direction, amount, gl1Asset }) {
+    this.validateAmount(amount);
+    if (!['MYZ_TO_GL1', 'GL1_TO_MYZ'].includes(direction)) throw new Error('Unsupported direction');
+    if (!gl1Asset) throw new Error('gl1Asset is required');
+    const quote = await this.gl1.quote({ direction, amount: String(amount), sourceAsset: direction === 'MYZ_TO_GL1' ? 'MYZ' : gl1Asset, targetAsset: direction === 'MYZ_TO_GL1' ? gl1Asset : 'MYZ' });
+    if (!quote?.id || !quote?.rate || !quote?.expiresAt) throw new Error('GL1 returned an invalid quote');
+    return quote;
+  }
+
+  async createTransfer({ quote, sender, beneficiary, idempotencyKey }) {
+    if (!quote?.id || !quote.direction) throw new Error('A complete quote is required');
+    if (!sender || !beneficiary) throw new Error('sender and beneficiary are required');
+    if (!idempotencyKey) throw new Error('idempotencyKey is required');
+    const existing = (await this.store.list()).find((item) => item.idempotencyKey === idempotencyKey);
+    if (existing) return existing;
+    if (new Date(quote.expiresAt) <= this.clock()) throw new Error('Quote has expired');
+
+    const transfer = {
+      id: crypto.randomUUID(),
+      idempotencyKey,
+      quote,
+      sender,
+      beneficiary,
+      state: 'CREATED',
+      sourceLockId: null,
+      destinationTransactionId: null,
+      audit: [],
+      createdAt: this.clock().toISOString(),
+      updatedAt: this.clock().toISOString(),
+    };
+    this.record(transfer, 'CREATED');
+    await this.store.save(transfer);
+    return this.execute(transfer.id);
+  }
+
+  async execute(id) {
+    const transfer = await this.requireTransfer(id);
+    if (TERMINAL_STATES.has(transfer.state)) return transfer;
+    try {
+      if (transfer.state === 'CREATED') await this.lockSource(transfer);
+      if (transfer.state === 'SOURCE_LOCKED') await this.issueDestination(transfer);
+      if (transfer.state === 'DESTINATION_ISSUED') {
+        transfer.state = 'COMPLETED';
+        this.record(transfer, 'COMPLETED');
+        await this.store.save(transfer);
+      }
+      return transfer;
+    } catch (error) {
+      transfer.error = error.message;
+      if (transfer.state === 'SOURCE_LOCKED') {
+        await this.rollback(transfer);
+      } else {
+        transfer.state = 'FAILED';
+        this.record(transfer, 'FAILED', { error: error.message });
+      }
+      await this.store.save(transfer);
+      throw error;
+    }
+  }
+
+  async lockSource(transfer) {
+    const request = { reference: transfer.id, sender: transfer.sender, amount: transfer.quote.sourceAmount };
+    const lock = transfer.quote.direction === 'MYZ_TO_GL1' ? await this.myzLedger.lock(request) : await this.gl1.lock({ ...request, asset: transfer.quote.sourceAsset });
+    if (!lock?.lockId) throw new Error('Source ledger did not return a lock ID');
+    transfer.sourceLockId = lock.lockId;
+    transfer.state = 'SOURCE_LOCKED';
+    this.record(transfer, 'SOURCE_LOCKED', { lockId: lock.lockId });
+    await this.store.save(transfer);
+  }
+
+  async issueDestination(transfer) {
+    const request = { reference: transfer.id, beneficiary: transfer.beneficiary, amount: transfer.quote.targetAmount, sourceLockId: transfer.sourceLockId };
+    const issued = transfer.quote.direction === 'MYZ_TO_GL1' ? await this.gl1.mint({ ...request, asset: transfer.quote.targetAsset }) : await this.myzLedger.mint(request);
+    if (!issued?.transactionId) throw new Error('Destination ledger did not return a transaction ID');
+    transfer.destinationTransactionId = issued.transactionId;
+    transfer.state = 'DESTINATION_ISSUED';
+    this.record(transfer, 'DESTINATION_ISSUED', { transactionId: issued.transactionId });
+    await this.store.save(transfer);
+  }
+
+  async rollback(transfer) {
+    const request = { reference: transfer.id, lockId: transfer.sourceLockId };
+    if (transfer.quote.direction === 'MYZ_TO_GL1') await this.myzLedger.unlock(request);
+    else await this.gl1.unlock({ ...request, asset: transfer.quote.sourceAsset });
+    transfer.state = 'REFUNDED';
+    this.record(transfer, 'REFUNDED', { reason: transfer.error });
+  }
+
+  async requireTransfer(id) {
+    const transfer = await this.store.get(id);
+    if (!transfer) throw new Error('Transfer not found');
+    return transfer;
+  }
+
+  record(transfer, state, details = {}) {
+    const timestamp = this.clock().toISOString();
+    transfer.updatedAt = timestamp;
+    transfer.audit.push({ state, timestamp, ...details });
+  }
+
+  validateAmount(amount) {
+    if (!Number.isFinite(Number(amount)) || Number(amount) <= 0) throw new Error('amount must be positive');
+  }
+}
+
+module.exports = { Gl1BridgeService, MemoryTransferStore, createGl1Client };

--- a/services/gl1Simulator.js
+++ b/services/gl1Simulator.js
@@ -1,0 +1,25 @@
+class Gl1Simulator {
+  constructor({ rate = 1.25, failMint = false, clock = () => new Date() } = {}) {
+    this.rate = rate;
+    this.failMint = failMint;
+    this.clock = clock;
+    this.locks = new Map();
+  }
+  async quote({ direction, amount, sourceAsset, targetAsset }) {
+    const sourceAmount = String(amount);
+    const targetAmount = String(direction === 'MYZ_TO_GL1' ? Number(amount) * this.rate : Number(amount) / this.rate);
+    return { id: `quote-${this.locks.size + 1}`, direction, sourceAsset, targetAsset, sourceAmount, targetAmount, rate: String(this.rate), expiresAt: new Date(this.clock().getTime() + 60000).toISOString() };
+  }
+  async lock(request) { const lockId = `gl1-lock-${this.locks.size + 1}`; this.locks.set(lockId, request); return { lockId }; }
+  async mint(request) { if (this.failMint) throw new Error('GL1 simulator mint failure'); return { transactionId: `gl1-tx-${request.reference}` }; }
+  async unlock({ lockId }) { this.locks.delete(lockId); return { unlocked: true }; }
+}
+
+class MyzLedgerSimulator {
+  constructor({ failMint = false } = {}) { this.failMint = failMint; this.locks = new Map(); }
+  async lock(request) { const lockId = `myz-lock-${this.locks.size + 1}`; this.locks.set(lockId, request); return { lockId }; }
+  async mint(request) { if (this.failMint) throw new Error('MYZ simulator mint failure'); return { transactionId: `myz-tx-${request.reference}` }; }
+  async unlock({ lockId }) { this.locks.delete(lockId); return { unlocked: true }; }
+}
+
+module.exports = { Gl1Simulator, MyzLedgerSimulator };

--- a/tests/gl1Bridge.test.js
+++ b/tests/gl1Bridge.test.js
@@ -1,0 +1,55 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { Gl1BridgeService } = require('../services/gl1BridgeService');
+const { Gl1Simulator, MyzLedgerSimulator } = require('../services/gl1Simulator');
+
+const clock = () => new Date('2026-08-06T12:00:00.000Z');
+function fixture(options = {}) {
+  const gl1 = new Gl1Simulator({ clock, ...options.gl1 });
+  const myzLedger = new MyzLedgerSimulator(options.myz);
+  return { service: new Gl1BridgeService({ gl1, myzLedger, clock }), gl1, myzLedger };
+}
+
+async function quote(service, direction = 'MYZ_TO_GL1') {
+  return service.quote({ direction, amount: '100', gl1Asset: 'GL1-SGD' });
+}
+
+describe('GL1 bridge integration', () => {
+  it('returns an expiring MYZ/GL1 conversion quote', async () => {
+    const { service } = fixture();
+    const result = await quote(service);
+    assert.equal(result.sourceAsset, 'MYZ');
+    assert.equal(result.targetAmount, '125');
+  });
+
+  it('locks MYZ and issues the GL1 destination asset atomically', async () => {
+    const { service, myzLedger } = fixture();
+    const result = await service.createTransfer({ quote: await quote(service), sender: 'myz-a', beneficiary: 'gl1-b', idempotencyKey: 'order-1' });
+    assert.equal(result.state, 'COMPLETED');
+    assert.equal(myzLedger.locks.size, 1);
+    assert.deepEqual(result.audit.map((event) => event.state), ['CREATED', 'SOURCE_LOCKED', 'DESTINATION_ISSUED', 'COMPLETED']);
+  });
+
+  it('supports GL1 to MYZ transfers', async () => {
+    const { service, gl1 } = fixture();
+    const result = await service.createTransfer({ quote: await quote(service, 'GL1_TO_MYZ'), sender: 'gl1-a', beneficiary: 'myz-b', idempotencyKey: 'order-2' });
+    assert.equal(result.state, 'COMPLETED');
+    assert.equal(gl1.locks.size, 1);
+  });
+
+  it('unlocks source funds when destination issuance fails', async () => {
+    const { service, myzLedger } = fixture({ gl1: { failMint: true } });
+    await assert.rejects(service.createTransfer({ quote: await quote(service), sender: 'myz-a', beneficiary: 'gl1-b', idempotencyKey: 'order-3' }), /mint failure/);
+    assert.equal(myzLedger.locks.size, 0);
+    assert.equal((await service.store.list())[0].state, 'REFUNDED');
+  });
+
+  it('uses idempotency keys to prevent duplicate cross-border transfers', async () => {
+    const { service } = fixture();
+    const request = { quote: await quote(service), sender: 'myz-a', beneficiary: 'gl1-b', idempotencyKey: 'same-order' };
+    const first = await service.createTransfer(request);
+    const second = await service.createTransfer(request);
+    assert.equal(first.id, second.id);
+    assert.equal((await service.store.list()).length, 1);
+  });
+});


### PR DESCRIPTION
Closes #370

Adds a GL1 API client, expiring MYZ/GL1 quotes, idempotent atomic lock/issue transfers, automatic source unlock on failure, a local GL1 simulator, integration tests, APIs, and developer documentation. It also removes the duplicate XMR route declaration currently preventing server.js from parsing.

Validation: node --test tests/gl1Bridge.test.js (5 passed); syntax checks; git diff --check.