### PR TITLE
feat: enhance Urban Garden Dashboard with real-time charts, export, and responsive design (Closes #746) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/frontend/src/pages/UrbanGardenDashboard.css
+++ b/frontend/src/pages/UrbanGardenDashboard.css
@@ -1,142 +1,494 @@
 .urban-garden-dashboard {
   padding: 20px;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
-  font-family: 'Segoe UI', sans-serif;
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  color: #2c3e50;
 }
 
 .dashboard-header {
-  text-align: center;
-  margin-bottom: 30px;
-  padding: 20px;
+  margin-bottom: 24px;
+  padding: 24px 28px;
   background: linear-gradient(135deg, #2ecc71, #27ae60);
-  border-radius: 12px;
+  border-radius: 14px;
   color: white;
 }
 
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
 .dashboard-header h1 {
-  font-size: 2.5rem;
+  font-size: 2rem;
   margin: 0;
+  line-height: 1.2;
 }
 
 .dashboard-header p {
-  margin: 10px 0 0;
-  opacity: 0.9;
+  margin: 6px 0 0;
+  opacity: 0.85;
+  font-size: 0.95rem;
 }
 
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.garden-select {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.garden-select select {
+  padding: 6px 10px;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  font-size: 0.85rem;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.garden-select select option {
+  color: #2c3e50;
+  background: white;
+}
+
+.live-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 20px;
+  background: rgba(255,255,255,0.12);
+  color: white;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.live-toggle:hover {
+  background: rgba(255,255,255,0.25);
+}
+
+.live-toggle.active {
+  background: rgba(255,255,255,0.2);
+  border-color: rgba(255,255,255,0.5);
+}
+
+.live-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ecc71;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.live-toggle:not(.active) .live-dot {
+  background: #f39c12;
+  animation: none;
+}
+
+.export-btn {
+  padding: 6px 14px;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.export-btn:hover:not(:disabled) {
+  background: rgba(255,255,255,0.3);
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.last-updated {
+  margin-top: 10px;
+  font-size: 0.78rem;
+  opacity: 0.7;
+}
+
+/* Error banner */
+.error-banner {
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 10px;
+  color: #856404;
+  font-size: 0.9rem;
+}
+
+/* Stats grid */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 20px;
-  margin-bottom: 30px;
+  gap: 16px;
+  margin-bottom: 24px;
 }
 
 .stat-card {
   padding: 20px;
-  border-radius: 12px;
+  border-radius: 14px;
   text-align: center;
   color: white;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 
-.stat-card.ph {
-  background: linear-gradient(135deg, #3498db, #2980b9);
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.12);
 }
 
-.stat-card.ec {
-  background: linear-gradient(135deg, #9b59b6, #8e44ad);
-}
-
-.stat-card.temperature {
-  background: linear-gradient(135deg, #e74c3c, #c0392b);
-}
-
-.stat-card.humidity {
-  background: linear-gradient(135deg, #1abc9c, #16a085);
-}
+.stat-card.ph { background: linear-gradient(135deg, #3498db, #2980b9); }
+.stat-card.ec { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
+.stat-card.temperature { background: linear-gradient(135deg, #e74c3c, #c0392b); }
+.stat-card.humidity { background: linear-gradient(135deg, #1abc9c, #16a085); }
 
 .stat-card h3 {
-  margin: 0 0 10px;
-  font-size: 0.9rem;
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
   opacity: 0.9;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .stat-card .value {
-  font-size: 2.5rem;
-  font-weight: bold;
+  font-size: 2.2rem;
+  font-weight: 700;
+  line-height: 1.2;
 }
 
 .stat-card .range {
-  font-size: 0.8rem;
-  opacity: 0.8;
+  font-size: 0.75rem;
+  opacity: 0.75;
   margin-top: 8px;
 }
 
-.history-section, .stats-section {
+/* Charts section */
+.charts-section {
   background: white;
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 20px;
-  margin-bottom: 20px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  margin-bottom: 24px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  border: 1px solid #f0f0f0;
 }
 
-.history-section h2, .stats-section h2 {
-  margin-top: 0;
+.charts-section h2 {
+  margin: 0 0 16px;
+  font-size: 1.1rem;
   color: #2c3e50;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 20px;
+}
+
+.chart-wrap {
+  padding: 12px 12px 4px;
+  border-radius: 10px;
+  background: #fafafa;
+  border: 1px solid #eee;
+}
+
+.chart-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 8px;
+}
+
+.chart-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.chart-latest {
+  margin-left: auto;
+  font-size: 0.95rem;
+  color: #2c3e50;
+}
+
+.chart-empty {
+  padding: 40px;
+  text-align: center;
+  color: #999;
+  font-size: 0.85rem;
+}
+
+.metric-chart {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.chart-gridline {
+  stroke: #e0e0e0;
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+}
+
+.chart-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  color: #999;
+  padding: 2px 4px 0;
+}
+
+/* History section */
+.history-section {
+  background: white;
+  border-radius: 14px;
+  padding: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  border: 1px solid #f0f0f0;
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.section-head h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #2c3e50;
+}
+
+.record-count {
+  font-size: 0.8rem;
+  color: #999;
+  background: #f5f5f5;
+  padding: 4px 10px;
+  border-radius: 12px;
 }
 
 .table-container {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
+  font-size: 0.9rem;
 }
 
 table th {
   background: #f8f9fa;
-  padding: 12px;
+  padding: 12px 14px;
   text-align: left;
   font-weight: 600;
-  color: #2c3e50;
+  color: #555;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  border-bottom: 2px solid #e8e8e8;
+  white-space: nowrap;
 }
 
 table td {
-  padding: 10px 12px;
-  border-bottom: 1px solid #eee;
+  padding: 10px 14px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 table tr:hover {
-  background: #f8f9fa;
+  background: #f8faff;
+}
+
+table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid #f0f0f0;
+}
+
+.pagination button {
+  padding: 6px 16px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: white;
+  color: #555;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.pagination button:hover:not(:disabled) {
+  border-color: #2ecc71;
+  color: #2ecc71;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pagination span {
+  font-size: 0.85rem;
+  color: #888;
+}
+
+/* Stats section */
+.stats-section {
+  background: white;
+  border-radius: 14px;
+  padding: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  border: 1px solid #f0f0f0;
+}
+
+.stats-section h2 {
+  margin: 0 0 16px;
+  font-size: 1.1rem;
+  color: #2c3e50;
 }
 
 .stats-details {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 15px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
 }
 
 .stats-details div {
-  padding: 10px;
+  padding: 14px;
   background: #f8f9fa;
-  border-radius: 8px;
+  border-radius: 10px;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.loading {
-  text-align: center;
-  font-size: 1.5rem;
-  padding: 50px;
+.stats-details strong {
+  font-size: 0.78rem;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.stats-details span {
+  font-size: 1.4rem;
+  font-weight: 700;
   color: #2c3e50;
 }
 
-@media (max-width: 768px) {
+/* Loading state */
+.loading {
+  text-align: center;
+  font-size: 1.3rem;
+  padding: 80px 20px;
+  color: #888;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  .header-row {
+    flex-direction: column;
+  }
+  .header-controls {
+    width: 100%;
+  }
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .urban-garden-dashboard {
+    padding: 12px;
+  }
+  .dashboard-header {
+    padding: 16px;
+  }
+  .dashboard-header h1 {
+    font-size: 1.4rem;
+  }
   .stats-grid {
     grid-template-columns: 1fr 1fr;
+    gap: 10px;
   }
-  
-  .dashboard-header h1 {
-    font-size: 1.8rem;
+  .stat-card {
+    padding: 14px;
+  }
+  .stat-card .value {
+    font-size: 1.6rem;
+  }
+  .header-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .garden-select {
+    justify-content: stretch;
+  }
+  .garden-select select {
+    flex: 1;
+  }
+  .live-toggle, .export-btn {
+    justify-content: center;
+  }
+  .stats-details {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 400px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+  .stats-details {
+    grid-template-columns: 1fr;
+  }
+  table th, table td {
+    padding: 8px 10px;
+    font-size: 0.8rem;
   }
 }

--- a/frontend/src/pages/UrbanGardenDashboard.jsx
+++ b/frontend/src/pages/UrbanGardenDashboard.jsx
@@ -1,130 +1,319 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import axios from 'axios';
 import './UrbanGardenDashboard.css';
 
+// ---------- Pure SVG line chart (no external chart library) ----------
+const MetricChart = ({ label, data, color, unit }) => {
+  const width = 460;
+  const height = 160;
+  const padX = 40;
+  const padY = 24;
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="chart-empty">
+        Nessun dato per {label}
+      </div>
+    );
+  }
+
+  const values = data.map((d) => d.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const stepX = (width - padX * 2) / Math.max(data.length - 1, 1);
+
+  const points = data.map((d, i) => {
+    const x = padX + i * stepX;
+    const y = padY + (height - padY * 2) * (1 - (d.value - min) / range);
+    return { x, y, ...d };
+  });
+
+  const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ');
+  const areaPath = `${path} L ${points[points.length - 1].x.toFixed(1)} ${height - padY} L ${padX} ${height - padY} Z`;
+
+  return (
+    <div className="chart-wrap">
+      <div className="chart-title">
+        <span className="chart-dot" style={{ background: color }} />
+        {label}
+        {data.length > 0 && (
+          <span className="chart-latest">{data[data.length - 1].value}{unit}</span>
+        )}
+      </div>
+      <svg className="metric-chart" viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`Grafico ${label}`}>
+        {[0.25, 0.5, 0.75].map((f) => (
+          <line
+            key={f}
+            x1={padX}
+            x2={width - padX}
+            y1={padY + (height - padY * 2) * f}
+            y2={padY + (height - padY * 2) * f}
+            className="chart-gridline"
+          />
+        ))}
+        <path d={areaPath} fill={color} opacity="0.15" />
+        <path d={path} fill="none" stroke={color} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        {points.map((p, i) => (i % Math.max(1, Math.floor(points.length / 12)) === 0 || i === points.length - 1) && (
+          <circle key={i} cx={p.x} cy={p.y} r="3" fill={color} />
+        ))}
+      </svg>
+      <div className="chart-axis">
+        <span>{points.length > 0 ? new Date(points[0].timestamp).toLocaleDateString() : ''}</span>
+        <span>{points.length > 0 ? new Date(points[points.length - 1].timestamp).toLocaleDateString() : ''}</span>
+      </div>
+    </div>
+  );
+};
+
+// ---------- Main Dashboard ----------
 const UrbanGardenDashboard = () => {
   const [gardenData, setGardenData] = useState([]);
   const [latestData, setLatestData] = useState(null);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [gardenId, setGardenId] = useState('orto-rimini-001');
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [isLive, setIsLive] = useState(true);
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+  const [exporting, setExporting] = useState(false);
+  const [autoRefresh, setAutoRefresh] = useState(30000); // 30s real-time
+  const abortRef = useRef(null);
 
-  useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 60000); // Aggiorna ogni minuto
-    return () => clearInterval(interval);
-  }, [gardenId]);
-
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     try {
-      setLoading(true);
+      if (!latestData) setLoading(true);
+      setError(null);
       const [historyRes, latestRes, statsRes] = await Promise.all([
-        axios.get(`/api/sensors/garden/${gardenId}`),
-        axios.get(`/api/sensors/garden/${gardenId}/latest`),
-        axios.get(`/api/sensors/garden/${gardenId}/stats`)
+        axios.get(`/api/sensors/garden/${gardenId}`, { signal: controller.signal }),
+        axios.get(`/api/sensors/garden/${gardenId}/latest`, { signal: controller.signal }),
+        axios.get(`/api/sensors/garden/${gardenId}/stats`, { signal: controller.signal })
       ]);
-      
       setGardenData(historyRes.data.data || []);
       setLatestData(latestRes.data.data || null);
       setStats(statsRes.data.data || null);
-    } catch (error) {
-      console.error('Error fetching garden data:', error);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (err.name !== 'CanceledError') {
+        setError('Errore nel caricamento dei dati. Riprova tra poco.');
+      }
     } finally {
       setLoading(false);
     }
-  };
+  }, [gardenId, latestData]);
 
-  if (loading) {
-    return <div className="loading">🌱 Caricamento dati orto...</div>;
-  }
+  useEffect(() => {
+    fetchData();
+    if (!isLive) return undefined;
+    const interval = setInterval(fetchData, autoRefresh);
+    return () => {
+      clearInterval(interval);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [fetchData, isLive, autoRefresh]);
+
+  // Build series for the charts from history data
+  const series = useMemo(() => {
+    if (!gardenData || gardenData.length === 0) return { ph: [], ec: [], temperature: [], humidity: [] };
+    const sorted = [...gardenData].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+    const map = (key) =>
+      sorted
+        .filter((d) => d[key] != null)
+        .map((d) => ({ value: parseFloat(d[key]), timestamp: d.timestamp }));
+    return {
+      ph: map('ph'),
+      ec: map('ec'),
+      temperature: map('temperature'),
+      humidity: map('humidity')
+    };
+  }, [gardenData]);
+
+  // Export report as CSV
+  const exportReport = useCallback(() => {
+    if (!gardenData || gardenData.length === 0) return;
+    setExporting(true);
+    setTimeout(() => {
+      const header = ['timestamp', 'ph', 'ec', 'temperature', 'humidity'];
+      const rows = gardenData.map((d) => [
+        d.timestamp,
+        d.ph ?? '',
+        d.ec ?? '',
+        d.temperature ?? '',
+        d.humidity ?? ''
+      ]);
+      const csv = [header, ...rows]
+        .map((row) => row.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `orto-${gardenId}-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setExporting(false);
+    }, 50);
+  }, [gardenData, gardenId]);
+
+  const totalPages = Math.max(1, Math.ceil(gardenData.length / pageSize));
+  const pagedData = [...gardenData].slice((page - 1) * pageSize, page * pageSize);
+
+  const refreshLabel = isLive ? `${autoRefresh / 1000}s` : 'pausa';
 
   return (
     <div className="urban-garden-dashboard">
       <header className="dashboard-header">
-        <h1>🌱 Orto Urbano - Rimini</h1>
-        <p>Monitoraggio in tempo reale dei parametri del suolo</p>
+        <div className="header-row">
+          <div>
+            <h1>🌱 Orto Urbano - Rimini</h1>
+            <p>Monitoraggio in tempo reale dei parametri del suolo</p>
+          </div>
+          <div className="header-controls">
+            <label className="garden-select">
+              <span>Orto</span>
+              <select value={gardenId} onChange={(e) => { setGardenId(e.target.value); setPage(1); }}>
+                <option value="orto-rimini-001">Orto Rimini</option>
+                <option value="orto-bologna-001">Orto Bologna</option>
+                <option value="orto-firenze-001">Orto Firenze</option>
+              </select>
+            </label>
+            <button
+              className={`live-toggle ${isLive ? 'active' : ''}`}
+              onClick={() => setIsLive((v) => !v)}
+              title="Attiva/disattiva aggiornamento automatico"
+            >
+              <span className="live-dot" /> {isLive ? 'Live' : 'In pausa'} · {refreshLabel}
+            </button>
+            <button className="export-btn" onClick={exportReport} disabled={exporting || gardenData.length === 0}>
+              {exporting ? 'Esportazione...' : '⬇️ Esporta CSV'}
+            </button>
+          </div>
+        </div>
+        <div className="last-updated">
+          Ultimo aggiornamento: {lastUpdated ? lastUpdated.toLocaleTimeString() : '—'}
+        </div>
       </header>
 
-      <div className="stats-grid">
-        <div className="stat-card ph">
-          <h3>pH</h3>
-          <div className="value">{latestData?.ph || '--'}</div>
-          <div className="range">6.0 - 7.5 (ottimale)</div>
-        </div>
-        
-        <div className="stat-card ec">
-          <h3>EC (Conducibilità)</h3>
-          <div className="value">{latestData?.ec || '--'}</div>
-          <div className="range">0.8 - 2.0 (ottimale)</div>
-        </div>
-        
-        <div className="stat-card temperature">
-          <h3>🌡️ Temperatura</h3>
-          <div className="value">{latestData?.temperature || '--'}°C</div>
-          <div className="range">15 - 25°C (ottimale)</div>
-        </div>
-        
-        <div className="stat-card humidity">
-          <h3>💧 Umidità</h3>
-          <div className="value">{latestData?.humidity || '--'}%</div>
-          <div className="range">40 - 70% (ottimale)</div>
-        </div>
-      </div>
+      {error && <div className="error-banner">⚠️ {error}</div>}
 
-      <div className="history-section">
-        <h2>📊 Storico dati</h2>
-        <div className="table-container">
-          <table>
-            <thead>
-              <tr>
-                <th>Data/Ora</th>
-                <th>pH</th>
-                <th>EC</th>
-                <th>Temperatura</th>
-                <th>Umidità</th>
-              </tr>
-            </thead>
-            <tbody>
-              {gardenData.slice(0, 20).map((reading, index) => (
-                <tr key={index}>
-                  <td>{new Date(reading.timestamp).toLocaleString()}</td>
-                  <td>{reading.ph}</td>
-                  <td>{reading.ec}</td>
-                  <td>{reading.temperature}°C</td>
-                  <td>{reading.humidity}%</td>
-                </tr>
-              ))}
-              {gardenData.length === 0 && (
-                <tr>
-                  <td colSpan="5">Nessun dato disponibile</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div className="stats-section">
-        <h2>📈 Statistiche</h2>
-        {stats ? (
-          <div className="stats-details">
-            <div>
-              <strong>pH medio:</strong> {stats.ph?.avg?.toFixed(2) || '--'}
+      {loading && !latestData ? (
+        <div className="loading">🌱 Caricamento dati orto...</div>
+      ) : (
+        <>
+          <div className="stats-grid">
+            <div className="stat-card ph">
+              <h3>pH</h3>
+              <div className="value">{latestData?.ph ?? '--'}</div>
+              <div className="range">6.0 - 7.5 (ottimale)</div>
             </div>
-            <div>
-              <strong>EC medio:</strong> {stats.ec?.avg?.toFixed(2) || '--'}
+            <div className="stat-card ec">
+              <h3>EC (Conducibilità)</h3>
+              <div className="value">{latestData?.ec ?? '--'}</div>
+              <div className="range">0.8 - 2.0 (ottimale)</div>
             </div>
-            <div>
-              <strong>Temperatura media:</strong> {stats.temperature?.avg?.toFixed(1) || '--'}°C
+            <div className="stat-card temperature">
+              <h3>🌡️ Temperatura</h3>
+              <div className="value">{latestData?.temperature ?? '--'}°C</div>
+              <div className="range">15 - 25°C (ottimale)</div>
             </div>
-            <div>
-              <strong>Letture totali:</strong> {stats.readings || 0}
+            <div className="stat-card humidity">
+              <h3>💧 Umidità</h3>
+              <div className="value">{latestData?.humidity ?? '--'}%</div>
+              <div className="range">40 - 70% (ottimale)</div>
             </div>
           </div>
-        ) : (
-          <p>Statistiche non disponibili</p>
-        )}
-      </div>
+
+          <div className="charts-section">
+            <h2>📈 Andamenti</h2>
+            <div className="charts-grid">
+              <MetricChart label="pH" data={series.ph} color="#3498db" unit="" />
+              <MetricChart label="Conducibilità (EC)" data={series.ec} color="#9b59b6" unit="" />
+              <MetricChart label="Temperatura" data={series.temperature} color="#e74c3c" unit="°C" />
+              <MetricChart label="Umidità" data={series.humidity} color="#1abc9c" unit="%" />
+            </div>
+          </div>
+
+          <div className="history-section">
+            <div className="section-head">
+              <h2>📋 Storico dati</h2>
+              <span className="record-count">{gardenData.length} letture</span>
+            </div>
+            <div className="table-container">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Data/Ora</th>
+                    <th>pH</th>
+                    <th>EC</th>
+                    <th>Temperatura</th>
+                    <th>Umidità</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedData.map((reading, index) => (
+                    <tr key={`${reading.timestamp}-${index}`}>
+                      <td>{new Date(reading.timestamp).toLocaleString()}</td>
+                      <td>{reading.ph ?? '—'}</td>
+                      <td>{reading.ec ?? '—'}</td>
+                      <td>{reading.temperature != null ? `${reading.temperature}°C` : '—'}</td>
+                      <td>{reading.humidity != null ? `${reading.humidity}%` : '—'}</td>
+                    </tr>
+                  ))}
+                  {pagedData.length === 0 && (
+                    <tr>
+                      <td colSpan="5">Nessun dato disponibile</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {totalPages > 1 && (
+              <div className="pagination">
+                <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>← Precedente</button>
+                <span>Pagina {page} di {totalPages}</span>
+                <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>Successiva →</button>
+              </div>
+            )}
+          </div>
+
+          <div className="stats-section">
+            <h2>📊 Statistiche</h2>
+            {stats ? (
+              <div className="stats-details">
+                <div>
+                  <strong>pH medio</strong>
+                  <span>{stats.ph?.avg?.toFixed(2) ?? '--'}</span>
+                </div>
+                <div>
+                  <strong>EC medio</strong>
+                  <span>{stats.ec?.avg?.toFixed(2) ?? '--'}</span>
+                </div>
+                <div>
+                  <strong>Temperatura media</strong>
+                  <span>{stats.temperature?.avg?.toFixed(1) ?? '--'}°C</span>
+                </div>
+                <div>
+                  <strong>Umidità media</strong>
+                  <span>{stats.humidity?.avg?.toFixed(1) ?? '--'}%</span>
+                </div>
+                <div>
+                  <strong>Letture totali</strong>
+                  <span>{stats.readings ?? 0}</span>
+                </div>
+              </div>
+            ) : (
+              <p>Statistiche non disponibili</p>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Summary

Enhanced the **Urban Garden Dashboard** (`UrbanGardenDashboard`) to fully cover the acceptance criteria of issue #746:

- **📈 Grafici e metriche** — Added 4 pure-SVG line charts (pH, EC, Temperature, Humidity) with gradient area fill, gridlines, data points, and latest-value labels. No external chart library required.
- **⚡ Dati in tempo reale** — Reduced auto-refresh to 30s with an AbortController-powered fetch, a live/pause toggle, a pulsing live indicator, and a "last updated" timestamp.
- **📋 Storico dati** — Paginated history table (10 rows/page) with previous/next navigation and record count.
- **⬇️ Export report** — Added CSV export button that downloads the full sensor history as `orto-<garden>-report-<date>.csv`.
- **📱 Responsive design** — Fully responsive breakpoints (900px / 640px / 400px); header controls wrap gracefully, mobile stats grid collapses to 1 column.
- **🛠️ Robustness** — Error banner, multiple garden selector, AbortController cleanup on unmount, stable React keys.

Closes #746