### PR TITLE
feat: add payments API

### DIFF
--- a/docs/PAYMENTS_API.md
+++ b/docs/PAYMENTS_API.md
@@ -1,0 +1,64 @@
+# Payments API
+
+Create payments, track their status, query history, and receive signed webhooks when the status changes. Payments are stored in MongoDB when the gateway has a live connection and in memory otherwise, so the API also works in local runs without a database.
+
+## API
+
+- `POST /api/payments` creates a payment. Accepts `userId`, `amount`, `currency`, and optionally `reference`, `callbackUrl`, `metadata`. Returns `201` with the payment.
+- `GET /api/payments/:id` returns the current status, `txId`, and confirmation count.
+- `GET /api/payments` returns history. Filters: `userId`, `status`, `currency`, `from`, `to`. Pagination: `limit` (default 50, max 200) and `offset`.
+- `POST /api/payments/:id/status` moves a payment to a new `status`, optionally recording `txId`, `confirmations`, and `reason`.
+- `GET /api/payments/:id/deliveries` returns the webhook delivery log for a payment.
+
+Currencies are `MYZ` and `XMR`. Amounts must be positive.
+
+## Idempotency
+
+Send an `Idempotency-Key` header (or `idempotencyKey` in the body) on `POST /api/payments`. A repeated key returns the original payment instead of creating a second one, so a retried request cannot double-charge.
+
+## Status machine
+
+```
+PENDING ──▶ CONFIRMING ──▶ COMPLETED
+   │             └────────▶ FAILED
+   ├──▶ COMPLETED / FAILED / CANCELLED / EXPIRED
+```
+
+`COMPLETED`, `FAILED`, `CANCELLED`, and `EXPIRED` are terminal. Any other move is rejected with `409`, and every accepted move appends to the payment's `audit` array with a timestamp.
+
+## Webhooks
+
+Set `callbackUrl` at creation and the gateway POSTs on every status change. The response to that create call contains `webhookSecret` — it is returned **once** and never again, so store it then.
+
+Each delivery carries:
+
+| Header | Meaning |
+| --- | --- |
+| `x-myz-event` | e.g. `payment.completed` |
+| `x-myz-timestamp` | delivery time, milliseconds since epoch |
+| `x-myz-signature` | `sha256=<hex>` |
+
+The signature is `HMAC-SHA256(secret, "<timestamp>.<raw body>")`. The timestamp is inside the signed string, so a captured delivery cannot be replayed later. Verify against the **raw** body before parsing it:
+
+```js
+const { verifyWebhook } = require('./services/paymentService');
+
+const ok = verifyWebhook(
+  secret,
+  req.get('x-myz-timestamp'),
+  rawBody,
+  req.get('x-myz-signature'),
+);
+```
+
+`verifyWebhook` compares in constant time and rejects timestamps outside a five-minute window (`toleranceMs` to override).
+
+Failed deliveries are retried three times with exponential backoff (500ms, 1s, 2s). Delivery is best-effort: a webhook that never lands is recorded in `deliveries` but never rolls back the status change, because the ledger — not the receiver — is the source of truth.
+
+## Tests
+
+```
+node --test tests/payments.test.js
+```
+
+Covers validation, idempotency, the status machine, signature verification, replay and tamper rejection, retry behaviour, and history filtering.

--- a/models/Payment.js
+++ b/models/Payment.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+const PaymentSchema = new mongoose.Schema({
+  id: { type: String, required: true, unique: true, index: true },
+  idempotencyKey: { type: String, default: null, index: true },
+  userId: { type: String, required: true, index: true },
+  amount: { type: Number, required: true },
+  currency: { type: String, enum: ['MYZ', 'XMR'], required: true },
+  reference: { type: String, default: null },
+  callbackUrl: { type: String, default: null },
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  status: {
+    type: String,
+    enum: ['PENDING', 'CONFIRMING', 'COMPLETED', 'FAILED', 'CANCELLED', 'EXPIRED'],
+    default: 'PENDING',
+    index: true
+  },
+  txId: { type: String, default: null },
+  confirmations: { type: Number, default: 0 },
+  webhookSecret: { type: String, default: null },
+  audit: { type: Array, default: [] },
+  deliveries: { type: Array, default: [] },
+  createdAt: { type: String, required: true },
+  updatedAt: { type: String, required: true }
+}, { versionKey: false });
+
+PaymentSchema.index({ userId: 1, createdAt: -1 });
+
+module.exports = mongoose.model('Payment', PaymentSchema);

--- a/routes/payments.js
+++ b/routes/payments.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const { PaymentService, MemoryPaymentStore, MongoPaymentStore, publicView } = require('../services/paymentService');
+
+const router = express.Router();
+
+// Mongo when the gateway has a live connection, memory otherwise, so the API
+// stays usable in local/dev runs without a database.
+function buildStore() {
+  if (mongoose.connection?.readyState === 1) {
+    return new MongoPaymentStore(require('../models/Payment'));
+  }
+  return new MemoryPaymentStore();
+}
+
+const service = new PaymentService({ store: buildStore() });
+
+router.post('/', async (req, res) => {
+  try {
+    const payment = await service.createPayment({ ...req.body, idempotencyKey: req.get('idempotency-key') || req.body.idempotencyKey || null });
+    return res.status(201).json({ success: true, data: publicView(payment, { includeSecret: true }) });
+  } catch (error) {
+    return res.status(400).json({ success: false, error: error.message });
+  }
+});
+
+router.get('/', async (req, res) => {
+  try {
+    const page = await service.list(req.query);
+    return res.json({ success: true, ...page, items: page.items.map((item) => publicView(item)) });
+  } catch (error) {
+    return res.status(400).json({ success: false, error: error.message });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    return res.json({ success: true, data: publicView(await service.requirePayment(req.params.id)) });
+  } catch (error) {
+    return res.status(404).json({ success: false, error: error.message });
+  }
+});
+
+router.post('/:id/status', async (req, res) => {
+  const { status, txId, confirmations, reason } = req.body || {};
+  if (!status) return res.status(400).json({ success: false, error: 'status is required' });
+  try {
+    const payment = await service.transition(req.params.id, status, { txId, confirmations, reason });
+    return res.json({ success: true, data: publicView(payment) });
+  } catch (error) {
+    const notFound = error.message === 'Payment not found';
+    return res.status(notFound ? 404 : 409).json({ success: false, error: error.message });
+  }
+});
+
+router.get('/:id/deliveries', async (req, res) => {
+  try {
+    const payment = await service.requirePayment(req.params.id);
+    return res.json({ success: true, data: payment.deliveries });
+  } catch (error) {
+    return res.status(404).json({ success: false, error: error.message });
+  }
+});
+
+module.exports = router;
+module.exports.service = service;

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
 const gl1BridgeRoutes = require('./routes/gl1Bridge');
+const paymentRoutes = require('./routes/payments');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -67,6 +68,7 @@ app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
 app.use('/api/gl1', gl1BridgeRoutes);
+app.use('/api/payments', paymentRoutes);
 
 // Robot routes
 try {

--- a/services/paymentService.js
+++ b/services/paymentService.js
@@ -1,0 +1,188 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const CURRENCIES = new Set(['MYZ', 'XMR']);
+const TERMINAL_STATES = new Set(['COMPLETED', 'FAILED', 'CANCELLED', 'EXPIRED']);
+const TRANSITIONS = {
+  PENDING: ['CONFIRMING', 'COMPLETED', 'FAILED', 'CANCELLED', 'EXPIRED'],
+  CONFIRMING: ['COMPLETED', 'FAILED'],
+};
+
+class MemoryPaymentStore {
+  constructor() { this.items = new Map(); }
+  async save(payment) { this.items.set(payment.id, structuredClone(payment)); return structuredClone(payment); }
+  async get(id) { const item = this.items.get(id); return item ? structuredClone(item) : null; }
+  async list() { return [...this.items.values()].map((item) => structuredClone(item)); }
+}
+
+class MongoPaymentStore {
+  constructor(model) { this.model = model; }
+  async save(payment) {
+    const saved = await this.model.findOneAndUpdate({ id: payment.id }, payment, { upsert: true, new: true, lean: true });
+    return this.strip(saved);
+  }
+  async get(id) { return this.strip(await this.model.findOne({ id }).lean()); }
+  async list() { return (await this.model.find().sort({ createdAt: -1 }).lean()).map((item) => this.strip(item)); }
+  strip(doc) {
+    if (!doc) return null;
+    const { _id, __v, ...rest } = doc;
+    return rest;
+  }
+}
+
+// Signature scheme shared with consumers: HMAC-SHA256 over `${timestamp}.${body}`.
+// The timestamp is signed too, so a captured delivery cannot be replayed later.
+function signWebhook(secret, timestamp, body) {
+  return crypto.createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('hex');
+}
+
+function verifyWebhook(secret, timestamp, body, signature, { toleranceMs = 5 * 60 * 1000, now = Date.now() } = {}) {
+  const received = String(signature || '').replace(/^sha256=/, '');
+  const expected = signWebhook(secret, timestamp, body);
+  if (received.length !== expected.length) return false;
+  if (Math.abs(now - Number(timestamp)) > toleranceMs) return false;
+  return crypto.timingSafeEqual(Buffer.from(received, 'utf8'), Buffer.from(expected, 'utf8'));
+}
+
+function createWebhookDispatcher({ client = axios, attempts = 3, backoffMs = 500, sleep, clock = () => new Date() } = {}) {
+  const wait = sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  return {
+    async deliver({ url, payload, secret }) {
+      const body = JSON.stringify(payload);
+      let lastError = null;
+      for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        const timestamp = clock().getTime();
+        try {
+          const response = await client.post(url, body, {
+            timeout: 10000,
+            headers: {
+              'content-type': 'application/json',
+              'x-myz-event': payload.event,
+              'x-myz-timestamp': String(timestamp),
+              'x-myz-signature': `sha256=${signWebhook(secret, timestamp, body)}`,
+            },
+          });
+          return { ok: true, attempts: attempt, statusCode: response?.status ?? 200 };
+        } catch (error) {
+          lastError = error;
+          if (attempt < attempts) await wait(backoffMs * 2 ** (attempt - 1));
+        }
+      }
+      return { ok: false, attempts, statusCode: lastError?.response?.status ?? null, error: lastError?.message ?? 'delivery failed' };
+    },
+  };
+}
+
+class PaymentService {
+  constructor({ store = new MemoryPaymentStore(), dispatcher = createWebhookDispatcher(), clock = () => new Date(), idGenerator = () => crypto.randomUUID(), secretGenerator = () => crypto.randomBytes(32).toString('hex') } = {}) {
+    this.store = store;
+    this.dispatcher = dispatcher;
+    this.clock = clock;
+    this.idGenerator = idGenerator;
+    this.secretGenerator = secretGenerator;
+  }
+
+  async createPayment({ userId, amount, currency, reference = null, callbackUrl = null, idempotencyKey = null, metadata = {} }) {
+    if (!userId) throw new Error('userId is required');
+    this.validateAmount(amount);
+    if (!CURRENCIES.has(currency)) throw new Error(`currency must be one of ${[...CURRENCIES].join(', ')}`);
+    if (callbackUrl) this.validateCallbackUrl(callbackUrl);
+
+    if (idempotencyKey) {
+      const existing = (await this.store.list()).find((item) => item.idempotencyKey === idempotencyKey);
+      if (existing) return existing;
+    }
+
+    const timestamp = this.clock().toISOString();
+    const payment = {
+      id: this.idGenerator(),
+      idempotencyKey,
+      userId,
+      amount: Number(amount),
+      currency,
+      reference,
+      callbackUrl,
+      metadata,
+      status: 'PENDING',
+      txId: null,
+      confirmations: 0,
+      webhookSecret: callbackUrl ? this.secretGenerator() : null,
+      audit: [{ status: 'PENDING', timestamp }],
+      deliveries: [],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    return this.store.save(payment);
+  }
+
+  async requirePayment(id) {
+    const payment = await this.store.get(id);
+    if (!payment) throw new Error('Payment not found');
+    return payment;
+  }
+
+  async transition(id, status, { txId = null, confirmations = null, reason = null } = {}) {
+    const payment = await this.requirePayment(id);
+    if (payment.status === status) return payment;
+    if (TERMINAL_STATES.has(payment.status)) throw new Error(`Payment is already ${payment.status}`);
+    if (!TRANSITIONS[payment.status]?.includes(status)) throw new Error(`Cannot move payment from ${payment.status} to ${status}`);
+
+    const timestamp = this.clock().toISOString();
+    payment.status = status;
+    payment.updatedAt = timestamp;
+    if (txId !== null) payment.txId = txId;
+    if (confirmations !== null) payment.confirmations = confirmations;
+    payment.audit.push({ status, timestamp, ...(txId ? { txId } : {}), ...(reason ? { reason } : {}) });
+    await this.store.save(payment);
+
+    await this.notify(payment, `payment.${status.toLowerCase()}`);
+    return this.store.get(payment.id);
+  }
+
+  // Webhook failures are recorded but never roll back a status change: the ledger
+  // is the source of truth, delivery is best-effort.
+  async notify(payment, event) {
+    if (!payment.callbackUrl) return null;
+    const result = await this.dispatcher.deliver({
+      url: payment.callbackUrl,
+      secret: payment.webhookSecret,
+      payload: { event, paymentId: payment.id, status: payment.status, amount: payment.amount, currency: payment.currency, txId: payment.txId, reference: payment.reference, occurredAt: this.clock().toISOString() },
+    });
+    payment.deliveries.push({ event, url: payment.callbackUrl, timestamp: this.clock().toISOString(), ...result });
+    await this.store.save(payment);
+    return result;
+  }
+
+  async list({ userId, status, currency, from, to, limit = 50, offset = 0 } = {}) {
+    const all = await this.store.list();
+    const filtered = all
+      .filter((item) => (userId ? item.userId === userId : true))
+      .filter((item) => (status ? item.status === status : true))
+      .filter((item) => (currency ? item.currency === currency : true))
+      .filter((item) => (from ? item.createdAt >= new Date(from).toISOString() : true))
+      .filter((item) => (to ? item.createdAt <= new Date(to).toISOString() : true))
+      .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+    const size = Math.min(Number(limit) || 50, 200);
+    const start = Math.max(Number(offset) || 0, 0);
+    return { total: filtered.length, limit: size, offset: start, items: filtered.slice(start, start + size) };
+  }
+
+  validateAmount(amount) {
+    if (!Number.isFinite(Number(amount)) || Number(amount) <= 0) throw new Error('amount must be positive');
+  }
+
+  validateCallbackUrl(callbackUrl) {
+    let parsed;
+    try { parsed = new URL(callbackUrl); } catch { throw new Error('callbackUrl must be a valid URL'); }
+    if (!['http:', 'https:'].includes(parsed.protocol)) throw new Error('callbackUrl must use http or https');
+  }
+}
+
+// The webhook secret is returned once, on creation, and never again.
+function publicView(payment, { includeSecret = false } = {}) {
+  if (!payment) return payment;
+  const { webhookSecret, ...rest } = payment;
+  return includeSecret && webhookSecret ? { ...rest, webhookSecret } : rest;
+}
+
+module.exports = { PaymentService, MemoryPaymentStore, MongoPaymentStore, createWebhookDispatcher, signWebhook, verifyWebhook, publicView, TERMINAL_STATES, TRANSITIONS };

--- a/tests/payments.test.js
+++ b/tests/payments.test.js
@@ -1,0 +1,192 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PaymentService,
+  MemoryPaymentStore,
+  createWebhookDispatcher,
+  signWebhook,
+  verifyWebhook,
+  publicView,
+} = require('../services/paymentService');
+
+const FIXED = new Date('2026-08-07T10:00:00.000Z');
+
+function fakeClient(responses = []) {
+  const calls = [];
+  return {
+    calls,
+    async post(url, body, config) {
+      calls.push({ url, body, config });
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      return next || { status: 200 };
+    },
+  };
+}
+
+function buildService({ responses = [], attempts = 3 } = {}) {
+  const client = fakeClient(responses);
+  const dispatcher = createWebhookDispatcher({ client, attempts, sleep: async () => {}, clock: () => FIXED });
+  const service = new PaymentService({ store: new MemoryPaymentStore(), dispatcher, clock: () => FIXED });
+  return { service, client };
+}
+
+test('creates a pending payment and issues a webhook secret when a callback is set', async () => {
+  const { service } = buildService();
+  const payment = await service.createPayment({
+    userId: 'user-1', amount: 12.5, currency: 'MYZ', reference: 'order-9', callbackUrl: 'https://shop.example/hooks',
+  });
+
+  assert.equal(payment.status, 'PENDING');
+  assert.equal(payment.amount, 12.5);
+  assert.equal(payment.confirmations, 0);
+  assert.equal(typeof payment.webhookSecret, 'string');
+  assert.equal(payment.webhookSecret.length, 64);
+  assert.deepEqual(payment.audit, [{ status: 'PENDING', timestamp: FIXED.toISOString() }]);
+});
+
+test('omits the webhook secret when no callback is configured', async () => {
+  const { service } = buildService();
+  const payment = await service.createPayment({ userId: 'user-1', amount: 1, currency: 'XMR' });
+  assert.equal(payment.webhookSecret, null);
+});
+
+test('rejects invalid input', async () => {
+  const { service } = buildService();
+  await assert.rejects(service.createPayment({ amount: 1, currency: 'MYZ' }), /userId is required/);
+  await assert.rejects(service.createPayment({ userId: 'u', amount: 0, currency: 'MYZ' }), /amount must be positive/);
+  await assert.rejects(service.createPayment({ userId: 'u', amount: -3, currency: 'MYZ' }), /amount must be positive/);
+  await assert.rejects(service.createPayment({ userId: 'u', amount: 1, currency: 'BTC' }), /currency must be one of/);
+  await assert.rejects(service.createPayment({ userId: 'u', amount: 1, currency: 'MYZ', callbackUrl: 'ftp://x/y' }), /http or https/);
+  await assert.rejects(service.createPayment({ userId: 'u', amount: 1, currency: 'MYZ', callbackUrl: 'not a url' }), /valid URL/);
+});
+
+test('replays the same payment for a repeated idempotency key', async () => {
+  const { service } = buildService();
+  const first = await service.createPayment({ userId: 'u', amount: 5, currency: 'MYZ', idempotencyKey: 'key-1' });
+  const second = await service.createPayment({ userId: 'u', amount: 5, currency: 'MYZ', idempotencyKey: 'key-1' });
+  assert.equal(second.id, first.id);
+  assert.equal((await service.list()).total, 1);
+});
+
+test('walks the status machine and records an audit trail', async () => {
+  const { service } = buildService();
+  const created = await service.createPayment({ userId: 'u', amount: 2, currency: 'XMR' });
+
+  await service.transition(created.id, 'CONFIRMING', { confirmations: 1 });
+  const done = await service.transition(created.id, 'COMPLETED', { txId: 'tx-abc', confirmations: 10 });
+
+  assert.equal(done.status, 'COMPLETED');
+  assert.equal(done.txId, 'tx-abc');
+  assert.equal(done.confirmations, 10);
+  assert.deepEqual(done.audit.map((entry) => entry.status), ['PENDING', 'CONFIRMING', 'COMPLETED']);
+});
+
+test('refuses illegal and post-terminal transitions', async () => {
+  const { service } = buildService();
+  const created = await service.createPayment({ userId: 'u', amount: 2, currency: 'XMR' });
+
+  await assert.rejects(service.transition(created.id, 'REFUNDED'), /Cannot move payment from PENDING to REFUNDED/);
+
+  await service.transition(created.id, 'COMPLETED');
+  await assert.rejects(service.transition(created.id, 'FAILED'), /already COMPLETED/);
+  await assert.rejects(service.transition('missing-id', 'COMPLETED'), /Payment not found/);
+});
+
+test('signs outbound webhooks so the receiver can verify them', async () => {
+  const { service, client } = buildService();
+  const created = await service.createPayment({ userId: 'u', amount: 7, currency: 'MYZ', callbackUrl: 'https://shop.example/hooks' });
+
+  await service.transition(created.id, 'COMPLETED', { txId: 'tx-1' });
+
+  assert.equal(client.calls.length, 1);
+  const [call] = client.calls;
+  assert.equal(call.url, 'https://shop.example/hooks');
+  assert.equal(call.config.headers['x-myz-event'], 'payment.completed');
+
+  const timestamp = call.config.headers['x-myz-timestamp'];
+  const signature = call.config.headers['x-myz-signature'];
+  assert.ok(verifyWebhook(created.webhookSecret, timestamp, call.body, signature, { now: FIXED.getTime() }));
+
+  const body = JSON.parse(call.body);
+  assert.equal(body.event, 'payment.completed');
+  assert.equal(body.paymentId, created.id);
+  assert.equal(body.txId, 'tx-1');
+
+  const stored = await service.store.get(created.id);
+  assert.equal(stored.deliveries.length, 1);
+  assert.equal(stored.deliveries[0].ok, true);
+  assert.equal(stored.deliveries[0].attempts, 1);
+});
+
+test('retries a failing webhook and records the failure without blocking the transition', async () => {
+  const boom = () => new Error('connect ECONNREFUSED');
+  const { service, client } = buildService({ responses: [boom(), boom(), boom()] });
+  const created = await service.createPayment({ userId: 'u', amount: 7, currency: 'MYZ', callbackUrl: 'https://down.example/hooks' });
+
+  const result = await service.transition(created.id, 'FAILED', { reason: 'insufficient funds' });
+
+  assert.equal(result.status, 'FAILED');
+  assert.equal(client.calls.length, 3);
+  assert.equal(result.deliveries[0].ok, false);
+  assert.equal(result.deliveries[0].attempts, 3);
+  assert.match(result.deliveries[0].error, /ECONNREFUSED/);
+});
+
+test('skips webhook delivery when no callback is configured', async () => {
+  const { service, client } = buildService();
+  const created = await service.createPayment({ userId: 'u', amount: 1, currency: 'MYZ' });
+  await service.transition(created.id, 'COMPLETED');
+  assert.equal(client.calls.length, 0);
+});
+
+test('filters and paginates history', async () => {
+  const { service } = buildService();
+  await service.createPayment({ userId: 'alice', amount: 1, currency: 'MYZ' });
+  await service.createPayment({ userId: 'alice', amount: 2, currency: 'XMR' });
+  const third = await service.createPayment({ userId: 'bob', amount: 3, currency: 'MYZ' });
+  await service.transition(third.id, 'COMPLETED');
+
+  assert.equal((await service.list({ userId: 'alice' })).total, 2);
+  assert.equal((await service.list({ currency: 'XMR' })).total, 1);
+  assert.equal((await service.list({ status: 'COMPLETED' })).total, 1);
+  assert.equal((await service.list({ status: 'PENDING' })).total, 2);
+
+  const page = await service.list({ limit: 2, offset: 0 });
+  assert.equal(page.total, 3);
+  assert.equal(page.items.length, 2);
+  assert.equal(page.limit, 2);
+
+  const rest = await service.list({ limit: 2, offset: 2 });
+  assert.equal(rest.items.length, 1);
+});
+
+test('caps the page size', async () => {
+  const { service } = buildService();
+  assert.equal((await service.list({ limit: 5000 })).limit, 200);
+});
+
+test('rejects tampered payloads and stale timestamps', () => {
+  const secret = 'a'.repeat(64);
+  const now = FIXED.getTime();
+  const body = JSON.stringify({ event: 'payment.completed', amount: 10 });
+  const signature = signWebhook(secret, now, body);
+
+  assert.ok(verifyWebhook(secret, now, body, signature, { now }));
+  assert.ok(verifyWebhook(secret, now, body, `sha256=${signature}`, { now }));
+
+  const tampered = JSON.stringify({ event: 'payment.completed', amount: 1000 });
+  assert.equal(verifyWebhook(secret, now, tampered, signature, { now }), false);
+  assert.equal(verifyWebhook('b'.repeat(64), now, body, signature, { now }), false);
+  assert.equal(verifyWebhook(secret, now, body, signature, { now: now + 10 * 60 * 1000 }), false);
+  assert.equal(verifyWebhook(secret, now, body, 'short', { now }), false);
+});
+
+test('publicView hides the webhook secret unless explicitly requested', async () => {
+  const { service } = buildService();
+  const created = await service.createPayment({ userId: 'u', amount: 1, currency: 'MYZ', callbackUrl: 'https://shop.example/hooks' });
+
+  assert.equal(publicView(created).webhookSecret, undefined);
+  assert.equal(publicView(created, { includeSecret: true }).webhookSecret, created.webhookSecret);
+});


### PR DESCRIPTION
Closes #721.

Implements the four acceptance criteria — create payment, check status, history, webhook.

## Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| `POST` | `/api/payments` | Create a payment (`userId`, `amount`, `currency`, optional `reference`, `callbackUrl`, `metadata`) |
| `GET` | `/api/payments/:id` | Current status, `txId`, confirmations |
| `GET` | `/api/payments` | History — filter by `userId`, `status`, `currency`, `from`, `to`; paginated |
| `POST` | `/api/payments/:id/status` | Move status, recording `txId` / `confirmations` / `reason` |
| `GET` | `/api/payments/:id/deliveries` | Webhook delivery log |

## Notes on the design

**Idempotency.** `POST /api/payments` honours an `Idempotency-Key` header. A repeated key returns the original payment rather than creating a second one, so a client retry over a flaky connection cannot double-charge.

**Guarded status machine.** `PENDING → CONFIRMING → COMPLETED/FAILED`, plus direct `PENDING → COMPLETED/FAILED/CANCELLED/EXPIRED`. Terminal states are final; any illegal or post-terminal move returns `409` instead of silently corrupting the record. Every accepted move appends to an `audit` array.

**Signed webhooks.** Deliveries are signed `HMAC-SHA256(secret, "<timestamp>.<raw body>")` and sent as `x-myz-signature: sha256=<hex>` alongside `x-myz-timestamp`. Signing the timestamp too means a captured delivery cannot be replayed later; `verifyWebhook()` compares in constant time and rejects anything outside a five-minute window. The per-payment secret is returned **once**, in the create response, and is never included in any later response.

**Delivery is best-effort.** Failures retry three times with exponential backoff and are recorded in `deliveries`, but a webhook that never lands does not roll back the status change — the ledger is the source of truth, not the receiver.

**Storage.** MongoDB when the gateway has a live connection, in-memory otherwise, so the API works in local runs without a database. Follows the `services/*Service.js` + thin-router layout used by `routes/gl1Bridge.js`.

## Tests

```
node --test tests/payments.test.js
```

13 passing — validation, idempotency replay, the status machine and its illegal transitions, signature verification, tamper and replay rejection, retry/backoff behaviour, history filtering and pagination, and that the webhook secret never leaks into list or read responses.

I ran the rest of `tests/` as well: `createRobot.test.js` has one failure and `rateLimiter.test.js` hangs, both of which reproduce on `main` without this branch — untouched here.

---

Re: reward — as discussed on #721 and #751, I'd like this settled in **XMR rather than MYZ**. At your own published garden-bounty rates (250 MYZ = 0.04, 300 = 0.05, 400 = 0.06 XMR) the listed 900 MYZ is about **0.14 XMR**.

```
45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8
```

Please include the full transaction hash and tx key with the payment so I can verify it with `check_tx_key`.
