### PR TITLE
feat: add dispute resolution

### DIFF
--- a/docs/DISPUTE_RESOLUTION.md
+++ b/docs/DISPUTE_RESOLUTION.md
@@ -1,0 +1,73 @@
+# Dispute resolution
+
+Settles contested escrow jobs through evidence, a mediator vote, and deadlines that guarantee a verdict.
+
+## The property that matters
+
+A dispute system fails the party who is **in the right**. If the process can stall, their money stays frozen and the other side wins by simply not participating. So every stage here has a deadline, and `tick()` resolves anything that runs out of time. A dispute cannot sit open indefinitely.
+
+## API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/disputes` | Open a dispute against a job |
+| `POST` | `/api/disputes/:id/evidence` | Submit evidence (parties only) |
+| `POST` | `/api/disputes/:id/mediators` | Fix the mediator panel |
+| `POST` | `/api/disputes/:id/votes` | Cast a mediator vote |
+| `POST` | `/api/disputes/tick` | Advance everything that is due |
+| `GET` | `/api/disputes/:id` | Full state, evidence, votes, audit trail |
+| `GET` | `/api/disputes/job/:jobId` | Every dispute on a job |
+| `GET` | `/api/disputes/summary` | Docket counts by state and outcome |
+
+## Lifecycle
+
+```
+EVIDENCE ──window closes, respondent answered, panel ready──▶ VOTING ──▶ RESOLVED
+    │                                                             │
+    └── respondent never answered ──▶ RESOLVED (REFUND)           └── deadline, no majority ──▶ RESOLVED (REFUND)
+```
+
+Outcomes are `RELEASE`, `REFUND` or `SPLIT`.
+
+## Design decisions worth knowing
+
+**Assigning mediators does not start the vote.** The parties keep their full evidence window even once a panel is lined up; `tick()` opens voting when the window closes. Otherwise whoever assigns mediators could cut short the other side's chance to answer.
+
+**A party can never mediate their own dispute.** Attempting it is rejected by name, not silently filtered.
+
+**Voting resolves as soon as the result is mathematically certain.** Once no distribution of the outstanding votes could overturn the leader, the verdict lands. Waiting for stragglers when the outcome is already decided just keeps the funds frozen — with a three-person panel, two matching votes end it.
+
+**A silent respondent forfeits.** If the evidence window closes and the respondent never submitted anything, the claimant wins by default. Ignoring a dispute must not be a viable strategy.
+
+**No majority means refund, not payout.** If the voting deadline passes below quorum, or with a tie, the money goes back to the client. Paying out a contested job on an inconclusive vote is the worse error: the client loses money they might be owed, whereas a refund only costs the robot work it could not get the panel to endorse.
+
+**The verdict survives a downstream failure.** `onResolved` notifies the escrow. If that call throws, the resolution still stands and the failure is logged as `ESCROW_NOTIFY_FAILED` — losing a decided verdict because a callback timed out would be worse than a retryable notification.
+
+## Wiring to the escrow
+
+`services/escrowAutomationService.js` routes a failed verification to `DISPUTED`. Point this service back at it:
+
+```js
+const disputes = new DisputeService({
+  onResolved: ({ jobId, outcome }) =>
+    escrow.resolve({ jobId, outcome: outcome === 'RELEASE' ? 'RELEASE' : 'REFUND' }),
+});
+```
+
+## Configuration
+
+| Option | Default |
+| --- | --- |
+| `evidenceWindowHours` | `72` |
+| `votingWindowHours` | `72` |
+| `quorum` | `2` — minimum votes for a verdict to count |
+
+Storage is MongoDB when a connection is live, memory otherwise.
+
+## Tests
+
+```
+node --test tests/disputes.test.js
+```
+
+17 passing — evidence access control, panel conflict-of-interest, the evidence window surviving early mediator assignment, early resolution on an unbeatable lead, holding when the lead is still reachable, silent-respondent forfeit, sub-quorum and tied fallbacks, verdict survival when the escrow callback throws, tick idempotency, and the docket summary.

--- a/models/Dispute.js
+++ b/models/Dispute.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+const DisputeSchema = new mongoose.Schema({
+  disputeId: { type: String, required: true, unique: true, index: true },
+  jobId: { type: String, required: true, index: true },
+  claimantId: { type: String, required: true, index: true },
+  respondentId: { type: String, required: true, index: true },
+  reason: { type: String, required: true },
+  amount: { type: Number, default: null },
+  currency: { type: String, enum: ['MYZ', 'XMR', null], default: null },
+  state: {
+    type: String,
+    enum: ['EVIDENCE', 'VOTING', 'RESOLVED'],
+    default: 'EVIDENCE',
+    index: true
+  },
+  evidence: { type: Array, default: [] },
+  mediators: { type: [String], default: [] },
+  votes: { type: Array, default: [] },
+  outcome: { type: String, enum: ['RELEASE', 'REFUND', 'SPLIT', null], default: null },
+  resolution: { type: mongoose.Schema.Types.Mixed, default: null },
+  evidenceDeadline: { type: String, required: true },
+  votingDeadline: { type: String, default: null },
+  events: { type: Array, default: [] },
+  createdAt: { type: String, required: true },
+  updatedAt: { type: String, required: true }
+}, { versionKey: false });
+
+// tick() sweeps on the two deadlines.
+DisputeSchema.index({ state: 1, evidenceDeadline: 1 });
+DisputeSchema.index({ state: 1, votingDeadline: 1 });
+
+module.exports = mongoose.model('Dispute', DisputeSchema);

--- a/routes/disputes.js
+++ b/routes/disputes.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const { DisputeService, MemoryDisputeStore, MongoDisputeStore } = require('../services/disputeService');
+
+const router = express.Router();
+
+function buildStore() {
+  if (mongoose.connection?.readyState === 1) {
+    return new MongoDisputeStore(require('../models/Dispute'));
+  }
+  return new MemoryDisputeStore();
+}
+
+const service = new DisputeService({ store: buildStore() });
+
+const fail = (res, error) => {
+  const notFound = error.message === 'Dispute not found';
+  const conflict = /already|not open|is closed|Cannot assign/.test(error.message);
+  return res.status(notFound ? 404 : conflict ? 409 : 400).json({ success: false, error: error.message });
+};
+
+router.post('/', async (req, res) => {
+  try { return res.status(201).json({ success: true, data: await service.open(req.body) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.post('/:disputeId/evidence', async (req, res) => {
+  try { return res.json({ success: true, data: await service.submitEvidence({ disputeId: req.params.disputeId, ...req.body }) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.post('/:disputeId/mediators', async (req, res) => {
+  try { return res.json({ success: true, data: await service.assignMediators({ disputeId: req.params.disputeId, mediators: req.body?.mediators }) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.post('/:disputeId/votes', async (req, res) => {
+  try { return res.json({ success: true, data: await service.vote({ disputeId: req.params.disputeId, ...req.body }) }); }
+  catch (error) { return fail(res, error); }
+});
+
+// Idempotent sweep: closes evidence windows, opens votes, resolves timeouts.
+router.post('/tick', async (_req, res) => {
+  try { return res.json({ success: true, data: await service.tick() }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/summary', async (_req, res) => {
+  try { return res.json({ success: true, data: await service.summary() }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/job/:jobId', async (req, res) => {
+  try { return res.json({ success: true, data: await service.listByJob(req.params.jobId) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/:disputeId', async (req, res) => {
+  try { return res.json({ success: true, data: await service.get(req.params.disputeId) }); }
+  catch (error) { return fail(res, error); }
+});
+
+module.exports = router;
+module.exports.service = service;

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
 const gl1BridgeRoutes = require('./routes/gl1Bridge');
+const disputeRoutes = require('./routes/disputes');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -67,6 +68,7 @@ app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
 app.use('/api/gl1', gl1BridgeRoutes);
+app.use('/api/disputes', disputeRoutes);
 
 // Robot routes
 try {

--- a/services/disputeService.js
+++ b/services/disputeService.js
@@ -1,0 +1,270 @@
+const crypto = require('node:crypto');
+
+const HOUR_MS = 3600 * 1000;
+const OUTCOMES = new Set(['RELEASE', 'REFUND', 'SPLIT']);
+const OPEN_STATES = new Set(['EVIDENCE', 'VOTING']);
+const round = (n) => Number(Number(n).toFixed(12));
+
+class MemoryDisputeStore {
+  constructor() { this.items = new Map(); }
+  async save(dispute) { this.items.set(dispute.disputeId, structuredClone(dispute)); return structuredClone(dispute); }
+  async get(disputeId) { const item = this.items.get(disputeId); return item ? structuredClone(item) : null; }
+  async list() { return [...this.items.values()].map((item) => structuredClone(item)); }
+}
+
+class MongoDisputeStore {
+  constructor(model) { this.model = model; }
+  async save(dispute) {
+    const saved = await this.model.findOneAndUpdate({ disputeId: dispute.disputeId }, dispute, { upsert: true, new: true, lean: true });
+    return this.strip(saved);
+  }
+  async get(disputeId) { return this.strip(await this.model.findOne({ disputeId }).lean()); }
+  async list() { return (await this.model.find().lean()).map((doc) => this.strip(doc)); }
+  strip(doc) { if (!doc) return null; const { _id, __v, ...rest } = doc; return rest; }
+}
+
+/**
+ * Dispute resolution for escrowed jobs.
+ *
+ * A dispute moves through evidence -> mediator vote -> outcome. Every stage has
+ * a deadline, and `tick()` resolves anything that has run out of time, so a
+ * dispute can never sit open forever with the funds frozen — which is the
+ * failure mode that matters most to the party who is in the right.
+ */
+class DisputeService {
+  constructor({
+    store = new MemoryDisputeStore(),
+    onResolved = null,
+    evidenceWindowHours = 72,
+    votingWindowHours = 72,
+    quorum = 2,
+    clock = () => new Date(),
+    idGenerator = () => crypto.randomUUID(),
+  } = {}) {
+    this.store = store;
+    this.onResolved = onResolved;
+    this.evidenceWindowHours = evidenceWindowHours;
+    this.votingWindowHours = votingWindowHours;
+    this.quorum = quorum;
+    this.clock = clock;
+    this.idGenerator = idGenerator;
+  }
+
+  log(dispute, event, detail = {}) {
+    dispute.events.push({ event, at: this.clock().toISOString(), ...detail });
+    dispute.updatedAt = this.clock().toISOString();
+    return dispute;
+  }
+
+  async open({ jobId, claimantId, respondentId, reason, evidence = null, amount = null, currency = null }) {
+    if (!jobId) throw new Error('jobId is required');
+    if (!claimantId || !respondentId) throw new Error('claimantId and respondentId are required');
+    if (claimantId === respondentId) throw new Error('claimant and respondent must differ');
+    if (!reason) throw new Error('reason is required');
+
+    const existing = (await this.store.list()).find((item) => item.jobId === jobId && OPEN_STATES.has(item.state));
+    if (existing) throw new Error(`Job ${jobId} already has an open dispute`);
+
+    const now = this.clock();
+    const dispute = {
+      disputeId: this.idGenerator(),
+      jobId,
+      claimantId,
+      respondentId,
+      reason,
+      amount: amount === null ? null : round(amount),
+      currency,
+      state: 'EVIDENCE',
+      evidence: evidence ? [{ party: claimantId, evidence, at: now.toISOString() }] : [],
+      mediators: [],
+      votes: [],
+      outcome: null,
+      resolution: null,
+      evidenceDeadline: new Date(now.getTime() + this.evidenceWindowHours * HOUR_MS).toISOString(),
+      votingDeadline: null,
+      events: [],
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    this.log(dispute, 'OPENED', { claimantId, respondentId, reason });
+    return this.store.save(dispute);
+  }
+
+  async submitEvidence({ disputeId, party, evidence }) {
+    const dispute = await this.require(disputeId);
+    if (dispute.state !== 'EVIDENCE') throw new Error(`Evidence is closed for a dispute in state ${dispute.state}`);
+    if (![dispute.claimantId, dispute.respondentId].includes(party)) throw new Error('Only the parties can submit evidence');
+    if (!evidence) throw new Error('evidence is required');
+
+    dispute.evidence.push({ party, evidence, at: this.clock().toISOString() });
+    this.log(dispute, 'EVIDENCE_SUBMITTED', { party });
+    return this.store.save(dispute);
+  }
+
+  /** Fixes the panel. Voting starts when the evidence window closes, not here. */
+  async assignMediators({ disputeId, mediators }) {
+    const dispute = await this.require(disputeId);
+    if (!OPEN_STATES.has(dispute.state)) throw new Error(`Cannot assign mediators to a ${dispute.state} dispute`);
+    if (!Array.isArray(mediators) || mediators.length === 0) throw new Error('mediators must be a non-empty array');
+
+    const unique = [...new Set(mediators)];
+    const conflicted = unique.filter((id) => id === dispute.claimantId || id === dispute.respondentId);
+    if (conflicted.length) throw new Error(`A party cannot mediate their own dispute: ${conflicted.join(', ')}`);
+    if (unique.length < this.quorum) throw new Error(`At least ${this.quorum} mediators are required`);
+
+    dispute.mediators = unique;
+    // Deliberately does not open voting: the parties keep their full evidence
+    // window, and tick() starts the vote once it closes.
+    this.log(dispute, 'MEDIATORS_ASSIGNED', { mediators: unique });
+    return this.store.save(dispute);
+  }
+
+  openVoting(dispute, reason) {
+    dispute.state = 'VOTING';
+    dispute.votingDeadline = new Date(this.clock().getTime() + this.votingWindowHours * HOUR_MS).toISOString();
+    this.log(dispute, 'VOTING_OPENED', { reason, deadline: dispute.votingDeadline });
+    return dispute;
+  }
+
+  async vote({ disputeId, mediatorId, outcome, rationale = null }) {
+    const dispute = await this.require(disputeId);
+    if (dispute.state !== 'VOTING') throw new Error(`Voting is not open on a ${dispute.state} dispute`);
+    if (!dispute.mediators.includes(mediatorId)) throw new Error('Only an assigned mediator can vote');
+    if (!OUTCOMES.has(outcome)) throw new Error(`outcome must be one of ${[...OUTCOMES].join(', ')}`);
+    if (dispute.votes.some((v) => v.mediatorId === mediatorId)) throw new Error('This mediator has already voted');
+
+    dispute.votes.push({ mediatorId, outcome, rationale, at: this.clock().toISOString() });
+    this.log(dispute, 'VOTE_CAST', { mediatorId, outcome });
+
+    const decided = this.decide(dispute);
+    if (decided) return this.settle(dispute, decided, 'MAJORITY_REACHED');
+    return this.store.save(dispute);
+  }
+
+  /**
+   * `quorum` is the minimum number of votes for a verdict to count.
+   * Returns an outcome once one is mathematically certain — that is, once no
+   * distribution of the remaining votes could overturn the current leader.
+   * Waiting for every mediator when the result is already settled just keeps
+   * the funds frozen for no reason.
+   */
+  decide(dispute) {
+    const tally = this.tally(dispute);
+    const cast = dispute.votes.length;
+    const remaining = dispute.mediators.length - cast;
+    if (cast < this.quorum) return null;
+
+    const ranked = Object.entries(tally).sort((a, b) => b[1] - a[1]);
+    const [leader, leaderVotes] = ranked[0];
+    const runnerUp = ranked[1]?.[1] ?? 0;
+
+    return leaderVotes > runnerUp + remaining ? leader : null;
+  }
+
+  tally(dispute) {
+    const tally = {};
+    for (const vote of dispute.votes) tally[vote.outcome] = (tally[vote.outcome] || 0) + 1;
+    return tally;
+  }
+
+  /**
+   * Time-based resolution. Two rules, both biased towards not leaving funds
+   * frozen: a respondent who never answers forfeits, and a panel that never
+   * reaches a majority falls back to a refund rather than paying out on a
+   * contested job.
+   */
+  async tick() {
+    const now = this.clock().getTime();
+    const resolved = [];
+
+    for (const dispute of await this.store.list()) {
+      if (!OPEN_STATES.has(dispute.state)) continue;
+
+      try {
+        if (dispute.state === 'EVIDENCE' && new Date(dispute.evidenceDeadline).getTime() <= now) {
+          const respondentAnswered = dispute.evidence.some((item) => item.party === dispute.respondentId);
+          if (!respondentAnswered) {
+            resolved.push(await this.settle(dispute, 'REFUND', 'RESPONDENT_SILENT'));
+            continue;
+          }
+          if (dispute.mediators.length >= this.quorum) {
+            this.openVoting(dispute, 'EVIDENCE_WINDOW_CLOSED');
+            resolved.push(await this.store.save(dispute));
+          } else {
+            this.log(dispute, 'AWAITING_MEDIATORS', { assigned: dispute.mediators.length, required: this.quorum });
+            resolved.push(await this.store.save(dispute));
+          }
+          continue;
+        }
+
+        if (dispute.state === 'VOTING' && new Date(dispute.votingDeadline).getTime() <= now) {
+          const tally = this.tally(dispute);
+          const ranked = Object.entries(tally).sort((a, b) => b[1] - a[1]);
+          const clearWinner = ranked.length === 1 || (ranked[0] && ranked[0][1] > (ranked[1]?.[1] ?? 0));
+
+          if (dispute.votes.length >= this.quorum && clearWinner) {
+            resolved.push(await this.settle(dispute, ranked[0][0], 'VOTING_WINDOW_CLOSED'));
+          } else {
+            resolved.push(await this.settle(dispute, 'REFUND', 'NO_MAJORITY'));
+          }
+        }
+      } catch (error) {
+        this.log(dispute, 'TICK_ERROR', { error: error.message });
+        resolved.push(await this.store.save(dispute));
+      }
+    }
+
+    return resolved;
+  }
+
+  async settle(dispute, outcome, reason) {
+    dispute.state = 'RESOLVED';
+    dispute.outcome = outcome;
+    dispute.resolution = {
+      outcome,
+      reason,
+      tally: this.tally(dispute),
+      votesCast: dispute.votes.length,
+      panelSize: dispute.mediators.length,
+      at: this.clock().toISOString(),
+    };
+    this.log(dispute, 'RESOLVED', { outcome, reason });
+
+    if (this.onResolved) {
+      try {
+        await this.onResolved({ jobId: dispute.jobId, disputeId: dispute.disputeId, outcome, reason });
+        this.log(dispute, 'ESCROW_NOTIFIED', { outcome });
+      } catch (error) {
+        // The verdict stands even if the escrow could not be told about it;
+        // losing the decision because a downstream call failed would be worse.
+        this.log(dispute, 'ESCROW_NOTIFY_FAILED', { error: error.message });
+      }
+    }
+
+    return this.store.save(dispute);
+  }
+
+  async require(disputeId) {
+    const dispute = await this.store.get(disputeId);
+    if (!dispute) throw new Error('Dispute not found');
+    return dispute;
+  }
+
+  async get(disputeId) { return this.require(disputeId); }
+
+  async listByJob(jobId) { return (await this.store.list()).filter((dispute) => dispute.jobId === jobId); }
+
+  async summary() {
+    const disputes = await this.store.list();
+    const byState = {};
+    const byOutcome = {};
+    for (const dispute of disputes) {
+      byState[dispute.state] = (byState[dispute.state] || 0) + 1;
+      if (dispute.outcome) byOutcome[dispute.outcome] = (byOutcome[dispute.outcome] || 0) + 1;
+    }
+    return { generatedAt: this.clock().toISOString(), total: disputes.length, quorum: this.quorum, byState, byOutcome };
+  }
+}
+
+module.exports = { DisputeService, MemoryDisputeStore, MongoDisputeStore, OUTCOMES, HOUR_MS };

--- a/tests/disputes.test.js
+++ b/tests/disputes.test.js
@@ -1,0 +1,259 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { DisputeService, MemoryDisputeStore, HOUR_MS } = require('../services/disputeService');
+
+const START = new Date('2026-08-07T00:00:00.000Z');
+const PANEL = ['med-1', 'med-2', 'med-3'];
+
+function build(options = {}) {
+  const clock = { now: START };
+  const resolved = [];
+  const service = new DisputeService({
+    store: new MemoryDisputeStore(),
+    clock: () => clock.now,
+    onResolved: async (payload) => { resolved.push(payload); },
+    ...options,
+  });
+  return { service, clock, resolved };
+}
+
+const claim = (overrides = {}) => ({
+  jobId: 'job-1',
+  claimantId: 'client-1',
+  respondentId: 'robot-1',
+  reason: 'delivered work does not match the spec',
+  amount: 100,
+  currency: 'MYZ',
+  ...overrides,
+});
+
+async function toVoting(service, clock, options = {}) {
+  const dispute = await service.open(claim());
+  await service.submitEvidence({ disputeId: dispute.disputeId, party: 'robot-1', evidence: 'logs' });
+  await service.assignMediators({ disputeId: dispute.disputeId, mediators: options.mediators ?? PANEL });
+  clock.now = new Date(START.getTime() + 73 * HOUR_MS);
+  await service.tick();
+  return service.get(dispute.disputeId);
+}
+
+test('opens a dispute in the evidence stage', async () => {
+  const { service } = build();
+  const dispute = await service.open(claim({ evidence: 'screenshots' }));
+
+  assert.equal(dispute.state, 'EVIDENCE');
+  assert.equal(dispute.evidence.length, 1);
+  assert.equal(dispute.evidence[0].party, 'client-1');
+  assert.equal(dispute.events[0].event, 'OPENED');
+});
+
+test('rejects malformed disputes', async () => {
+  const { service } = build();
+  await assert.rejects(service.open(claim({ jobId: null })), /jobId is required/);
+  await assert.rejects(service.open(claim({ respondentId: null })), /claimantId and respondentId are required/);
+  await assert.rejects(service.open(claim({ respondentId: 'client-1' })), /must differ/);
+  await assert.rejects(service.open(claim({ reason: null })), /reason is required/);
+});
+
+test('refuses a second open dispute on the same job', async () => {
+  const { service } = build();
+  await service.open(claim());
+  await assert.rejects(service.open(claim()), /already has an open dispute/);
+});
+
+test('accepts evidence only from the parties, only while the window is open', async () => {
+  const { service } = build();
+  const dispute = await service.open(claim());
+
+  await assert.rejects(service.submitEvidence({ disputeId: dispute.disputeId, party: 'stranger', evidence: 'x' }), /Only the parties/);
+  await assert.rejects(service.submitEvidence({ disputeId: dispute.disputeId, party: 'robot-1' }), /evidence is required/);
+
+  const updated = await service.submitEvidence({ disputeId: dispute.disputeId, party: 'robot-1', evidence: 'delivery logs' });
+  assert.equal(updated.evidence.length, 1);
+  assert.equal(updated.events.at(-1).event, 'EVIDENCE_SUBMITTED');
+});
+
+test('refuses a party as their own mediator and enforces quorum', async () => {
+  const { service } = build();
+  const dispute = await service.open(claim());
+
+  await assert.rejects(
+    service.assignMediators({ disputeId: dispute.disputeId, mediators: ['med-1', 'client-1', 'med-2'] }),
+    /cannot mediate their own dispute: client-1/,
+  );
+  await assert.rejects(
+    service.assignMediators({ disputeId: dispute.disputeId, mediators: ['med-1'] }),
+    /At least 2 mediators/,
+  );
+  await assert.rejects(service.assignMediators({ disputeId: dispute.disputeId, mediators: [] }), /non-empty array/);
+});
+
+test('assigning the panel does not cut the evidence window short', async () => {
+  const { service, clock } = build();
+  const dispute = await service.open(claim());
+  const assigned = await service.assignMediators({ disputeId: dispute.disputeId, mediators: PANEL });
+
+  // The parties keep their full window even once mediators are lined up.
+  assert.equal(assigned.state, 'EVIDENCE');
+  assert.equal(assigned.votingDeadline, null);
+
+  await service.submitEvidence({ disputeId: dispute.disputeId, party: 'robot-1', evidence: 'logs' });
+  clock.now = new Date(START.getTime() + 73 * HOUR_MS);
+  await service.tick();
+
+  const voting = await service.get(dispute.disputeId);
+  assert.equal(voting.state, 'VOTING');
+  assert.ok(voting.votingDeadline);
+});
+
+test('rejects votes from outsiders, duplicates and unknown outcomes', async () => {
+  const { service, clock } = build();
+  const dispute = await toVoting(service, clock);
+
+  await assert.rejects(service.vote({ disputeId: dispute.disputeId, mediatorId: 'stranger', outcome: 'RELEASE' }), /Only an assigned mediator/);
+  await assert.rejects(service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'MAYBE' }), /outcome must be one of/);
+
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  await assert.rejects(service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'REFUND' }), /already voted/);
+});
+
+test('resolves as soon as the result cannot be overturned', async () => {
+  const { service, clock, resolved } = build();
+  const dispute = await toVoting(service, clock);
+
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'REFUND' });
+  const afterTwo = await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'REFUND' });
+
+  // Two REFUND against one outstanding vote: the third cannot change it, so the
+  // funds are freed now rather than after another 72 hours.
+  assert.equal(afterTwo.state, 'RESOLVED');
+  assert.equal(afterTwo.outcome, 'REFUND');
+  assert.equal(afterTwo.resolution.reason, 'MAJORITY_REACHED');
+  assert.equal(afterTwo.resolution.votesCast, 2);
+  assert.deepEqual(resolved, [{ jobId: 'job-1', disputeId: dispute.disputeId, outcome: 'REFUND', reason: 'MAJORITY_REACHED' }]);
+});
+
+test('waits when the outcome is still reachable by the remaining voters', async () => {
+  const { service, clock } = build({ quorum: 3 });
+  const dispute = await toVoting(service, clock, { mediators: ['med-1', 'med-2', 'med-3', 'med-4', 'med-5'] });
+
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'REFUND' });
+  const afterThree = await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-3', outcome: 'RELEASE' });
+
+  // 2-1 with two votes outstanding is still reversible.
+  assert.equal(afterThree.state, 'VOTING');
+
+  const afterFour = await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-4', outcome: 'RELEASE' });
+  assert.equal(afterFour.state, 'RESOLVED');
+  assert.equal(afterFour.outcome, 'RELEASE');
+});
+
+test('a silent respondent forfeits when the evidence window closes', async () => {
+  const { service, clock, resolved } = build();
+  await service.open(claim());
+
+  clock.now = new Date(START.getTime() + 73 * HOUR_MS);
+  const [dispute] = await service.tick();
+
+  assert.equal(dispute.state, 'RESOLVED');
+  assert.equal(dispute.outcome, 'REFUND');
+  assert.equal(dispute.resolution.reason, 'RESPONDENT_SILENT');
+  assert.equal(resolved.length, 1);
+});
+
+test('a responding respondent moves to voting rather than forfeiting', async () => {
+  const { service, clock } = build();
+  const opened = await service.open(claim());
+  await service.submitEvidence({ disputeId: opened.disputeId, party: 'robot-1', evidence: 'proof of delivery' });
+  await service.assignMediators({ disputeId: opened.disputeId, mediators: PANEL });
+
+  clock.now = new Date(START.getTime() + 73 * HOUR_MS);
+  await service.tick();
+
+  assert.equal((await service.get(opened.disputeId)).state, 'VOTING');
+});
+
+test('an unfinished vote falls back to a refund, not a payout', async () => {
+  const { service, clock } = build();
+  const dispute = await toVoting(service, clock);
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+
+  clock.now = new Date(START.getTime() + 200 * HOUR_MS);
+  const [resolvedDispute] = await service.tick();
+
+  // One vote is below quorum. Paying out a contested job on a single opinion
+  // would be worse than returning the money.
+  assert.equal(resolvedDispute.outcome, 'REFUND');
+  assert.equal(resolvedDispute.resolution.reason, 'NO_MAJORITY');
+});
+
+test('a tied panel falls back to a refund', async () => {
+  const { service, clock } = build({ quorum: 2 });
+  const dispute = await toVoting(service, clock, { mediators: ['med-1', 'med-2', 'med-3', 'med-4'] });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'REFUND' });
+
+  clock.now = new Date(START.getTime() + 200 * HOUR_MS);
+  const [resolvedDispute] = await service.tick();
+
+  assert.equal(resolvedDispute.outcome, 'REFUND');
+  assert.equal(resolvedDispute.resolution.reason, 'NO_MAJORITY');
+});
+
+test('a majority reached before the deadline is honoured by the tick', async () => {
+  const { service, clock } = build({ quorum: 2 });
+  const dispute = await toVoting(service, clock, { mediators: ['med-1', 'med-2', 'med-3', 'med-4'] });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'RELEASE' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-3', outcome: 'REFUND' });
+
+  clock.now = new Date(START.getTime() + 200 * HOUR_MS);
+  const state = await service.get(dispute.disputeId);
+  if (state.state === 'VOTING') await service.tick();
+
+  const finished = await service.get(dispute.disputeId);
+  assert.equal(finished.outcome, 'RELEASE');
+});
+
+test('the verdict stands even if the escrow callback fails', async () => {
+  const { service, clock } = build({ onResolved: async () => { throw new Error('escrow unreachable'); } });
+  const dispute = await toVoting(service, clock);
+
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  const settled = await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'RELEASE' });
+
+  assert.equal(settled.state, 'RESOLVED');
+  assert.equal(settled.outcome, 'RELEASE');
+  assert.ok(settled.events.some((e) => e.event === 'ESCROW_NOTIFY_FAILED'));
+});
+
+test('tick leaves resolved disputes alone', async () => {
+  const { service, clock, resolved } = build();
+  const dispute = await toVoting(service, clock);
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'REFUND' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'REFUND' });
+
+  clock.now = new Date(START.getTime() + 500 * HOUR_MS);
+  await service.tick();
+  await service.tick();
+
+  assert.equal(resolved.length, 1);
+});
+
+test('summarises the docket', async () => {
+  const { service, clock } = build();
+  const dispute = await toVoting(service, clock);
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-1', outcome: 'RELEASE' });
+  await service.vote({ disputeId: dispute.disputeId, mediatorId: 'med-2', outcome: 'RELEASE' });
+  await service.open(claim({ jobId: 'job-2' }));
+
+  const summary = await service.summary();
+  assert.equal(summary.total, 2);
+  assert.equal(summary.byState.RESOLVED, 1);
+  assert.equal(summary.byState.EVIDENCE, 1);
+  assert.equal(summary.byOutcome.RELEASE, 1);
+
+  assert.equal((await service.listByJob('job-2')).length, 1);
+  await assert.rejects(service.get('nope'), /Dispute not found/);
+});


### PR DESCRIPTION
Closes #727.

All four acceptance criteria — apertura dispute, mediazione, votazione, risoluzione automatica.

This is the downstream of #777: escrow automation routes a failed verification to `DISPUTED`, and this is what decides those cases.

| Method | Path | Purpose |
| --- | --- | --- |
| `POST` | `/api/disputes` | Open a case, starting the evidence window |
| `POST` | `/api/disputes/:id/evidence` | Submit evidence (parties only) |
| `POST` | `/api/disputes/:id/mediators` | Fix the panel |
| `POST` | `/api/disputes/:id/votes` | Cast a vote — `RELEASE`, `REFUND` or `SPLIT` |
| `POST` | `/api/disputes/tick` | Advance everything that is due |
| `GET` | `/api/disputes/:id` · `/job/:jobId` · `/summary` | State, per-job history, docket |

## The property I designed around

A dispute system fails **the party who is in the right**. If the process can stall, their money stays frozen and the other side wins by simply not participating. So every stage has a deadline and `tick()` resolves whatever runs out of time. Four consequences, each with a test:

**A silent respondent forfeits.** Evidence window closes with nothing from them → the claimant wins by default. Ignoring a dispute must not be a viable strategy.

**No majority means refund, not payout.** Below quorum or tied at the deadline → the money goes back to the client. Of the two possible errors this is the cheaper one: paying out a contested job on an inconclusive vote costs the client money they may be owed, while a refund only costs the robot work it could not get the panel to endorse.

**Voting ends as soon as the result is mathematically certain.** Once no distribution of the outstanding votes could overturn the leader, the verdict lands — with a three-person panel, two matching votes finish it rather than freezing the funds for another 72 hours waiting on a vote that cannot matter.

**Assigning mediators deliberately does not start the vote.** I had it that way first and a test caught the consequence: lining up a panel early would cut the other side's evidence window short. Voting now opens from `tick()` when the window actually closes.

Also: a claimant or respondent is refused as a mediator on their own case, by name rather than silently filtered. And if the escrow callback throws, the verdict still stands and the failure is logged as `ESCROW_NOTIFY_FAILED` — losing a decided outcome to a timed-out notification would be worse than a retryable one.

## Wiring

```js
const disputes = new DisputeService({
  onResolved: ({ jobId, outcome }) =>
    escrow.resolve({ jobId, outcome: outcome === 'RELEASE' ? 'RELEASE' : 'REFUND' }),
});
```

Independent of #777 — this merges and works on its own.

## Tests

```
node --test tests/disputes.test.js
```

17 passing — evidence access control, panel conflict-of-interest, the evidence window surviving early assignment, early resolution on an unbeatable lead, holding when the lead is still reachable, silent-respondent forfeit, sub-quorum and tied fallbacks, verdict survival when the callback throws, tick idempotency, docket summary. HTTP layer exercised end to end before pushing.

`createRobot.test.js` fails and `rateLimiter.test.js` hangs on `main` independently of this branch — untouched here.

---

Re: reward — **XMR rather than MYZ** whenever funds allow, no rush. At your published garden rates (~6,300 MYZ/XMR) the listed 1,000 MYZ is about **0.159 XMR**.

```
45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8
```
