### PR TITLE
feat: add Monero payment gateway for fuel stations

### DIFF
--- a/docs/XMR_GATEWAY.md
+++ b/docs/XMR_GATEWAY.md
@@ -1,0 +1,72 @@
+# Monero payment gateway (BENZINA-XMR)
+
+Takes XMR at the pump: one subaddress per order, confirmation-gated settlement, and no credentials in logs.
+
+## Why not extend `services/xmrService.js`
+
+That module cannot work as a gateway, for four reasons worth stating plainly:
+
+1. **`generatePaymentAddress()` returns one static address for every customer.** With a shared address there is no way to tell whose payment arrived — two customers paying the same amount are indistinguishable. Attribution has to come from the address itself.
+2. **`get_transaction` is not a Monero RPC method.** The daemon exposes `get_transactions` (plural, `txs_hashes`); the wallet exposes `get_transfer_by_txid`. The call is also aimed at port 18081 — the daemon — while reading `tx.amount`, a wallet-level field.
+3. **`verified: amount >= expectedAmount` ignores confirmations entirely.** A zero-confirmation transaction would pass. At a fuel pump that means dispensing against a reversible payment.
+4. **No authentication.** `monero-wallet-rpc` is normally behind digest auth.
+
+So this is a separate service. `xmrService.js` is untouched, and nothing currently using it changes.
+
+## API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/xmr-gateway/health` | Wallet reachability and chain height |
+| `POST` | `/api/xmr-gateway/invoices` | Create an invoice — returns a dedicated subaddress |
+| `GET` | `/api/xmr-gateway/invoices/:orderId` | Current state |
+| `POST` | `/api/xmr-gateway/invoices/:orderId/check` | Re-read the chain for this invoice |
+| `POST` | `/api/xmr-gateway/sweep` | Advance every open invoice |
+| `POST` | `/api/xmr-gateway/validate-address` | Ask the wallet whether an address is real |
+| `GET` | `/api/xmr-gateway/summary` | Counts by state and settled total |
+
+## Invoice states
+
+```
+AWAITING_PAYMENT ──▶ PARTIALLY_PAID ──▶ CONFIRMING ──▶ PAID
+        │
+        └── ttl elapsed, nothing received ──▶ EXPIRED
+```
+
+**Fuel is dispensed on `PAID` only**, which requires `XMR_MIN_CONFIRMATIONS` (default 10). When an invoice is paid by several transfers, the **least-confirmed** one gates it: enough money that is only one block deep is not yet money.
+
+**A partial payment keeps the invoice open** rather than expiring it, so the customer can top up instead of losing what they already sent. Only an invoice with nothing received can expire.
+
+**An overpayment settles** and is recorded as an `OVERPAID` event. **A transfer flagged `double_spend_seen` is ignored** and does not count toward the total.
+
+## Money is never a float
+
+Amounts are parsed into atomic piconero as `BigInt` and only formatted for display. A double cannot hold 12 decimals without drift, and a gateway that is off by a rounding error is a gateway that loses money in one direction and overcharges in the other. `0.1 + 0.2` reports exactly `0.3`, and there is a test for it. Atomic values cross the API and the database as **strings** for the same reason.
+
+Rejected at the door: negative amounts, zero, more than 12 decimal places, exponent notation, and anything non-numeric.
+
+## Security
+
+- **Digest auth** via `MONERO_RPC_USER` / `MONERO_RPC_PASSWORD`.
+- **Credentials are scrubbed from errors.** The RPC password lives in the axios config, which axios copies into its error objects — so every error is passed through `redact()` before it can reach a log line or an HTTP response. There is a test asserting the password never appears in a thrown error.
+- **Addresses are validated by the wallet**, not by a regex in our code.
+- **Invoices expire**, so a stale address is not left indefinitely associated with an open order.
+- Confirmation gating is the anti-double-spend measure; `double_spend_seen` transfers are dropped outright.
+
+## Configuration
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `MONERO_WALLET_RPC_URL` | *(unset)* | monero-wallet-rpc endpoint. Unset means simulation mode. |
+| `MONERO_RPC_USER` / `MONERO_RPC_PASSWORD` | *(unset)* | Digest auth |
+| `XMR_MIN_CONFIRMATIONS` | `10` | Blocks before `PAID` |
+
+With `MONERO_WALLET_RPC_URL` unset the routes run against an in-memory wallet and report `"simulated": true`. A simulated `PAID` is not a real payment — do not wire a pump to it.
+
+## Tests
+
+```
+node --test tests/moneroGateway.test.js
+```
+
+22 passing — exact atomic conversion and every rejected amount form, one subaddress per invoice, idempotent creation, zero-confirmation never settling, the least-confirmed transfer gating a multi-transfer invoice, top-up after partial payment, overpayment, double-spend rejection, cross-invoice isolation, ttl expiry sparing partially paid invoices, sweep skipping settled invoices, wallet-side address validation, and the password never leaking into an error.

--- a/models/XmrInvoice.js
+++ b/models/XmrInvoice.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+// Atomic amounts are stored as strings, not Numbers: piconero exceeds the
+// precision of a double, and a rounded balance is a wrong balance.
+const XmrInvoiceSchema = new mongoose.Schema({
+  orderId: { type: String, required: true, unique: true, index: true },
+  stationId: { type: String, default: null, index: true },
+  pumpId: { type: String, default: null },
+  address: { type: String, required: true, index: true },
+  addressIndex: { type: Number, required: true },
+  accountIndex: { type: Number, default: 0 },
+  expectedAtomic: { type: String, required: true },
+  expectedXmr: { type: String, required: true },
+  paidAtomic: { type: String, default: '0' },
+  paidXmr: { type: String, default: '0' },
+  confirmations: { type: Number, default: 0 },
+  requiredConfirmations: { type: Number, required: true },
+  state: {
+    type: String,
+    enum: ['AWAITING_PAYMENT', 'PARTIALLY_PAID', 'CONFIRMING', 'PAID', 'EXPIRED'],
+    default: 'AWAITING_PAYMENT',
+    index: true
+  },
+  transactions: { type: Array, default: [] },
+  metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+  expiresAt: { type: String, required: true },
+  events: { type: Array, default: [] },
+  createdAt: { type: String, required: true },
+  updatedAt: { type: String, required: true }
+}, { versionKey: false });
+
+XmrInvoiceSchema.index({ state: 1, expiresAt: 1 });
+
+module.exports = mongoose.model('XmrInvoice', XmrInvoiceSchema);

--- a/routes/xmrGateway.js
+++ b/routes/xmrGateway.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const {
+  MoneroPaymentGateway,
+  MemoryInvoiceStore,
+  MongoInvoiceStore,
+  SimulatedWalletRpc,
+  createWalletRpc,
+} = require('../services/moneroGatewayService');
+
+const router = express.Router();
+
+function buildStore() {
+  if (mongoose.connection?.readyState === 1) {
+    return new MongoInvoiceStore(require('../models/XmrInvoice'));
+  }
+  return new MemoryInvoiceStore();
+}
+
+const simulated = !process.env.MONERO_WALLET_RPC_URL;
+const rpc = simulated ? new SimulatedWalletRpc() : createWalletRpc();
+const gateway = new MoneroPaymentGateway({ rpc, store: buildStore() });
+
+const fail = (res, error) => {
+  const notFound = error.message === 'Invoice not found';
+  return res.status(notFound ? 404 : 400).json({ success: false, error: error.message });
+};
+
+router.get('/health', async (_req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.health() }); }
+  catch (error) { return res.status(503).json({ success: false, simulated, error: error.message }); }
+});
+
+router.post('/invoices', async (req, res) => {
+  try { return res.status(201).json({ success: true, simulated, data: await gateway.createInvoice(req.body) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/invoices/:orderId', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.get(req.params.orderId) }); }
+  catch (error) { return fail(res, error); }
+});
+
+// Re-reads the chain for this invoice. Safe to poll from a pump terminal.
+router.post('/invoices/:orderId/check', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.checkInvoice(req.params.orderId) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.post('/sweep', async (_req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.sweep() }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.post('/validate-address', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.validateAddress(req.body?.address) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/summary', async (_req, res) => {
+  try { return res.json({ success: true, simulated, data: await gateway.summary() }); }
+  catch (error) { return fail(res, error); }
+});
+
+module.exports = router;
+module.exports.gateway = gateway;

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ const sensorRoutes = require('./routes/sensors');
 const securityRoutes = require('./routes/security');
 const xmrRoutes = require('./routes/xmr');
 const gl1BridgeRoutes = require('./routes/gl1Bridge');
+const xmrGatewayRoutes = require('./routes/xmrGateway');
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -67,6 +68,7 @@ app.use('/api/sensors', sensorRoutes);
 app.use('/api/security', securityRoutes);
 app.use('/api/xmr', xmrRoutes);
 app.use('/api/gl1', gl1BridgeRoutes);
+app.use('/api/xmr-gateway', xmrGatewayRoutes);
 
 // Robot routes
 try {

--- a/services/moneroGatewayService.js
+++ b/services/moneroGatewayService.js
@@ -1,0 +1,288 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const ATOMIC_PER_XMR = 1_000_000_000_000n;
+const OPEN_STATES = new Set(['AWAITING_PAYMENT', 'PARTIALLY_PAID', 'CONFIRMING']);
+
+/**
+ * Money is handled as atomic piconero in BigInt and only formatted for display.
+ * A float cannot hold 12 decimals without drift, and "close enough" is not a
+ * property a payment gateway may have.
+ */
+function toAtomic(amountXmr) {
+  const text = String(amountXmr).trim();
+  if (!/^\d+(\.\d{1,12})?$/.test(text)) throw new Error('amount must be a positive decimal with at most 12 places');
+  const [whole, fraction = ''] = text.split('.');
+  const atomic = BigInt(whole) * ATOMIC_PER_XMR + BigInt(fraction.padEnd(12, '0'));
+  if (atomic <= 0n) throw new Error('amount must be greater than zero');
+  return atomic;
+}
+
+function formatXmr(atomic) {
+  const value = BigInt(atomic);
+  const whole = value / ATOMIC_PER_XMR;
+  const fraction = (value % ATOMIC_PER_XMR).toString().padStart(12, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : String(whole);
+}
+
+/** Strips anything credential-shaped out of text that may reach a log or an API response. */
+function redact(text, secrets = []) {
+  let safe = String(text ?? '');
+  for (const secret of secrets.filter(Boolean)) safe = safe.split(secret).join('***');
+  // The separator is required, so the surrounding syntax survives redaction
+  // and a redacted JSON blob stays parseable.
+  return safe.replace(/(password|passwd|secret|viewkey|spendkey|seed)(\s*["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1$2***');
+}
+
+class MemoryInvoiceStore {
+  constructor() { this.items = new Map(); }
+  async save(invoice) { this.items.set(invoice.orderId, structuredClone(invoice)); return structuredClone(invoice); }
+  async get(orderId) { const item = this.items.get(orderId); return item ? structuredClone(item) : null; }
+  async list() { return [...this.items.values()].map((item) => structuredClone(item)); }
+}
+
+class MongoInvoiceStore {
+  constructor(model) { this.model = model; }
+  async save(invoice) {
+    const saved = await this.model.findOneAndUpdate({ orderId: invoice.orderId }, invoice, { upsert: true, new: true, lean: true });
+    return this.strip(saved);
+  }
+  async get(orderId) { return this.strip(await this.model.findOne({ orderId }).lean()); }
+  async list() { return (await this.model.find().lean()).map((doc) => this.strip(doc)); }
+  strip(doc) { if (!doc) return null; const { _id, __v, ...rest } = doc; return rest; }
+}
+
+/**
+ * monero-wallet-rpc client. Uses the wallet RPC — not the daemon — because
+ * subaddress creation and per-address transfer lookup only exist there.
+ * Digest auth is the default for monero-wallet-rpc, so it is supported here.
+ */
+function createWalletRpc({ url = process.env.MONERO_WALLET_RPC_URL, username = process.env.MONERO_RPC_USER, password = process.env.MONERO_RPC_PASSWORD, client = axios, timeoutMs = 15000 } = {}) {
+  if (!url) throw new Error('MONERO_WALLET_RPC_URL is required');
+
+  const secrets = [password];
+  const http = client.create
+    ? client.create({ baseURL: url, timeout: timeoutMs, ...(username ? { auth: { username, password } } : {}) })
+    : client;
+
+  return {
+    async call(method, params = {}) {
+      try {
+        const response = await http.post('/json_rpc', { jsonrpc: '2.0', id: 'myz-gateway', method, params }, { timeout: timeoutMs });
+        const body = response?.data;
+        if (body?.error) throw new Error(`wallet rpc ${method}: ${body.error.message ?? 'unknown error'}`);
+        return body?.result ?? {};
+      } catch (error) {
+        // The password lives in the axios config, which ends up inside axios
+        // error objects. Never let it reach a log line or an HTTP response.
+        throw new Error(redact(error.message, secrets));
+      }
+    },
+  };
+}
+
+class SimulatedWalletRpc {
+  constructor() {
+    this.nextIndex = 1;
+    this.transfers = [];
+    this.height = 3_000_000;
+    this.calls = [];
+  }
+  credit({ addressIndex, amountXmr, confirmations = 0, txid = crypto.randomUUID().replace(/-/g, '') }) {
+    this.transfers.push({ subaddr_index: { major: 0, minor: addressIndex }, amount: Number(toAtomic(amountXmr)), confirmations, txid, double_spend_seen: false, unlock_time: 0 });
+    return txid;
+  }
+  async call(method, params = {}) {
+    this.calls.push({ method, params });
+    if (method === 'create_address') return { address: `8SIM${String(this.nextIndex).padStart(4, '0')}`, address_index: this.nextIndex++ };
+    if (method === 'validate_address') return { valid: /^[48]/.test(params.address ?? ''), nettype: 'mainnet' };
+    if (method === 'get_height') return { height: this.height };
+    if (method === 'get_transfers') {
+      const wanted = new Set(params.subaddr_indices ?? []);
+      return { in: this.transfers.filter((t) => wanted.size === 0 || wanted.has(t.subaddr_index.minor)) };
+    }
+    throw new Error(`unsupported method ${method}`);
+  }
+}
+
+class MoneroPaymentGateway {
+  constructor({
+    rpc,
+    store = new MemoryInvoiceStore(),
+    accountIndex = 0,
+    requiredConfirmations = Number(process.env.XMR_MIN_CONFIRMATIONS || 10),
+    invoiceTtlMinutes = 60,
+    clock = () => new Date(),
+  } = {}) {
+    if (!rpc) throw new Error('An RPC client is required');
+    this.rpc = rpc;
+    this.store = store;
+    this.accountIndex = accountIndex;
+    this.requiredConfirmations = requiredConfirmations;
+    this.invoiceTtlMinutes = invoiceTtlMinutes;
+    this.clock = clock;
+  }
+
+  log(invoice, event, detail = {}) {
+    invoice.events.push({ event, at: this.clock().toISOString(), ...detail });
+    invoice.updatedAt = this.clock().toISOString();
+    return invoice;
+  }
+
+  async health() {
+    const { height } = await this.rpc.call('get_height');
+    return { connected: true, height, requiredConfirmations: this.requiredConfirmations };
+  }
+
+  /**
+   * One fresh subaddress per invoice. A shared static address makes it
+   * impossible to tell whose payment arrived — two customers paying the same
+   * amount are indistinguishable — so attribution has to come from the address.
+   */
+  async createInvoice({ orderId, amountXmr, stationId = null, pumpId = null, metadata = {} }) {
+    if (!orderId) throw new Error('orderId is required');
+    const expectedAtomic = toAtomic(amountXmr);
+
+    const existing = await this.store.get(orderId);
+    if (existing) return existing;
+
+    const { address, address_index: addressIndex } = await this.rpc.call('create_address', {
+      account_index: this.accountIndex,
+      label: `order:${orderId}`,
+    });
+    if (!address || addressIndex === undefined) throw new Error('wallet did not return a subaddress');
+
+    const now = this.clock();
+    const invoice = {
+      orderId,
+      stationId,
+      pumpId,
+      address,
+      addressIndex,
+      accountIndex: this.accountIndex,
+      expectedAtomic: expectedAtomic.toString(),
+      expectedXmr: formatXmr(expectedAtomic),
+      paidAtomic: '0',
+      paidXmr: '0',
+      confirmations: 0,
+      requiredConfirmations: this.requiredConfirmations,
+      state: 'AWAITING_PAYMENT',
+      transactions: [],
+      metadata,
+      expiresAt: new Date(now.getTime() + this.invoiceTtlMinutes * 60_000).toISOString(),
+      events: [],
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    };
+
+    this.log(invoice, 'INVOICE_CREATED', { address, expectedXmr: invoice.expectedXmr });
+    return this.store.save(invoice);
+  }
+
+  /**
+   * Reads every transfer that landed on this invoice's subaddress and decides
+   * the state. Fuel is only dispensed on PAID, which requires the confirmation
+   * threshold — a zero-confirmation transaction is reversible, and handing out
+   * fuel against one is a free tank.
+   */
+  async checkInvoice(orderId) {
+    const invoice = await this.require(orderId);
+    if (!OPEN_STATES.has(invoice.state)) return invoice;
+
+    const { in: transfers = [] } = await this.rpc.call('get_transfers', {
+      in: true,
+      account_index: invoice.accountIndex,
+      subaddr_indices: [invoice.addressIndex],
+    });
+
+    const mine = transfers.filter((transfer) => transfer.subaddr_index?.minor === invoice.addressIndex);
+    let paid = 0n;
+    let minConfirmations = null;
+    const seen = [];
+
+    for (const transfer of mine) {
+      if (transfer.double_spend_seen) {
+        this.log(invoice, 'DOUBLE_SPEND_IGNORED', { txid: transfer.txid });
+        continue;
+      }
+      paid += BigInt(transfer.amount);
+      minConfirmations = minConfirmations === null ? (transfer.confirmations ?? 0) : Math.min(minConfirmations, transfer.confirmations ?? 0);
+      seen.push({ txid: transfer.txid, atomic: String(transfer.amount), xmr: formatXmr(transfer.amount), confirmations: transfer.confirmations ?? 0 });
+    }
+
+    const expected = BigInt(invoice.expectedAtomic);
+    invoice.paidAtomic = paid.toString();
+    invoice.paidXmr = formatXmr(paid);
+    invoice.confirmations = minConfirmations ?? 0;
+    invoice.transactions = seen;
+
+    const previousState = invoice.state;
+    if (paid === 0n) {
+      invoice.state = new Date(invoice.expiresAt).getTime() <= this.clock().getTime() ? 'EXPIRED' : 'AWAITING_PAYMENT';
+    } else if (paid < expected) {
+      // Partial payment keeps the invoice open rather than expiring it, so the
+      // customer can top up instead of losing what they already sent.
+      invoice.state = 'PARTIALLY_PAID';
+    } else if ((minConfirmations ?? 0) < this.requiredConfirmations) {
+      invoice.state = 'CONFIRMING';
+    } else {
+      invoice.state = 'PAID';
+      if (paid > expected) this.log(invoice, 'OVERPAID', { overpaidXmr: formatXmr(paid - expected) });
+    }
+
+    if (invoice.state !== previousState) this.log(invoice, invoice.state, { paidXmr: invoice.paidXmr, confirmations: invoice.confirmations });
+    return this.store.save(invoice);
+  }
+
+  /** Idempotent sweep for a scheduler; settled invoices are skipped. */
+  async sweep() {
+    const results = [];
+    for (const invoice of await this.store.list()) {
+      if (!OPEN_STATES.has(invoice.state)) continue;
+      try {
+        results.push(await this.checkInvoice(invoice.orderId));
+      } catch (error) {
+        results.push({ orderId: invoice.orderId, state: 'ERROR', error: error.message });
+      }
+    }
+    return results;
+  }
+
+  /** Never trust an address supplied by a caller; the wallet decides if it is real. */
+  async validateAddress(address) {
+    if (!address) throw new Error('address is required');
+    const result = await this.rpc.call('validate_address', { address, any_net_type: false });
+    return { address, valid: Boolean(result.valid), nettype: result.nettype ?? null };
+  }
+
+  async require(orderId) {
+    const invoice = await this.store.get(orderId);
+    if (!invoice) throw new Error('Invoice not found');
+    return invoice;
+  }
+
+  async get(orderId) { return this.require(orderId); }
+
+  async summary() {
+    const invoices = await this.store.list();
+    const byState = {};
+    let settled = 0n;
+    for (const invoice of invoices) {
+      byState[invoice.state] = (byState[invoice.state] || 0) + 1;
+      if (invoice.state === 'PAID') settled += BigInt(invoice.paidAtomic);
+    }
+    return { generatedAt: this.clock().toISOString(), total: invoices.length, byState, settledXmr: formatXmr(settled) };
+  }
+}
+
+module.exports = {
+  MoneroPaymentGateway,
+  MemoryInvoiceStore,
+  MongoInvoiceStore,
+  SimulatedWalletRpc,
+  createWalletRpc,
+  toAtomic,
+  formatXmr,
+  redact,
+  ATOMIC_PER_XMR,
+};

--- a/tests/moneroGateway.test.js
+++ b/tests/moneroGateway.test.js
@@ -1,0 +1,256 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MoneroPaymentGateway,
+  MemoryInvoiceStore,
+  SimulatedWalletRpc,
+  createWalletRpc,
+  toAtomic,
+  formatXmr,
+  redact,
+} = require('../services/moneroGatewayService');
+
+const START = new Date('2026-08-07T00:00:00.000Z');
+
+function build(options = {}) {
+  const clock = { now: START };
+  const rpc = new SimulatedWalletRpc();
+  const gateway = new MoneroPaymentGateway({ rpc, store: new MemoryInvoiceStore(), clock: () => clock.now, ...options });
+  return { gateway, rpc, clock };
+}
+
+const order = (overrides = {}) => ({ orderId: 'order-1', amountXmr: '0.5', stationId: 'station-7', pumpId: '3', ...overrides });
+
+test('atomic conversion is exact at 12 decimals', () => {
+  assert.equal(toAtomic('1').toString(), '1000000000000');
+  assert.equal(toAtomic('0.000000000001').toString(), '1');
+  assert.equal(toAtomic('0.1').toString(), '100000000000');
+
+  // The float trap: 0.1 + 0.2 must be exactly 0.3.
+  assert.equal(formatXmr(toAtomic('0.1') + toAtomic('0.2')), '0.3');
+  assert.equal(formatXmr(toAtomic('12.345678901234')), '12.345678901234');
+  assert.equal(formatXmr('1000000000000'), '1');
+});
+
+test('rejects amounts a payment gateway must not accept', () => {
+  assert.throws(() => toAtomic('0'), /greater than zero/);
+  assert.throws(() => toAtomic('-1'), /positive decimal/);
+  assert.throws(() => toAtomic('0.0000000000001'), /at most 12 places/);
+  assert.throws(() => toAtomic('abc'), /positive decimal/);
+  assert.throws(() => toAtomic('1e-3'), /positive decimal/);
+});
+
+test('requires an rpc client', () => {
+  assert.throws(() => new MoneroPaymentGateway({}), /RPC client is required/);
+});
+
+test('issues a fresh subaddress per invoice', async () => {
+  const { gateway, rpc } = build();
+
+  const first = await gateway.createInvoice(order());
+  const second = await gateway.createInvoice(order({ orderId: 'order-2' }));
+
+  assert.notEqual(first.address, second.address);
+  assert.notEqual(first.addressIndex, second.addressIndex);
+  assert.equal(first.state, 'AWAITING_PAYMENT');
+  assert.equal(first.expectedXmr, '0.5');
+  assert.equal(rpc.calls[0].params.label, 'order:order-1');
+});
+
+test('createInvoice is idempotent on orderId', async () => {
+  const { gateway } = build();
+  const first = await gateway.createInvoice(order());
+  const again = await gateway.createInvoice(order({ amountXmr: '99' }));
+
+  assert.equal(again.address, first.address);
+  assert.equal(again.expectedXmr, '0.5');
+});
+
+test('rejects an invoice without an order id', async () => {
+  const { gateway } = build();
+  await assert.rejects(gateway.createInvoice({ amountXmr: '1' }), /orderId is required/);
+});
+
+test('an unconfirmed payment is CONFIRMING, never PAID', async () => {
+  const { gateway, rpc } = build();
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.5', confirmations: 0 });
+
+  const checked = await gateway.checkInvoice('order-1');
+
+  // Dispensing fuel against a zero-confirmation transaction is a free tank.
+  assert.equal(checked.state, 'CONFIRMING');
+  assert.equal(checked.paidXmr, '0.5');
+  assert.equal(checked.confirmations, 0);
+});
+
+test('settles once the confirmation threshold is met', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 3 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.5', confirmations: 3 });
+
+  const checked = await gateway.checkInvoice('order-1');
+
+  assert.equal(checked.state, 'PAID');
+  assert.equal(checked.transactions.length, 1);
+  assert.ok(checked.events.some((e) => e.event === 'PAID'));
+});
+
+test('a partial payment stays open so the customer can top up', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.2', confirmations: 5 });
+
+  const partial = await gateway.checkInvoice('order-1');
+  assert.equal(partial.state, 'PARTIALLY_PAID');
+  assert.equal(partial.paidXmr, '0.2');
+
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.3', confirmations: 5 });
+  const settled = await gateway.checkInvoice('order-1');
+
+  assert.equal(settled.state, 'PAID');
+  assert.equal(settled.paidXmr, '0.5');
+  assert.equal(settled.transactions.length, 2);
+});
+
+test('the least-confirmed transfer gates a multi-transfer invoice', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 5 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.3', confirmations: 20 });
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.2', confirmations: 1 });
+
+  const checked = await gateway.checkInvoice('order-1');
+
+  // Enough money, but part of it is one block deep. The weakest leg decides.
+  assert.equal(checked.state, 'CONFIRMING');
+  assert.equal(checked.confirmations, 1);
+});
+
+test('records an overpayment and still settles', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.7', confirmations: 5 });
+
+  const checked = await gateway.checkInvoice('order-1');
+
+  assert.equal(checked.state, 'PAID');
+  assert.ok(checked.events.some((e) => e.event === 'OVERPAID' && e.overpaidXmr === '0.2'));
+});
+
+test('ignores a transfer the daemon flagged as a double spend', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.5', confirmations: 9 });
+  rpc.transfers.at(-1).double_spend_seen = true;
+
+  const checked = await gateway.checkInvoice('order-1');
+
+  assert.equal(checked.paidXmr, '0');
+  assert.equal(checked.state, 'AWAITING_PAYMENT');
+  assert.ok(checked.events.some((e) => e.event === 'DOUBLE_SPEND_IGNORED'));
+});
+
+test('never credits another invoice\'s subaddress', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const mine = await gateway.createInvoice(order());
+  const theirs = await gateway.createInvoice(order({ orderId: 'order-2' }));
+  rpc.credit({ addressIndex: theirs.addressIndex, amountXmr: '0.5', confirmations: 9 });
+
+  assert.equal((await gateway.checkInvoice('order-1')).paidXmr, '0');
+  assert.equal((await gateway.checkInvoice('order-2')).state, 'PAID');
+  assert.ok(mine.addressIndex !== theirs.addressIndex);
+});
+
+test('expires an unpaid invoice after its ttl', async () => {
+  const { gateway, clock } = build({ invoiceTtlMinutes: 30 });
+  await gateway.createInvoice(order());
+
+  clock.now = new Date(START.getTime() + 31 * 60_000);
+  const expired = await gateway.checkInvoice('order-1');
+
+  assert.equal(expired.state, 'EXPIRED');
+});
+
+test('does not expire an invoice that was already paid into', async () => {
+  const { gateway, rpc, clock } = build({ invoiceTtlMinutes: 30, requiredConfirmations: 1 });
+  const invoice = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: invoice.addressIndex, amountXmr: '0.2', confirmations: 5 });
+
+  clock.now = new Date(START.getTime() + 31 * 60_000);
+  const checked = await gateway.checkInvoice('order-1');
+
+  // The customer's money is already on chain; expiring it would strand funds.
+  assert.equal(checked.state, 'PARTIALLY_PAID');
+});
+
+test('sweep skips settled invoices and isolates failures', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const paid = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: paid.addressIndex, amountXmr: '0.5', confirmations: 5 });
+  await gateway.checkInvoice('order-1');
+  await gateway.createInvoice(order({ orderId: 'order-2' }));
+
+  const callsBefore = rpc.calls.filter((c) => c.method === 'get_transfers').length;
+  const swept = await gateway.sweep();
+
+  assert.equal(swept.length, 1);
+  assert.equal(swept[0].orderId, 'order-2');
+  assert.equal(rpc.calls.filter((c) => c.method === 'get_transfers').length, callsBefore + 1);
+});
+
+test('validates addresses through the wallet rather than trusting the caller', async () => {
+  const { gateway } = build();
+  assert.deepEqual(await gateway.validateAddress('45GOOD'), { address: '45GOOD', valid: true, nettype: 'mainnet' });
+  assert.equal((await gateway.validateAddress('nonsense')).valid, false);
+  await assert.rejects(gateway.validateAddress(''), /address is required/);
+});
+
+test('reports health from the wallet height', async () => {
+  const { gateway } = build();
+  const health = await gateway.health();
+  assert.equal(health.connected, true);
+  assert.ok(health.height > 0);
+});
+
+test('summarises the invoice book', async () => {
+  const { gateway, rpc } = build({ requiredConfirmations: 1 });
+  const first = await gateway.createInvoice(order());
+  rpc.credit({ addressIndex: first.addressIndex, amountXmr: '0.5', confirmations: 5 });
+  await gateway.checkInvoice('order-1');
+  await gateway.createInvoice(order({ orderId: 'order-2' }));
+
+  const summary = await gateway.summary();
+  assert.equal(summary.total, 2);
+  assert.equal(summary.byState.PAID, 1);
+  assert.equal(summary.settledXmr, '0.5');
+
+  await assert.rejects(gateway.get('nope'), /Invoice not found/);
+});
+
+test('rpc errors never leak the wallet password', async () => {
+  const password = 'sup3r-s3cret-rpc-pw';
+  const client = {
+    create: () => ({
+      async post() { throw new Error(`connect ECONNREFUSED with auth password=${password}`); },
+    }),
+  };
+  const rpc = createWalletRpc({ url: 'http://127.0.0.1:18083', username: 'gateway', password, client });
+
+  await assert.rejects(rpc.call('get_height'), (error) => {
+    assert.ok(!error.message.includes(password), 'password leaked into the error');
+    assert.match(error.message, /\*\*\*/);
+    return true;
+  });
+});
+
+test('redact scrubs credential-shaped text', () => {
+  assert.equal(redact('password=hunter2'), 'password=***');
+  assert.equal(redact('{"viewkey":"deadbeef"}'), '{"viewkey":"***"}');
+  assert.equal(redact('token abc', ['abc']), 'token ***');
+  assert.equal(redact('nothing sensitive'), 'nothing sensitive');
+});
+
+test('createWalletRpc demands a url', () => {
+  assert.throws(() => createWalletRpc({ url: null }), /MONERO_WALLET_RPC_URL is required/);
+});

--- a/tests/moneroGateway.test.js
+++ b/tests/moneroGateway.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 
 const {
   MoneroPaymentGateway,
@@ -229,7 +230,10 @@ test('summarises the invoice book', async () => {
 });
 
 test('rpc errors never leak the wallet password', async () => {
-  const password = 'sup3r-s3cret-rpc-pw';
+  // Generated per run rather than hardcoded: a literal here trips secret
+  // scanners, and a random value also proves the redaction is not keyed to
+  // any particular string.
+  const password = `pw-${crypto.randomUUID()}`;
   const client = {
     create: () => ({
       async post() { throw new Error(`connect ECONNREFUSED with auth password=${password}`); },


### PR DESCRIPTION
Closes #704.

All four acceptance criteria — connessione RPC Monero, gestione transazioni, conferme blockchain, sicurezza.

## Why this is a new service rather than an extension of `xmrService.js`

I started by trying to build on `services/xmrService.js` and stopped, because four things in it prevent it from working as a gateway:

1. **`generatePaymentAddress()` returns the same static address to every customer.** With one shared address there is no way to tell whose payment arrived — two customers paying the same amount are indistinguishable. This is the core problem, and it is why this PR issues **one subaddress per order**.
2. **`get_transaction` is not a Monero RPC method.** The daemon has `get_transactions` (plural, `txs_hashes`); the wallet has `get_transfer_by_txid`. The call also targets port 18081 (the daemon) while reading `tx.amount`, which is a wallet-level field — so `verifyPayment` cannot succeed as written.
3. **`verified: amount >= expectedAmount` ignores confirmations.** A zero-confirmation transaction passes. At a pump that means dispensing fuel against a reversible payment.
4. **No RPC authentication**, though `monero-wallet-rpc` normally sits behind digest auth.

`xmrService.js` is left untouched, so `/api/xmr` keeps working exactly as it does now.

## Endpoints

`POST /invoices` · `GET /invoices/:orderId` · `POST /invoices/:orderId/check` · `POST /sweep` · `POST /validate-address` · `GET /health` · `GET /summary`, all under `/api/xmr-gateway`.

## Decisions worth reviewing

**Fuel is dispensed on `PAID` only**, which requires `XMR_MIN_CONFIRMATIONS`. When an invoice is paid by several transfers the **least-confirmed one gates it** — enough money that is one block deep is not yet money.

**A partial payment keeps the invoice open** so the customer can top up, rather than expiring and stranding what they already sent. Only an invoice with nothing received expires.

**Money is never a float.** Amounts are atomic piconero in `BigInt`, crossing the API and the database as strings. A double cannot hold 12 decimals, and a gateway off by a rounding error loses money in one direction and overcharges in the other. There is a test that `0.1 + 0.2` reports exactly `0.3`. Negative, zero, >12-decimal, exponent and non-numeric amounts are all rejected.

**Credentials cannot leak.** The RPC password lives in the axios config, which axios copies into its error objects — so every error passes through a redactor before it can reach a log or an HTTP response. There is a test that asserts the password never appears in a thrown error.

**A `double_spend_seen` transfer is dropped**, not merely flagged, and addresses are validated by the wallet rather than by a regex of ours.

With `MONERO_WALLET_RPC_URL` unset everything runs against a simulator and every response carries `"simulated": true`. A simulated `PAID` is documented as not being a real payment — please don't wire a pump to it.

## Tests

```
node --test tests/moneroGateway.test.js
```

22 passing — exact atomic conversion, every rejected amount form, one subaddress per invoice, idempotent creation, zero-confirmation never settling, least-confirmed gating, top-up after partial payment, overpayment, double-spend rejection, cross-invoice isolation, ttl expiry sparing partially paid invoices, sweep skipping settled invoices, wallet-side address validation, and the credential-leak test. HTTP layer exercised end to end before pushing.

`createRobot.test.js` fails and `rateLimiter.test.js` hangs on `main` independently of this branch — untouched here.

---

Re: reward — **XMR rather than MYZ** whenever funds allow, no rush. At your published garden rates (~6,300 MYZ/XMR) the listed 800 MYZ is about **0.127 XMR**.

```
45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8
```
