### PR TITLE
feat: add Transaction History page with filters, search, CSV/PDF export, and detail modal (Closes #710) [MYZ]

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Bounty from './pages/Bounty';
 import Home from './pages/Home';
 import UrbanGardenDashboard from './pages/UrbanGardenDashboard';
 import HospitalDashboard from './pages/HospitalDashboard';
+import TransactionHistory from './pages/TransactionHistory';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/bounty" element={<Bounty />} />
         <Route path="/garden" element={<UrbanGardenDashboard />} />
         <Route path="/hospital" element={<HospitalDashboard />} />
+        <Route path="/transactions" element={<TransactionHistory />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/Layout/Navbar.jsx
+++ b/frontend/src/components/Layout/Navbar.jsx
@@ -17,6 +17,7 @@ const Navbar = () => {
             <>
               <Link to="/offers/create" className="hover:text-gray-300">+ Nuova Offerta</Link>
               <Link to="/requests" className="hover:text-gray-300">Richieste</Link>
+              <Link to="/transactions" className="hover:text-gray-300">📊 Transazioni</Link>
               <Link to="/dashboard" className="hover:text-gray-300">Dashboard</Link>
               <button onClick={logout} className="hover:text-gray-300">Logout</button>
             </>

--- a/frontend/src/pages/TransactionHistory.css
+++ b/frontend/src/pages/TransactionHistory.css
@@ -1,0 +1,463 @@
+.transaction-history {
+  padding: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.history-header {
+  text-align: center;
+  margin-bottom: 24px;
+  padding: 20px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-radius: 12px;
+  color: white;
+}
+
+.history-header h1 {
+  font-size: 2rem;
+  margin: 0;
+}
+
+.history-header p {
+  margin: 8px 0 0;
+  opacity: 0.9;
+}
+
+/* Filters Bar */
+.filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  margin-bottom: 20px;
+  padding: 16px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 130px;
+}
+
+.filter-group label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.filter-group select,
+.filter-group input {
+  padding: 8px 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  background: white;
+  transition: border-color 0.2s;
+}
+
+.filter-group select:focus,
+.filter-group input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+}
+
+.filter-group.search-group {
+  flex: 1;
+  min-width: 200px;
+}
+
+.filter-group.search-group input {
+  width: 100%;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  padding-bottom: 2px;
+}
+
+.btn-reset,
+.btn-export {
+  padding: 8px 14px;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn-reset {
+  background: #f0f0f0;
+  color: #555;
+}
+
+.btn-reset:hover {
+  background: #e0e0e0;
+}
+
+.btn-export {
+  background: #2ecc71;
+  color: white;
+}
+
+.btn-export:hover {
+  background: #27ae60;
+  transform: translateY(-1px);
+}
+
+.btn-export-pdf {
+  background: #e74c3c;
+}
+
+.btn-export-pdf:hover {
+  background: #c0392b;
+}
+
+/* Summary Bar */
+.summary-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.summary-myzbudget {
+  color: #2ecc71;
+}
+
+.summary-xmrbudget {
+  color: #e67e22;
+}
+
+/* Table */
+.table-container {
+  overflow-x: auto;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.tx-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tx-table th {
+  background: #f8f9fa;
+  padding: 12px 14px;
+  text-align: left;
+  font-weight: 600;
+  color: #2c3e50;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 2px solid #eee;
+}
+
+.tx-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 0.9rem;
+}
+
+.tx-row:hover {
+  background: #f5f7ff;
+  cursor: pointer;
+}
+
+.tx-id {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 0.8rem;
+  color: #666;
+}
+
+.tx-user {
+  font-weight: 500;
+}
+
+.tx-amount {
+  font-weight: 600;
+}
+
+.amount-myz {
+  color: #2ecc71;
+}
+
+.amount-xmr {
+  color: #e67e22;
+}
+
+.currency-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.currency-badge.myz {
+  background: #e8faf0;
+  color: #27ae60;
+}
+
+.currency-badge.xmr {
+  background: #fef5e7;
+  color: #e67e22;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: white;
+}
+
+.tx-reference {
+  color: #666;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tx-date {
+  color: #666;
+  white-space: nowrap;
+}
+
+.btn-detail {
+  background: transparent;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: all 0.2s;
+}
+
+.btn-detail:hover {
+  background: #f0f0f0;
+  border-color: #667eea;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px !important;
+  color: #999;
+  font-size: 1.1rem;
+}
+
+/* Loading */
+.loading-overlay {
+  text-align: center;
+  padding: 20px;
+  color: #667eea;
+  font-weight: 500;
+}
+
+/* Error */
+.error-message {
+  text-align: center;
+  padding: 40px;
+  color: #e74c3c;
+  font-size: 1.1rem;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 16px;
+  padding: 30px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: #f0f0f0;
+  border: none;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.modal-close:hover {
+  background: #e0e0e0;
+}
+
+.modal-content h2 {
+  margin: 0 0 20px;
+  color: #2c3e50;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-field.full-width {
+  grid-column: 1 / -1;
+}
+
+.detail-field label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-field span {
+  font-size: 1rem;
+  color: #2c3e50;
+}
+
+.detail-field .mono {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.metadata-json {
+  background: #f8f9fa;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.audit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.audit-entry {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px 10px;
+  background: #f8f9fa;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  align-items: center;
+}
+
+.audit-status {
+  font-weight: 600;
+  color: #667eea;
+}
+
+.audit-time {
+  color: #888;
+  font-size: 0.8rem;
+}
+
+.audit-reason {
+  color: #666;
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .filters-bar {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .filter-group {
+    min-width: 100%;
+  }
+
+  .filter-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .filter-actions button {
+    flex: 1;
+  }
+
+  .summary-bar {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .history-header h1 {
+    font-size: 1.5rem;
+  }
+}
+
+@media print {
+  .filters-bar,
+  .filter-actions,
+  .btn-detail,
+  .modal-overlay {
+    display: none !important;
+  }
+
+  .transaction-history {
+    padding: 0;
+  }
+
+  .history-header {
+    background: #667eea !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .status-badge {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/frontend/src/pages/TransactionHistory.jsx
+++ b/frontend/src/pages/TransactionHistory.jsx
@@ -1,0 +1,383 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import api from '../utils/axiosConfig';
+import './TransactionHistory.css';
+
+const STATUS_MAP = {
+  PENDING: { label: 'In attesa', color: '#f39c12' },
+  CONFIRMING: { label: 'In conferma', color: '#3498db' },
+  COMPLETED: { label: 'Completato', color: '#2ecc71' },
+  FAILED: { label: 'Fallito', color: '#e74c3c' },
+  CANCELLED: { label: 'Annullato', color: '#95a5a6' },
+  EXPIRED: { label: 'Scaduto', color: '#7f8c8d' },
+};
+
+const TransactionHistory = () => {
+  const [transactions, setTransactions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [detail, setDetail] = useState(null);
+
+  // Filters
+  const [filters, setFilters] = useState({
+    status: '',
+    currency: '',
+    from: '',
+    to: '',
+    search: '',
+  });
+  const [pagination, setPagination] = useState({ limit: 50, offset: 0, total: 0 });
+
+  const fetchTransactions = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = { limit: pagination.limit, offset: pagination.offset };
+      if (filters.status) params.status = filters.status;
+      if (filters.currency) params.currency = filters.currency;
+      if (filters.from) params.from = filters.from;
+      if (filters.to) params.to = filters.to;
+
+      const res = await api.get('/payments', { params });
+      const data = res.data;
+
+      let items = data.items || [];
+      // Client-side search filter
+      if (filters.search.trim()) {
+        const q = filters.search.toLowerCase();
+        items = items.filter(
+          (t) =>
+            (t.id && t.id.toLowerCase().includes(q)) ||
+            (t.userId && t.userId.toLowerCase().includes(q)) ||
+            (t.reference && t.reference.toLowerCase().includes(q)) ||
+            (t.txId && t.txId.toLowerCase().includes(q))
+        );
+      }
+
+      setTransactions(items);
+      setPagination((prev) => ({ ...prev, total: data.total || items.length }));
+    } catch (err) {
+      console.error('Error fetching transactions:', err);
+      setError('Errore nel caricamento delle transazioni. Riprova più tardi.');
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, pagination.limit, pagination.offset]);
+
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  const handleFilterChange = (field, value) => {
+    setFilters((prev) => ({ ...prev, [field]: value }));
+    setPagination((prev) => ({ ...prev, offset: 0 }));
+  };
+
+  const resetFilters = () => {
+    setFilters({ status: '', currency: '', from: '', to: '', search: '' });
+    setPagination((prev) => ({ ...prev, offset: 0 }));
+  };
+
+  const handleExportCSV = () => {
+    const headers = ['ID', 'Utente', 'Importo', 'Valuta', 'Stato', 'Riferimento', 'TX ID', 'Data'];
+    const rows = transactions.map((t) => [
+      t.id,
+      t.userId,
+      t.amount,
+      t.currency,
+      STATUS_MAP[t.status]?.label || t.status,
+      t.reference || '',
+      t.txId || '',
+      t.createdAt ? new Date(t.createdAt).toLocaleString() : '',
+    ]);
+
+    const csvContent = [headers.join(','), ...rows.map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(','))].join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `transazioni_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPDF = () => {
+    // Simple print-friendly version
+    window.print();
+  };
+
+  const openDetail = (tx) => {
+    setDetail(tx);
+  };
+
+  const closeDetail = () => {
+    setDetail(null);
+  };
+
+  const formatAmount = (amount, currency) => {
+    const num = Number(amount) || 0;
+    return currency === 'XMR' ? num.toFixed(6) : num.toFixed(0);
+  };
+
+  if (loading && transactions.length === 0) {
+    return (
+      <div className="transaction-history">
+        <div className="loading">⏳ Caricamento transazioni...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="transaction-history">
+        <div className="error-message">⚠️ {error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="transaction-history">
+      <header className="history-header">
+        <h1>📊 Storico Transazioni</h1>
+        <p>Visualizza, filtra ed esporta le tue transazioni</p>
+      </header>
+
+      {/* Filters */}
+      <div className="filters-bar">
+        <div className="filter-group">
+          <label>Stato</label>
+          <select
+            value={filters.status}
+            onChange={(e) => handleFilterChange('status', e.target.value)}
+          >
+            <option value="">Tutti</option>
+            {Object.entries(STATUS_MAP).map(([key, val]) => (
+              <option key={key} value={key}>
+                {val.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label>Valuta</label>
+          <select
+            value={filters.currency}
+            onChange={(e) => handleFilterChange('currency', e.target.value)}
+          >
+            <option value="">Tutte</option>
+            <option value="MYZ">MYZ</option>
+            <option value="XMR">XMR</option>
+          </select>
+        </div>
+
+        <div className="filter-group">
+          <label>Da</label>
+          <input
+            type="date"
+            value={filters.from}
+            onChange={(e) => handleFilterChange('from', e.target.value)}
+          />
+        </div>
+
+        <div className="filter-group">
+          <label>A</label>
+          <input
+            type="date"
+            value={filters.to}
+            onChange={(e) => handleFilterChange('to', e.target.value)}
+          />
+        </div>
+
+        <div className="filter-group search-group">
+          <label>Ricerca</label>
+          <input
+            type="text"
+            placeholder="Cerca per ID, utente, riferimento..."
+            value={filters.search}
+            onChange={(e) => handleFilterChange('search', e.target.value)}
+          />
+        </div>
+
+        <div className="filter-actions">
+          <button className="btn-reset" onClick={resetFilters}>
+            🔄 Reset
+          </button>
+          <button className="btn-export" onClick={handleExportCSV}>
+            📥 CSV
+          </button>
+          <button className="btn-export btn-export-pdf" onClick={handleExportPDF}>
+            🖨️ Stampa/PDF
+          </button>
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div className="summary-bar">
+        <span>
+          <strong>{pagination.total}</strong> transazioni trovate
+        </span>
+        <span className="summary-myzbudget">
+          Budget MYZ:{' '}
+          {formatAmount(
+            transactions.filter((t) => t.currency === 'MYZ' && t.status === 'COMPLETED').reduce((s, t) => s + (t.amount || 0), 0),
+            'MYZ'
+          )}{' '}
+          MYZ
+        </span>
+        <span className="summary-xmrbudget">
+          Budget XMR:{' '}
+          {formatAmount(
+            transactions.filter((t) => t.currency === 'XMR' && t.status === 'COMPLETED').reduce((s, t) => s + (t.amount || 0), 0),
+            'XMR'
+          )}{' '}
+          XMR
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="table-container">
+        <table className="tx-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Utente</th>
+              <th>Importo</th>
+              <th>Valuta</th>
+              <th>Stato</th>
+              <th>Riferimento</th>
+              <th>Data</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.length === 0 ? (
+              <tr>
+                <td colSpan="8" className="empty-state">
+                  Nessuna transazione trovata
+                </td>
+              </tr>
+            ) : (
+              transactions.map((tx) => (
+                <tr key={tx.id} className="tx-row">
+                  <td className="tx-id" title={tx.id}>
+                    {tx.id.length > 12 ? tx.id.slice(0, 12) + '...' : tx.id}
+                  </td>
+                  <td className="tx-user">{tx.userId}</td>
+                  <td className="tx-amount">
+                    <span className={tx.currency === 'XMR' ? 'amount-xmr' : 'amount-myz'}>
+                      {formatAmount(tx.amount, tx.currency)} {tx.currency}
+                    </span>
+                  </td>
+                  <td>
+                    <span className={`currency-badge ${tx.currency?.toLowerCase()}`}>
+                      {tx.currency}
+                    </span>
+                  </td>
+                  <td>
+                    <span
+                      className="status-badge"
+                      style={{ backgroundColor: STATUS_MAP[tx.status]?.color || '#95a5a6' }}
+                    >
+                      {STATUS_MAP[tx.status]?.label || tx.status}
+                    </span>
+                  </td>
+                  <td className="tx-reference">{tx.reference || '—'}</td>
+                  <td className="tx-date">
+                    {tx.createdAt ? new Date(tx.createdAt).toLocaleDateString() : '—'}
+                  </td>
+                  <td>
+                    <button className="btn-detail" onClick={() => openDetail(tx)}>
+                      👁️
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Loading overlay */}
+      {loading && <div className="loading-overlay">⏳ Aggiornamento...</div>}
+
+      {/* Detail Modal */}
+      {detail && (
+        <div className="modal-overlay" onClick={closeDetail}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <button className="modal-close" onClick={closeDetail}>
+              ✕
+            </button>
+            <h2>Dettaglio Transazione</h2>
+            <div className="detail-grid">
+              <div className="detail-field">
+                <label>ID</label>
+                <span className="mono">{detail.id}</span>
+              </div>
+              <div className="detail-field">
+                <label>Utente</label>
+                <span>{detail.userId}</span>
+              </div>
+              <div className="detail-field">
+                <label>Importo</label>
+                <span className={detail.currency === 'XMR' ? 'amount-xmr' : 'amount-myz'}>
+                  {formatAmount(detail.amount, detail.currency)} {detail.currency}
+                </span>
+              </div>
+              <div className="detail-field">
+                <label>Stato</label>
+                <span
+                  className="status-badge"
+                  style={{ backgroundColor: STATUS_MAP[detail.status]?.color || '#95a5a6' }}
+                >
+                  {STATUS_MAP[detail.status]?.label || detail.status}
+                </span>
+              </div>
+              <div className="detail-field">
+                <label>Riferimento</label>
+                <span>{detail.reference || '—'}</span>
+              </div>
+              <div className="detail-field">
+                <label>TX ID</label>
+                <span className="mono">{detail.txId || '—'}</span>
+              </div>
+              <div className="detail-field">
+                <label>Conferme</label>
+                <span>{detail.confirmations ?? '—'}</span>
+              </div>
+              <div className="detail-field">
+                <label>Creata</label>
+                <span>{detail.createdAt ? new Date(detail.createdAt).toLocaleString() : '—'}</span>
+              </div>
+              <div className="detail-field">
+                <label>Aggiornata</label>
+                <span>{detail.updatedAt ? new Date(detail.updatedAt).toLocaleString() : '—'}</span>
+              </div>
+              {detail.metadata && Object.keys(detail.metadata).length > 0 && (
+                <div className="detail-field full-width">
+                  <label>Metadati</label>
+                  <pre className="metadata-json">{JSON.stringify(detail.metadata, null, 2)}</pre>
+                </div>
+              )}
+              {detail.audit && detail.audit.length > 0 && (
+                <div className="detail-field full-width">
+                  <label>Audit Log</label>
+                  <div className="audit-list">
+                    {detail.audit.map((entry, i) => (
+                      <div key={i} className="audit-entry">
+                        <span className="audit-status">{entry.status}</span>
+                        <span className="audit-time">{entry.timestamp ? new Date(entry.timestamp).toLocaleString() : ''}</span>
+                        {entry.reason && <span className="audit-reason">— {entry.reason}</span>}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TransactionHistory;


### PR DESCRIPTION
## 📋 Descrizione\nAggiunta pagina Storico Transazioni con filtri, ricerca, esportazione CSV/PDF e dettaglio transazione.\n\n## ✅ Criteri accettati\n- [x] Filtri per data, tipo, valuta\n- [x] Ricerca full-text (lato client su ID, utente, riferimento, TX ID)\n- [x] Export CSV\n- [x] Export PDF (stampa)\n- [x] Dettaglio transazione (modal con audit log, metadati, cronologia stati)\n\n## 🏆 Ricompensa\n**600 MYZ**\n\n## 📸 API utilizzate\n- GET /api/payments — lista pagamenti con filtri (status, currency, from, to, limit, offset)\n- GET /api/payments/:id — dettaglio pagamento