### PR TITLE
feat: add automated payment verification

### DIFF
--- a/docs/PAYMENT_VERIFICATION.md
+++ b/docs/PAYMENT_VERIFICATION.md
@@ -1,0 +1,68 @@
+# Automated payment verification
+
+Checks payments against the chain instead of trusting what the sender claims: reads confirmations from `monero-wallet-rpc`, settles a payment once it is deep enough, and flags anything that does not add up.
+
+## API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/verification/verify` | Check one payment now |
+| `POST` | `/api/verification/sweep` | Check a batch, skipping already-settled ones |
+| `GET` | `/api/verification/:paymentId` | Latest verdict, confirmations and history |
+| `GET` | `/api/verification/anomalies` | Every record carrying at least one anomaly |
+| `GET` | `/api/verification/report` | Aggregate counts, anomaly breakdown, confirmed value |
+
+A subject is `{ paymentId, txId, expectedAmount, expectedAddress, currency, createdAt }`.
+
+## Verdicts
+
+- **PENDING** — the transaction is on-chain but below `XMR_MIN_CONFIRMATIONS` (default 10), or too young to worry about being missing yet.
+- **CONFIRMED** — deep enough, right address, right amount.
+- **REJECTED** — a blocking anomaly was found. Never auto-recovers; a human decides what to do.
+
+## Anomalies
+
+| Code | Meaning | Blocks settlement |
+| --- | --- | --- |
+| `TX_NOT_FOUND` | Never appeared on-chain within the grace window (default 1h) | yes |
+| `UNDERPAID` | On-chain amount is short | yes |
+| `OVERPAID` | On-chain amount exceeds the invoice | **no** |
+| `ADDRESS_MISMATCH` | Paid to an address we did not issue | yes |
+| `DOUBLE_SPEND_SEEN` | The daemon flagged a double spend | yes |
+| `REORG_SUSPECTED` | Confirmations moved backwards | yes |
+| `TXID_REUSED` | The same transaction is already credited to another payment | yes |
+
+Three of these deserve a word on *why*:
+
+**Overpayment does not block.** Holding a customer's order hostage because they sent too much punishes them for our accounting convenience. It is recorded, reported, and settled.
+
+**Confirmations moving backwards is treated as a reorg.** On a healthy chain the count only grows. A drop means the block was orphaned and the payment is no longer settled — silently keeping the old `CONFIRMED` would mean shipping goods against money that no longer exists.
+
+**A reused txid is refused.** Without this check, replaying one transaction hash against several invoices would credit each of them.
+
+## Missing transactions
+
+A transaction can legitimately be absent for a short while after broadcast, so absence alone is not an anomaly. Only a subject older than `missingTxGraceMs` (default one hour) that still has nothing on-chain is rejected.
+
+## Sweeping
+
+`sweep(subjects)` is built for a scheduler: subjects that already reached `CONFIRMED` or `REJECTED` are skipped, so a timer can re-run it over the same list without reopening settled payments or hammering the daemon. A chain lookup that throws is contained to its own subject and reported as `ERROR` — one unreachable daemon call does not abort the batch.
+
+## Configuration
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `XMR_WALLET_URL` | *(unset)* | monero-wallet-rpc endpoint. Unset means simulation mode. |
+| `XMR_MIN_CONFIRMATIONS` | `10` | Blocks required before `CONFIRMED` |
+
+With `XMR_WALLET_URL` unset the routes run against an in-memory `SimulatedChain` and report `"simulated": true` in every response, so the endpoints work locally without a daemon. A simulated verdict is not proof of settlement.
+
+Storage is MongoDB when a connection is live and memory otherwise.
+
+## Tests
+
+```
+node --test tests/paymentVerification.test.js
+```
+
+15 passing — the confirmation threshold, each anomaly above, the grace window for missing transactions, reorg detection across two observations, terminal verdicts surviving a later chain change, per-subject error isolation during a sweep, and report aggregation.

--- a/models/VerificationRecord.js
+++ b/models/VerificationRecord.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+
+const VerificationRecordSchema = new mongoose.Schema({
+  paymentId: { type: String, required: true, unique: true, index: true },
+  txId: { type: String, required: true, index: true },
+  currency: { type: String, enum: ['MYZ', 'XMR'], default: 'XMR' },
+  expectedAmount: { type: Number, required: true },
+  observedAmount: { type: Number, default: null },
+  expectedAddress: { type: String, default: null },
+  verdict: {
+    type: String,
+    enum: ['PENDING', 'CONFIRMED', 'REJECTED'],
+    default: 'PENDING',
+    index: true
+  },
+  confirmations: { type: Number, default: 0 },
+  requiredConfirmations: { type: Number, required: true },
+  anomalies: { type: Array, default: [] },
+  height: { type: Number, default: null },
+  history: { type: Array, default: [] },
+  firstSeenAt: { type: String, required: true },
+  updatedAt: { type: String, required: true }
+}, { versionKey: false });
+
+VerificationRecordSchema.index({ verdict: 1, updatedAt: -1 });
+
+module.exports = mongoose.model('VerificationRecord', VerificationRecordSchema);

--- a/routes/verification.js
+++ b/routes/verification.js
@@ -1,53 +1,59 @@
 const express = require('express');
+const mongoose = require('mongoose');
+const {
+  PaymentVerificationService,
+  MemoryVerificationStore,
+  MongoVerificationStore,
+  SimulatedChain,
+  createMoneroChain,
+} = require('../services/paymentVerificationService');
+
 const router = express.Router();
 
-// GET /api/verification
-router.get('/', (req, res) => {
-  res.json({
-    success: true,
-    message: 'Verification endpoint',
-    verifications: []
-  });
+function buildStore() {
+  if (mongoose.connection?.readyState === 1) {
+    return new MongoVerificationStore(require('../models/VerificationRecord'));
+  }
+  return new MemoryVerificationStore();
+}
+
+// A real wallet when one is configured, a simulator otherwise, so the endpoints
+// stay usable in local runs without a Monero daemon.
+const simulated = !process.env.XMR_WALLET_URL;
+const chain = simulated ? new SimulatedChain() : createMoneroChain();
+const service = new PaymentVerificationService({ chain, store: buildStore() });
+
+const fail = (res, error) => {
+  const notFound = error.message === 'Verification record not found';
+  return res.status(notFound ? 404 : 400).json({ success: false, error: error.message });
+};
+
+router.get('/report', async (_req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.report() }); }
+  catch (error) { return fail(res, error); }
 });
 
-// POST /api/verification
-router.post('/', (req, res) => {
-  res.status(201).json({
-    success: true,
-    message: 'Verification request created',
-    verification: {
-      id: 'ver_1',
-      status: 'pending',
-      userId: req.body.userId || 'unknown',
-      timestamp: new Date().toISOString()
-    }
-  });
+router.get('/anomalies', async (_req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.anomalies() }); }
+  catch (error) { return fail(res, error); }
 });
 
-// GET /api/verification/:id
-router.get('/:id', (req, res) => {
-  res.json({
-    success: true,
-    verification: {
-      id: req.params.id,
-      status: 'completed',
-      verified: true,
-      timestamp: new Date().toISOString()
-    }
-  });
+router.post('/verify', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.verify(req.body) }); }
+  catch (error) { return fail(res, error); }
 });
 
-// PUT /api/verification/:id
-router.put('/:id', (req, res) => {
-  res.json({
-    success: true,
-    message: 'Verification updated',
-    verification: {
-      id: req.params.id,
-      status: 'verified',
-      updatedAt: new Date().toISOString()
-    }
-  });
+router.post('/sweep', async (req, res) => {
+  const subjects = Array.isArray(req.body?.subjects) ? req.body.subjects : null;
+  if (!subjects) return res.status(400).json({ success: false, error: 'subjects must be an array' });
+  try { return res.json({ success: true, simulated, data: await service.sweep(subjects) }); }
+  catch (error) { return fail(res, error); }
+});
+
+router.get('/:paymentId', async (req, res) => {
+  try { return res.json({ success: true, simulated, data: await service.get(req.params.paymentId) }); }
+  catch (error) { return fail(res, error); }
 });
 
 module.exports = router;
+module.exports.service = service;

--- a/services/paymentVerificationService.js
+++ b/services/paymentVerificationService.js
@@ -1,0 +1,216 @@
+const crypto = require('node:crypto');
+const axios = require('axios');
+
+const ATOMIC_PER_XMR = 1e12;
+const TERMINAL_VERDICTS = new Set(['CONFIRMED', 'REJECTED']);
+const round = (n) => Number(Number(n).toFixed(12));
+
+class MemoryVerificationStore {
+  constructor() { this.items = new Map(); }
+  async save(record) { this.items.set(record.paymentId, structuredClone(record)); return structuredClone(record); }
+  async get(paymentId) { const item = this.items.get(paymentId); return item ? structuredClone(item) : null; }
+  async list() { return [...this.items.values()].map((item) => structuredClone(item)); }
+}
+
+class MongoVerificationStore {
+  constructor(model) { this.model = model; }
+  async save(record) {
+    const saved = await this.model.findOneAndUpdate({ paymentId: record.paymentId }, record, { upsert: true, new: true, lean: true });
+    return this.strip(saved);
+  }
+  async get(paymentId) { return this.strip(await this.model.findOne({ paymentId }).lean()); }
+  async list() { return (await this.model.find().sort({ updatedAt: -1 }).lean()).map((doc) => this.strip(doc)); }
+  strip(doc) { if (!doc) return null; const { _id, __v, ...rest } = doc; return rest; }
+}
+
+// Reads confirmations straight from monero-wallet-rpc. Injectable so the
+// verifier can be tested — and run locally — without a wallet or a daemon.
+function createMoneroChain({ walletUrl = process.env.XMR_WALLET_URL, client = axios } = {}) {
+  if (!walletUrl) throw new Error('XMR_WALLET_URL is required for the Monero chain client');
+  return {
+    async getTransaction(txId) {
+      const response = await client.post(`${walletUrl}/json_rpc`, {
+        jsonrpc: '2.0', id: 'myz-gateway', method: 'get_transfer_by_txid', params: { txid: txId },
+      }, { timeout: 15000 });
+
+      const transfer = response?.data?.result?.transfer;
+      if (!transfer) return { found: false };
+      return {
+        found: true,
+        amount: round(transfer.amount / ATOMIC_PER_XMR),
+        address: transfer.address ?? null,
+        confirmations: transfer.confirmations ?? 0,
+        height: transfer.height ?? null,
+        doubleSpendSeen: Boolean(transfer.double_spend_seen),
+      };
+    },
+  };
+}
+
+class SimulatedChain {
+  constructor(transactions = {}) { this.transactions = new Map(Object.entries(transactions)); }
+  set(txId, transaction) { this.transactions.set(txId, transaction); return this; }
+  async getTransaction(txId) {
+    const transaction = this.transactions.get(txId);
+    return transaction ? { found: true, doubleSpendSeen: false, ...transaction } : { found: false };
+  }
+}
+
+class PaymentVerificationService {
+  constructor({
+    chain,
+    store = new MemoryVerificationStore(),
+    requiredConfirmations = Number(process.env.XMR_MIN_CONFIRMATIONS || 10),
+    missingTxGraceMs = 60 * 60 * 1000,
+    amountTolerance = 0,
+    clock = () => new Date(),
+  } = {}) {
+    if (!chain) throw new Error('A chain adapter is required');
+    this.chain = chain;
+    this.store = store;
+    this.requiredConfirmations = requiredConfirmations;
+    this.missingTxGraceMs = missingTxGraceMs;
+    this.amountTolerance = amountTolerance;
+    this.clock = clock;
+  }
+
+  /**
+   * Checks one payment against the chain and records the outcome.
+   * `subject` is { paymentId, txId, expectedAmount, expectedAddress, currency, createdAt }.
+   */
+  async verify(subject) {
+    this.validateSubject(subject);
+    const previous = await this.store.get(subject.paymentId);
+    const now = this.clock();
+    const anomalies = [];
+
+    const onChain = await this.chain.getTransaction(subject.txId);
+
+    if (!onChain.found) {
+      const age = now.getTime() - new Date(subject.createdAt ?? now).getTime();
+      // A transaction can legitimately be absent for a short while after
+      // broadcast, so only an old one that never appeared is an anomaly.
+      if (age > this.missingTxGraceMs) anomalies.push({ code: 'TX_NOT_FOUND', detail: `no transaction ${subject.txId} after ${Math.round(age / 60000)} minutes` });
+      return this.record(subject, { verdict: anomalies.length ? 'REJECTED' : 'PENDING', confirmations: 0, anomalies, onChain: null, previous, now });
+    }
+
+    if (onChain.doubleSpendSeen) anomalies.push({ code: 'DOUBLE_SPEND_SEEN', detail: 'daemon flagged a double spend' });
+
+    if (subject.expectedAddress && onChain.address && onChain.address !== subject.expectedAddress) {
+      anomalies.push({ code: 'ADDRESS_MISMATCH', detail: `paid to ${onChain.address}, expected ${subject.expectedAddress}` });
+    }
+
+    const delta = round(onChain.amount - subject.expectedAmount);
+    if (Math.abs(delta) > this.amountTolerance) {
+      anomalies.push({ code: delta < 0 ? 'UNDERPAID' : 'OVERPAID', detail: `on-chain ${onChain.amount}, expected ${subject.expectedAmount} (delta ${delta})` });
+    }
+
+    // Confirmations only ever move forward on a healthy chain; going backwards
+    // means the block was orphaned and the payment is no longer settled.
+    if (previous && onChain.confirmations < previous.confirmations) {
+      anomalies.push({ code: 'REORG_SUSPECTED', detail: `confirmations fell from ${previous.confirmations} to ${onChain.confirmations}` });
+    }
+
+    const reused = (await this.store.list()).find((record) => record.txId === subject.txId && record.paymentId !== subject.paymentId);
+    if (reused) anomalies.push({ code: 'TXID_REUSED', detail: `transaction already credited to payment ${reused.paymentId}` });
+
+    const blocking = anomalies.filter((anomaly) => anomaly.code !== 'OVERPAID');
+    let verdict = 'PENDING';
+    if (blocking.length) verdict = 'REJECTED';
+    else if (onChain.confirmations >= this.requiredConfirmations) verdict = 'CONFIRMED';
+
+    return this.record(subject, { verdict, confirmations: onChain.confirmations, anomalies, onChain, previous, now });
+  }
+
+  async record(subject, { verdict, confirmations, anomalies, onChain, previous, now }) {
+    const history = previous?.history ?? [];
+    if (!previous || previous.verdict !== verdict) {
+      history.push({ verdict, confirmations, at: now.toISOString(), ...(anomalies.length ? { anomalies: anomalies.map((a) => a.code) } : {}) });
+    }
+
+    return this.store.save({
+      paymentId: subject.paymentId,
+      txId: subject.txId,
+      currency: subject.currency ?? 'XMR',
+      expectedAmount: round(subject.expectedAmount),
+      observedAmount: onChain ? onChain.amount : null,
+      expectedAddress: subject.expectedAddress ?? null,
+      verdict,
+      confirmations,
+      requiredConfirmations: this.requiredConfirmations,
+      anomalies,
+      height: onChain?.height ?? null,
+      history,
+      firstSeenAt: previous?.firstSeenAt ?? now.toISOString(),
+      updatedAt: now.toISOString(),
+    });
+  }
+
+  /**
+   * Sweeps a batch of subjects, skipping any that already reached a terminal
+   * verdict so a scheduler can call this on a timer without extra bookkeeping.
+   */
+  async sweep(subjects = []) {
+    const results = [];
+    for (const subject of subjects) {
+      const existing = await this.store.get(subject.paymentId);
+      if (existing && TERMINAL_VERDICTS.has(existing.verdict)) { results.push(existing); continue; }
+      try {
+        results.push(await this.verify(subject));
+      } catch (error) {
+        results.push({ paymentId: subject.paymentId, verdict: 'ERROR', error: error.message });
+      }
+    }
+    return results;
+  }
+
+  async get(paymentId) {
+    const record = await this.store.get(paymentId);
+    if (!record) throw new Error('Verification record not found');
+    return record;
+  }
+
+  async anomalies() {
+    return (await this.store.list()).filter((record) => record.anomalies.length > 0);
+  }
+
+  async report() {
+    const records = await this.store.list();
+    const byVerdict = {};
+    const byAnomaly = {};
+    let confirmedValue = 0;
+
+    for (const record of records) {
+      byVerdict[record.verdict] = (byVerdict[record.verdict] || 0) + 1;
+      for (const anomaly of record.anomalies) byAnomaly[anomaly.code] = (byAnomaly[anomaly.code] || 0) + 1;
+      if (record.verdict === 'CONFIRMED') confirmedValue += record.observedAmount ?? 0;
+    }
+
+    return {
+      generatedAt: this.clock().toISOString(),
+      requiredConfirmations: this.requiredConfirmations,
+      total: records.length,
+      byVerdict,
+      byAnomaly,
+      confirmedValue: round(confirmedValue),
+      anomalyRate: records.length ? round(Object.values(byAnomaly).reduce((a, b) => a + b, 0) / records.length) : 0,
+    };
+  }
+
+  validateSubject(subject) {
+    if (!subject?.paymentId) throw new Error('paymentId is required');
+    if (!subject.txId) throw new Error('txId is required');
+    if (!Number.isFinite(Number(subject.expectedAmount)) || Number(subject.expectedAmount) <= 0) {
+      throw new Error('expectedAmount must be positive');
+    }
+  }
+}
+
+module.exports = {
+  PaymentVerificationService,
+  MemoryVerificationStore,
+  MongoVerificationStore,
+  SimulatedChain,
+  createMoneroChain,
+  ATOMIC_PER_XMR,
+};

--- a/tests/paymentVerification.test.js
+++ b/tests/paymentVerification.test.js
@@ -1,0 +1,204 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  PaymentVerificationService,
+  MemoryVerificationStore,
+  SimulatedChain,
+} = require('../services/paymentVerificationService');
+
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+
+function build({ transactions = {}, requiredConfirmations = 10, now = NOW } = {}) {
+  const clock = { now };
+  const chain = new SimulatedChain(transactions);
+  const service = new PaymentVerificationService({
+    chain,
+    store: new MemoryVerificationStore(),
+    requiredConfirmations,
+    clock: () => clock.now,
+  });
+  return { service, chain, clock };
+}
+
+const subject = (overrides = {}) => ({
+  paymentId: 'pay-1',
+  txId: 'tx-1',
+  expectedAmount: 0.5,
+  expectedAddress: '45ADDR',
+  currency: 'XMR',
+  createdAt: NOW.toISOString(),
+  ...overrides,
+});
+
+test('requires a chain adapter', () => {
+  assert.throws(() => new PaymentVerificationService({}), /chain adapter is required/);
+});
+
+test('rejects malformed subjects', async () => {
+  const { service } = build();
+  await assert.rejects(service.verify({ txId: 'tx-1', expectedAmount: 1 }), /paymentId is required/);
+  await assert.rejects(service.verify({ paymentId: 'p', expectedAmount: 1 }), /txId is required/);
+  await assert.rejects(service.verify({ paymentId: 'p', txId: 't', expectedAmount: 0 }), /expectedAmount must be positive/);
+});
+
+test('stays PENDING until the confirmation target is reached', async () => {
+  const { service } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 3, height: 100 } } });
+
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'PENDING');
+  assert.equal(record.confirmations, 3);
+  assert.equal(record.requiredConfirmations, 10);
+  assert.deepEqual(record.anomalies, []);
+});
+
+test('confirms once enough blocks are on top', async () => {
+  const { service, chain } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 3, height: 100 } } });
+  await service.verify(subject());
+
+  chain.set('tx-1', { amount: 0.5, address: '45ADDR', confirmations: 12, height: 100 });
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'CONFIRMED');
+  assert.equal(record.observedAmount, 0.5);
+  assert.deepEqual(record.history.map((entry) => entry.verdict), ['PENDING', 'CONFIRMED']);
+});
+
+test('tolerates a briefly missing transaction, then rejects a stale one', async () => {
+  const { service, clock } = build();
+
+  const fresh = await service.verify(subject());
+  assert.equal(fresh.verdict, 'PENDING');
+  assert.deepEqual(fresh.anomalies, []);
+
+  clock.now = new Date(NOW.getTime() + 2 * 60 * 60 * 1000);
+  const stale = await service.verify(subject());
+
+  assert.equal(stale.verdict, 'REJECTED');
+  assert.equal(stale.anomalies[0].code, 'TX_NOT_FOUND');
+});
+
+test('flags an underpayment and refuses to confirm it', async () => {
+  const { service } = build({ transactions: { 'tx-1': { amount: 0.4, address: '45ADDR', confirmations: 50 } } });
+
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'REJECTED');
+  assert.equal(record.anomalies[0].code, 'UNDERPAID');
+  assert.match(record.anomalies[0].detail, /delta -0\.1/);
+});
+
+test('flags an overpayment but still confirms it', async () => {
+  const { service } = build({ transactions: { 'tx-1': { amount: 0.7, address: '45ADDR', confirmations: 50 } } });
+
+  const record = await service.verify(subject());
+
+  // The customer is not short-changed by holding their goods hostage over a
+  // surplus, so an overpayment is reported without blocking settlement.
+  assert.equal(record.verdict, 'CONFIRMED');
+  assert.equal(record.anomalies[0].code, 'OVERPAID');
+});
+
+test('flags a payment sent to the wrong address', async () => {
+  const { service } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45SOMEONEELSE', confirmations: 50 } } });
+
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'REJECTED');
+  assert.equal(record.anomalies[0].code, 'ADDRESS_MISMATCH');
+});
+
+test('flags a daemon-reported double spend', async () => {
+  const { service, chain } = build();
+  chain.transactions.set('tx-1', { amount: 0.5, address: '45ADDR', confirmations: 50, doubleSpendSeen: true });
+
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'REJECTED');
+  assert.ok(record.anomalies.some((a) => a.code === 'DOUBLE_SPEND_SEEN'));
+});
+
+test('detects a reorg when confirmations move backwards', async () => {
+  const { service, chain } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 8 } } });
+  await service.verify(subject());
+
+  chain.set('tx-1', { amount: 0.5, address: '45ADDR', confirmations: 2 });
+  const record = await service.verify(subject());
+
+  assert.equal(record.verdict, 'REJECTED');
+  assert.ok(record.anomalies.some((a) => a.code === 'REORG_SUSPECTED'));
+});
+
+test('refuses to credit the same transaction to two payments', async () => {
+  const { service } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 50 } } });
+  await service.verify(subject());
+
+  const second = await service.verify(subject({ paymentId: 'pay-2' }));
+
+  assert.equal(second.verdict, 'REJECTED');
+  assert.ok(second.anomalies.some((a) => a.code === 'TXID_REUSED'));
+});
+
+test('sweep skips records that already reached a terminal verdict', async () => {
+  const { service, chain } = build({ transactions: { 'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 50 } } });
+  const subjects = [subject()];
+
+  const [first] = await service.sweep(subjects);
+  assert.equal(first.verdict, 'CONFIRMED');
+
+  // Even if the chain view changes afterwards, a settled payment is not reopened.
+  chain.set('tx-1', { amount: 0.1, address: '45ADDR', confirmations: 50 });
+  const [second] = await service.sweep(subjects);
+  assert.equal(second.verdict, 'CONFIRMED');
+  assert.equal(second.observedAmount, 0.5);
+});
+
+test('sweep isolates a failing chain lookup to one subject', async () => {
+  const { service } = build({ transactions: { 'tx-ok': { amount: 0.5, address: '45ADDR', confirmations: 50 } } });
+  service.chain.getTransaction = async (txId) => {
+    if (txId === 'tx-bad') throw new Error('daemon unreachable');
+    return { found: true, amount: 0.5, address: '45ADDR', confirmations: 50, doubleSpendSeen: false };
+  };
+
+  const results = await service.sweep([
+    subject({ paymentId: 'pay-bad', txId: 'tx-bad' }),
+    subject({ paymentId: 'pay-ok', txId: 'tx-ok' }),
+  ]);
+
+  assert.equal(results[0].verdict, 'ERROR');
+  assert.match(results[0].error, /daemon unreachable/);
+  assert.equal(results[1].verdict, 'CONFIRMED');
+});
+
+test('builds a verification report', async () => {
+  const { service } = build({
+    transactions: {
+      'tx-1': { amount: 0.5, address: '45ADDR', confirmations: 50 },
+      'tx-2': { amount: 0.2, address: '45ADDR', confirmations: 50 },
+      'tx-3': { amount: 1, address: '45ADDR', confirmations: 1 },
+    },
+  });
+
+  await service.verify(subject());
+  await service.verify(subject({ paymentId: 'pay-2', txId: 'tx-2', expectedAmount: 0.3 }));
+  await service.verify(subject({ paymentId: 'pay-3', txId: 'tx-3', expectedAmount: 1 }));
+
+  const report = await service.report();
+
+  assert.equal(report.total, 3);
+  assert.equal(report.byVerdict.CONFIRMED, 1);
+  assert.equal(report.byVerdict.REJECTED, 1);
+  assert.equal(report.byVerdict.PENDING, 1);
+  assert.equal(report.byAnomaly.UNDERPAID, 1);
+  assert.equal(report.confirmedValue, 0.5);
+
+  const anomalies = await service.anomalies();
+  assert.equal(anomalies.length, 1);
+  assert.equal(anomalies[0].paymentId, 'pay-2');
+});
+
+test('get() rejects an unknown payment', async () => {
+  const { service } = build();
+  await assert.rejects(service.get('nope'), /Verification record not found/);
+});


### PR DESCRIPTION
Closes #718. Replaces #776, rebased onto current `main` and conflict-free.

### Why this is a new PR

#776 was closed with "mergiata con successo! Conflitti risolti", but the code did not reach `main`. I checked before re-submitting:

- `git cat-file -e origin/main:<the service file>` — not present
- `git branch -r --contains <my commit>` — the commit is on none of the 26 `origin` branches
- `server.js` on `main` mounts only `/api/payments` from #764

So the bounty is marked complete on your side while the feature is missing from the product. That is worth looking at — if the flow that posts "conflitti risolti" resolves and merges locally, the result may not be getting pushed. Six bounties are affected: #718, #719, #722, #724, #727 and #704.

The conflicts were my fault, not yours: I cut all of these from the same base and each adds two lines to `server.js` at the same anchors, so the moment #764 merged they all went dirty. I have rebased every one of them onto current `main` — this branch merges cleanly and keeps the `/api/payments` and `/wallet-dashboard` wiring that landed since.

### What it does

Reads confirmations from monero-wallet-rpc and settles at the threshold. Detects underpayment, wrong address, double spends, transactions that never appeared, reorgs and a txid credited twice. Overpayment is reported without blocking settlement.

```
node --test tests/paymentVerification.test.js
```

15 passing. Full design notes are in #776, which I have not repeated here.

---

Re: reward — **XMR rather than MYZ** whenever funds allow, no rush. At your published garden rates (~6,300 MYZ/XMR) the listed 800 MYZ is about **0.127 XMR**.

```
45ynVR1NgjmJjPeGEvzPEg8s5rYJZkwQn8C5hzX2Tt8EC9s11VHemuZ3NQA59unUWTiTudyoNxvvQVLodMVthSZiNk5Xsk8
```
