### PR TITLE
fix: Remove hardcoded JWT secret fallback

### DIFF
--- a/core-backend/src/middleware/auth.js
+++ b/core-backend/src/middleware/auth.js
@@ -1,6 +1,14 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 
+// SECURITY FIX (Issue #889): Removed hardcoded JWT secret fallback.
+// JWT_SECRET environment variable is now REQUIRED.
+// Fail closed: if missing, all token verification fails.
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  console.error('[SECURITY] JWT_SECRET environment variable is not set. Authentication is disabled.');
+}
+
 const auth = {
   verifyToken: async (req, res, next) => {
     try {
@@ -9,7 +17,11 @@ const auth = {
         return res.status(401).json({ success: false, error: 'No token provided' });
       }
 
-      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+      if (!JWT_SECRET) {
+        return res.status(500).json({ success: false, error: 'Server configuration error' });
+      }
+
+      const decoded = jwt.verify(token, JWT_SECRET);
       const user = await User.findById(decoded.id);
 
       if (!user) {


### PR DESCRIPTION
- Remove insecure fallback to 'secret' when JWT_SECRET env var is missing
- Fail closed: disable authentication if JWT_SECRET is not configured
- Prevents production deployments with default/weak JWT secret

Fixes #889