### PR TITLE
[BOUNTY #867 — 100 MYZ] feat: Spanish locale — traducción completa del gateway

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,22 @@
+{
+  "health": {
+    "message": "¡{{service}} Gateway está funcionando!"
+  },
+  "auth": {
+    "loginEndpoint": "Endpoint de inicio de sesión",
+    "registerEndpoint": "Endpoint de registro",
+    "required": "Autenticación requerida"
+  },
+  "admin": {
+    "required": "Se requieren privilegios de administrador"
+  },
+  "validation": {
+    "targetUrlRequired": "targetUrl es obligatorio"
+  },
+  "webhooks": {
+    "sentWithRetry": "Webhook enviado con reintento automático"
+  },
+  "errors": {
+    "internal": "Error interno del servidor"
+  }
+}


### PR DESCRIPTION
Closes #867

## Changes
- Add `locales/es.json` with complete Spanish translations
- Covers health, auth, admin, validation, webhooks, and error messages
- Follows existing locale structure (en.json, it.json)

Ciao! Spanish translation ready for review.