### PR TITLE
[BOUNTY #875 — 80 MYZ] feat: Dark/Light mode toggle with localStorage persistence

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') === 'dark' ||
+        (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      root.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [dark]);
+
+  return (
+    <button
+      onClick={() => setDark(!dark)}
+      className="theme-toggle"
+      aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={dark ? 'Cambia a modo chiaro' : 'Cambia a modo scuro'}
+      style={{
+        position: 'fixed',
+        bottom: '1.5rem',
+        right: '1.5rem',
+        zIndex: 9999,
+        width: '44px',
+        height: '44px',
+        borderRadius: '50%',
+        border: '1px solid var(--border)',
+        background: 'var(--bg)',
+        color: 'var(--text-h)',
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '1.2rem',
+        boxShadow: 'var(--shadow)',
+        transition: 'transform 0.2s, background 0.3s',
+      }}
+      onMouseEnter={e => e.currentTarget.style.transform = 'scale(1.1)'}
+      onMouseLeave={e => e.currentTarget.style.transform = 'scale(1)'}
+    >
+      {dark ? '\u2600' : '\u263D'}
+    </button>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import ThemeToggle from './components/ThemeToggle.jsx';
 import './index.css';
+
+// Apply saved theme before render to prevent flash
+(function() {
+  const saved = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (saved === 'dark' || (!saved && prefersDark)) {
+    document.documentElement.classList.add('dark');
+  }
+})();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
+    <ThemeToggle />
   </React.StrictMode>,
 );


### PR DESCRIPTION
Closes #875

## Changes
- Add `ThemeToggle.jsx` floating button (sun/moon icon)
- Update `main.jsx` with anti-flash theme detection
- localStorage persistence (survives page reloads)
- Respects `prefers-color-scheme` media query as fallback
- Smooth transition animations
- Leverages existing CSS custom properties (`.dark` class)
- Keyboard accessible (Enter/Space)

Ciao! Dark/light mode toggle ready with saved preferences.