### PR TITLE
[BOUNTY #876 — 80 MYZ] feat: Accessibility improvements — skip links, focus, ARIA, reduced motion

### DIFF
--- a/frontend/src/utils/accessibility.js
+++ b/frontend/src/utils/accessibility.js
@@ -1,0 +1,53 @@
+// Accessibility enhancements for MyZubster Gateway
+(function() {
+  'use strict';
+
+  // Inject skip link
+  const skipLink = document.createElement('a');
+  skipLink.href = '#root';
+  skipLink.className = 'skip-link';
+  skipLink.textContent = 'Skip to main content';
+  document.body.prepend(skipLink);
+
+  // Add ARIA live region for dynamic content updates
+  const liveRegion = document.createElement('div');
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('aria-atomic', 'true');
+  liveRegion.className = 'sr-only';
+  liveRegion.id = 'aria-live-region';
+  document.body.appendChild(liveRegion);
+
+  // Observe DOM for new focusable elements
+  const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(mutation) {
+      mutation.addedNodes.forEach(function(node) {
+        if (node.nodeType === 1) {
+          // Ensure new interactive elements are keyboard accessible
+          const focusable = node.querySelectorAll && node.querySelectorAll('div[onclick], span[onclick], li[onclick]');
+          focusable.forEach(function(el) {
+            if (!el.hasAttribute('tabindex')) {
+              el.setAttribute('tabindex', '0');
+              el.setAttribute('role', 'button');
+            }
+          });
+        }
+      });
+    });
+  });
+  
+  if (document.body) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  // Trap focus in modals/dialogs (auto-detect)
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      const openModal = document.querySelector('[role="dialog"][open], dialog[open]');
+      if (openModal) {
+        openModal.close && openModal.close();
+      }
+    }
+  });
+
+  console.log('[a11y] MyZubster Gateway accessibility enhancements loaded');
+})();

--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -1,0 +1,73 @@
+/* Accessibility enhancements for MyZubster Gateway */
+/* Skip to main content link */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--accent);
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 10000;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+}
+.skip-link:focus {
+  top: 0;
+}
+
+/* Visible focus indicator */
+*:focus-visible {
+  outline: 3px solid var(--accent) !important;
+  outline-offset: 2px !important;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* High contrast mode improvements */
+@media (forced-colors: active) {
+  .theme-toggle {
+    border: 2px solid ButtonText;
+  }
+}
+
+/* Screen reader only utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Print styles */
+@media print {
+  .theme-toggle,
+  nav,
+  footer {
+    display: none !important;
+  }
+  body {
+    font-size: 12pt;
+    color: #000;
+    background: #fff;
+  }
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+  }
+}

--- a/public/css/accessibility.css
+++ b/public/css/accessibility.css
@@ -1,0 +1,83 @@
+/* Accessibility Improvements - Closes #876 */
+
+/* Skip to main content link */
+.skip-to-main {
+  position: absolute;
+  top: -100px;
+  left: 8px;
+  background: var(--accent, #4f46e5);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 0 0 8px 8px;
+  z-index: 10000;
+  font-weight: 600;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skip-to-main:focus {
+  top: 0;
+}
+
+/* Focus visible - keyboard navigation */
+:focus-visible {
+  outline: 3px solid var(--accent, #4f46e5) !important;
+  outline-offset: 2px !important;
+}
+
+/* Remove default focus for mouse users */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* High contrast focus for interactive elements */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--accent, #4f46e5) !important;
+  outline-offset: 3px !important;
+  border-radius: 4px;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Minimum touch target size (WCAG 2.5.5) */
+button, [role="button"], .clickable, a[href]:not([class*="skip"]) {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+/* Color contrast improvements */
+@media (forced-colors: active) {
+  .theme-toggle, .skip-to-main {
+    border: 2px solid ButtonText;
+  }
+}
+
+/* ARIA live region styling */
+[aria-live="polite"], [aria-live="assertive"] {
+  position: relative;
+}

--- a/public/js/accessibility.js
+++ b/public/js/accessibility.js
@@ -1,0 +1,108 @@
+// Accessibility Enhancements - Closes #876
+(function() {
+  'use strict';
+
+  // Inject skip-to-main link
+  function injectSkipLink() {
+    const main = document.querySelector('main, [role="main"], #main-content');
+    if (!main) return;
+
+    const existing = document.querySelector('.skip-to-main');
+    if (existing) return;
+
+    const link = document.createElement('a');
+    link.className = 'skip-to-main sr-only';
+    link.href = '#' + (main.id || 'main-content');
+    link.textContent = 'Skip to main content';
+
+    if (!main.id) main.id = 'main-content';
+
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      main.setAttribute('tabindex', '-1');
+      main.focus({ preventScroll: false });
+    });
+
+    document.body.insertBefore(link, document.body.firstChild);
+  }
+
+  // Add ARIA labels to interactive elements missing them
+  function enhanceAriaLabels() {
+    // Links with icon-only content
+    document.querySelectorAll('a[href]:empty, a[href]:has(svg:only-child)').forEach(el => {
+      if (!el.getAttribute('aria-label')) {
+        const text = el.textContent.trim() || el.getAttribute('title') || 'Link';
+        el.setAttribute('aria-label', text);
+      }
+    });
+
+    // Buttons without labels
+    document.querySelectorAll('button:empty, button:has(svg:only-child)').forEach(el => {
+      if (!el.getAttribute('aria-label')) {
+        el.setAttribute('aria-label', el.getAttribute('title') || 'Button');
+      }
+    });
+  }
+
+  // Create ARIA live region for dynamic content
+  function createLiveRegion() {
+    const existing = document.getElementById('a11y-announcements');
+    if (existing) return;
+
+    const region = document.createElement('div');
+    region.id = 'a11y-announcements';
+    region.setAttribute('aria-live', 'polite');
+    region.setAttribute('aria-atomic', 'true');
+    region.className = 'sr-only';
+    document.body.appendChild(region);
+
+    // Expose globally
+    window.announceToScreenReader = function(message) {
+      region.textContent = '';
+      setTimeout(() => { region.textContent = message; }, 50);
+    };
+  }
+
+  // Keyboard trap prevention for modals
+  function setupFocusTraps() {
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape') return;
+
+      const modal = document.querySelector('[role="dialog"][open], .modal:not([hidden])');
+      if (modal) {
+        const closeBtn = modal.querySelector('[aria-label*="close" i], [aria-label*="Close" i], .close, .modal-close, [data-close]');
+        if (closeBtn) closeBtn.click();
+        e.preventDefault();
+      }
+    });
+  }
+
+  // Observe DOM for new content
+  function observeDOM() {
+    const observer = new MutationObserver(() => {
+      enhanceAriaLabels();
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+
+    // Initial pass
+    enhanceAriaLabels();
+  }
+
+  // Initialize on DOM ready
+  function init() {
+    injectSkipLink();
+    createLiveRegion();
+    setupFocusTraps();
+    observeDOM();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
Closes #876

## Changes
- Add `public/accessibility.css`:
  - Skip-to-content link (hidden until focused)
  - Visible `:focus-visible` indicators (3px accent outline)
  - `prefers-reduced-motion` support (disables all animations)
  - High contrast / forced-colors mode support
  - Screen-reader-only utility class
  - Print stylesheet
- Add `frontend/src/utils/accessibility.js`:
  - Auto-injected skip link
  - ARIA live region for dynamic content
  - MutationObserver: auto-adds tabindex/role to clickable divs
  - Escape key closes open dialogs/modals

Ciao! Accessibility layer ready — keyboard nav, screen reader, and reduced motion support.