### PR TITLE
[BOUNTY #868 — 100 MYZ] feat: French locale — traduction complete du gateway

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,35 @@
+{
+  "health": {
+    "message": "{{service}} Gateway est opérationnel !"
+  },
+  "auth": {
+    "loginEndpoint": "Point de connexion",
+    "registerEndpoint": "Point d'inscription",
+    "required": "Authentification requise"
+  },
+  "admin": {
+    "required": "Privilèges administrateur requis"
+  },
+  "validation": {
+    "targetUrlRequired": "targetUrl est obligatoire"
+  },
+  "webhooks": {
+    "sentWithRetry": "Webhook envoyé avec nouvelle tentative automatique"
+  },
+  "errors": {
+    "internal": "Erreur interne du serveur"
+  },
+  "marketplace": {
+    "title": "Marketplace",
+    "noItems": "Aucun article disponible",
+    "search": "Rechercher...",
+    "buy": "Acheter",
+    "sell": "Vendre"
+  },
+  "navigation": {
+    "home": "Accueil",
+    "dashboard": "Tableau de bord",
+    "settings": "Paramètres",
+    "logout": "Déconnexion"
+  }
+}


### PR DESCRIPTION
## Traduction Française 🇫🇷

Closes #868

### Fichiers
- `locales/fr.json` — Traduction complète de l'interface (marketplace, navigation, auth, erreurs)

### Terminologie vérifiée
- Termes techniques cohérents (gateway, webhook, endpoint)
- Cohérence des temps et modes
- Noms de rôles (admin) conservés en minuscule selon conventions UI