### PR TITLE
[MAPPING — 400 MYZ] Mappa Orti Urbani con geolocalizzazione (Closes #745)

### DIFF
--- a/client/src/components/GardenMap.css
+++ b/client/src/components/GardenMap.css
@@ -1,0 +1,10 @@
+.garden-map-container { position: relative; height: calc(100vh - 120px); display: flex; flex-direction: column; }
+.garden-map-controls { padding: 12px 16px; background: white; border-bottom: 1px solid #e0e0e0; display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+.garden-search { padding: 8px 12px; border: 1px solid #ccc; border-radius: 6px; font-size: 0.9rem; min-width: 180px; }
+.garden-export-btn { padding: 8px 16px; background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+.garden-export-btn:hover { background: #1557b0; }
+.garden-leaflet-map { flex: 1; z-index: 1; }
+.garden-popup h3 { margin: 0 0 8px 0; font-size: 1rem; color: #2E7D32; }
+.garden-popup p { margin: 4px 0; font-size: 0.85rem; }
+.garden-loading { position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%); z-index: 1000; background: white; padding: 20px 40px; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+.garden-stats { padding: 8px 16px; background: #f5f5f5; border-top: 1px solid #e0e0e0; font-size: 0.85rem; color: #666; }

--- a/client/src/components/GardenMap.jsx
+++ b/client/src/components/GardenMap.jsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import L from 'leaflet';
+import './GardenMap.css';
+
+// Fix Leaflet default icon
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+});
+
+const gardenIcon = new L.Icon({
+  iconUrl: 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="14" fill="#4CAF50" stroke="#2E7D32" stroke-width="2"/><text x="16" y="21" text-anchor="middle" fill="white" font-size="16">🌱</text></svg>'),
+  iconSize: [32, 32],
+  iconAnchor: [16, 32],
+  popupAnchor: [0, -32]
+});
+
+function MapBoundsUpdater({ gardens }) {
+  const map = useMap();
+  useEffect(() => {
+    if (gardens.length > 0) {
+      const bounds = gardens.map(g => [g.geometry.coordinates[1], g.geometry.coordinates[0]]);
+      map.fitBounds(bounds, { padding: [50, 50] });
+    }
+  }, [gardens, map]);
+  return null;
+}
+
+function GardenMap() {
+  const [gardens, setGardens] = useState([]);
+  const [filters, setFilters] = useState({ crop: '', minArea: '' });
+  const [loading, setLoading] = useState(true);
+
+  const fetchGardens = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (filters.crop) params.append('crop', filters.crop);
+      if (filters.minArea) params.append('minArea', filters.minArea);
+      
+      const res = await fetch(`/api/gardens?${params}`);
+      const data = await res.json();
+      setGardens(data.features || []);
+    } catch (err) {
+      console.error('Failed to fetch gardens:', err);
+    }
+    setLoading(false);
+  }, [filters]);
+
+  useEffect(() => { fetchGardens(); }, [fetchGardens]);
+
+  const handleExport = async (format) => {
+    window.open(`/api/gardens/export/${format}`, '_blank');
+  };
+
+  return (
+    <div className="garden-map-container">
+      <div className="garden-map-controls">
+        <input
+          type="text"
+          placeholder="Filtra per coltura (es. pomodori)..."
+          value={filters.crop}
+          onChange={e => setFilters(f => ({ ...f, crop: e.target.value }))}
+          className="garden-search"
+        />
+        <input
+          type="number"
+          placeholder="Area minima (m²)..."
+          value={filters.minArea}
+          onChange={e => setFilters(f => ({ ...f, minArea: e.target.value }))}
+          className="garden-search"
+        />
+        <button onClick={() => handleExport('csv')} className="garden-export-btn">Esporta CSV</button>
+        <button onClick={() => handleExport('geojson')} className="garden-export-btn">Esporta GeoJSON</button>
+      </div>
+      
+      {loading && <div className="garden-loading">Caricamento mappa...</div>}
+      
+      <MapContainer center={[41.9028, 12.4964]} zoom={6} className="garden-leaflet-map">
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <MapBoundsUpdater gardens={gardens} />
+        {gardens.map(garden => (
+          <Marker
+            key={garden.properties.id}
+            position={[garden.geometry.coordinates[1], garden.geometry.coordinates[0]]}
+            icon={gardenIcon}
+          >
+            <Popup>
+              <div className="garden-popup">
+                <h3>{garden.properties.name}</h3>
+                <p>🌍 {garden.properties.area_sqm} m²</p>
+                <p>🌿 {garden.properties.crops?.join(', ') || 'N/D'}</p>
+                {garden.properties.description && <p>{garden.properties.description}</p>}
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+      
+      <div className="garden-stats">
+        {gardens.length} orti trovati
+      </div>
+    </div>
+  );
+}
+
+export default GardenMap;

--- a/models/Garden.js
+++ b/models/Garden.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+const gardenSchema = new mongoose.Schema({
+  name: { type: String, required: true, index: true },
+  location: {
+    type: { type: String, enum: ['Point'], default: 'Point' },
+    coordinates: {
+      type: [Number], // [longitude, latitude]
+      required: true,
+      validate: {
+        validator: v => v.length === 2 && v[0] >= -180 && v[0] <= 180 && v[1] >= -90 && v[1] <= 90,
+        message: 'Invalid coordinates'
+      }
+    }
+  },
+  area_sqm: { type: Number, required: true, min: 1 },
+  crops: [{ type: String }],
+  description: { type: String, default: '' },
+  photos: [{ type: String }],
+  owner: { type: String },
+  isActive: { type: Boolean, default: true },
+  lastHarvest: { type: Date }
+}, { timestamps: true });
+
+gardenSchema.index({ location: '2dsphere' });
+gardenSchema.index({ crops: 1 });
+gardenSchema.index({ name: 'text', description: 'text' });
+
+module.exports = mongoose.model('Garden', gardenSchema);

--- a/routes/gardenMap.js
+++ b/routes/gardenMap.js
@@ -1,0 +1,133 @@
+const express = require('express');
+const router = express.Router();
+const { body, query, validationResult } = require('express-validator');
+const Garden = require('../models/Garden');
+
+// List all gardens with search & filters
+router.get('/',
+  query('lat').optional().isFloat(),
+  query('lng').optional().isFloat(),
+  query('radius').optional().isFloat(),
+  query('crop').optional().isString(),
+  query('minArea').optional().isFloat(),
+  async (req, res) => {
+    try {
+      const filter = {};
+      
+      // Geo-spatial search
+      if (req.query.lat && req.query.lng) {
+        const radius = parseFloat(req.query.radius) || 5000; // 5km default
+        filter.location = {
+          $near: {
+            $geometry: {
+              type: 'Point',
+              coordinates: [parseFloat(req.query.lng), parseFloat(req.query.lat)]
+            },
+            $maxDistance: radius
+          }
+        };
+      }
+      
+      if (req.query.crop) {
+        filter.crops = { $in: [new RegExp(req.query.crop, 'i')] };
+      }
+      if (req.query.minArea) {
+        filter.area_sqm = { $gte: parseFloat(req.query.minArea) };
+      }
+      
+      const gardens = await Garden.find(filter)
+        .select('name location area_sqm crops description photos')
+        .limit(100);
+      
+      res.json({
+        type: 'FeatureCollection',
+        features: gardens.map(g => ({
+          type: 'Feature',
+          geometry: g.location,
+          properties: {
+            id: g._id,
+            name: g.name,
+            area_sqm: g.area_sqm,
+            crops: g.crops,
+            description: g.description,
+            photos: g.photos
+          }
+        }))
+      });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  }
+);
+
+// Get single garden
+router.get('/:id', async (req, res) => {
+  try {
+    const garden = await Garden.findById(req.params.id);
+    if (!garden) return res.status(404).json({ error: 'Garden not found' });
+    res.json(garden);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Create garden
+router.post('/',
+  body('name').isString().notEmpty(),
+  body('latitude').isFloat({ min: -90, max: 90 }),
+  body('longitude').isFloat({ min: -180, max: 180 }),
+  body('area_sqm').isFloat({ min: 1 }),
+  body('crops').isArray(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return res.status(400).json({ errors: errors.array() });
+    
+    try {
+      const garden = new Garden({
+        name: req.body.name,
+        location: {
+          type: 'Point',
+          coordinates: [req.body.longitude, req.body.latitude]
+        },
+        area_sqm: req.body.area_sqm,
+        crops: req.body.crops,
+        description: req.body.description || '',
+        photos: req.body.photos || [],
+        owner: req.body.owner
+      });
+      await garden.save();
+      res.status(201).json(garden);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  }
+);
+
+// Export gardens as CSV/GeoJSON
+router.get('/export/:format', async (req, res) => {
+  try {
+    const gardens = await Garden.find({}).lean();
+    
+    if (req.params.format === 'csv') {
+      const header = 'name,latitude,longitude,area_sqm,crops\n';
+      const rows = gardens.map(g => 
+        `"${g.name}",${g.location.coordinates[1]},${g.location.coordinates[0]},${g.area_sqm},"${g.crops.join(';')}"`
+      ).join('\n');
+      res.setHeader('Content-Type', 'text/csv');
+      res.send(header + rows);
+    } else {
+      res.json({
+        type: 'FeatureCollection',
+        features: gardens.map(g => ({
+          type: 'Feature',
+          geometry: g.location,
+          properties: { name: g.name, area_sqm: g.area_sqm, crops: g.crops }
+        }))
+      });
+    }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Descrizione
Mappa interattiva degli orti urbani con geolocalizzazione, ricerca e export dati.

## ✅ Criteri soddisfatti
- [x] Mappa interattiva — React + Leaflet con marker personalizzati 🌱
- [x] Geolocalizzazione orti — modello Mongoose con indice 2dsphere
- [x] Dati orti — nome, superficie (area_sqm), colture, descrizione, foto
- [x] Ricerca e filtri — per coltura, area minima, ricerca geospaziale per raggio
- [x] Export dati — CSV e GeoJSON

## 📁 File
| File | Descrizione |
|------|-------------|
| `routes/gardenMap.js` | Route Express: GET geo-search, GET/:id, POST create, GET export/:format |
| `models/Garden.js` | Modello Mongoose: 2dsphere, crops[], area_sqm, photos[], text index |
| `client/src/components/GardenMap.jsx` | Componente React+Leaflet: mappa interattiva, popup, filtri, export |
| `client/src/components/GardenMap.css` | Stili full-height map con controlli sticky |

Closes #745