### PR TITLE
[DASHBOARD — 300 MYZ] Dashboard Orti — visualizzazione dati e metriche (Closes #744)

### DIFF
--- a/client/src/components/GardenDashboard.css
+++ b/client/src/components/GardenDashboard.css
@@ -1,0 +1,20 @@
+.garden-dashboard { padding: 20px; max-width: 1200px; margin: 0 auto; font-family: system-ui, sans-serif; }
+.gd-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.gd-header h2 { font-size: 1.5rem; color: #2E7D32; margin: 0; }
+.gd-export-btn { padding: 10px 20px; background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer; }
+.gd-summary-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 24px; }
+.gd-card { background: #f8f9fa; border-radius: 10px; padding: 20px; text-align: center; border: 1px solid #e0e0e0; }
+.gd-card-label { display: block; color: #666; font-size: 0.8rem; text-transform: uppercase; margin-bottom: 8px; }
+.gd-card-value { font-size: 1.8rem; font-weight: 700; color: #1a73e8; }
+.gd-charts { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 24px; }
+.gd-chart-panel { background: white; border-radius: 10px; padding: 16px; border: 1px solid #e0e0e0; }
+.gd-chart-panel h3 { margin: 0 0 12px; font-size: 1rem; }
+.gd-chart-body { height: 250px; }
+.gd-chart-controls { display: flex; gap: 10px; margin-bottom: 12px; }
+.gd-chart-controls select { padding: 6px 10px; border: 1px solid #ccc; border-radius: 4px; }
+.gd-recent-metrics table { width: 100%; border-collapse: collapse; }
+.gd-recent-metrics th, .gd-recent-metrics td { padding: 8px; text-align: left; border-bottom: 1px solid #eee; font-size: 0.85rem; }
+.gd-recent-metrics h3 { margin-bottom: 12px; }
+.gd-footer { text-align: right; color: #999; font-size: 0.8rem; margin-top: 16px; }
+.gd-loading, .gd-error { text-align: center; padding: 60px; font-size: 1.1rem; }
+@media (max-width: 768px) { .gd-charts { grid-template-columns: 1fr; } }

--- a/client/src/components/GardenDashboard.jsx
+++ b/client/src/components/GardenDashboard.jsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from 'react';
+import { Line, Bar, Doughnut } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale, LinearScale, PointElement, LineElement,
+  BarElement, ArcElement, Title, Tooltip, Legend, Filler
+} from 'chart.js';
+import './GardenDashboard.css';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Title, Tooltip, Legend, Filler);
+
+function GardenDashboard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [timeRange, setTimeRange] = useState(30);
+  const [selectedMetric, setSelectedMetric] = useState('temperature');
+  const [history, setHistory] = useState(null);
+
+  useEffect(() => { fetchDashboard(); }, []);
+  useEffect(() => { fetchHistory(); }, [timeRange, selectedMetric]);
+
+  const fetchDashboard = async () => {
+    try {
+      const res = await fetch('/api/garden-dashboard');
+      const d = await res.json();
+      setData(d);
+      setLoading(false);
+    } catch (err) {
+      console.error(err);
+      setLoading(false);
+    }
+  };
+
+  const fetchHistory = async () => {
+    try {
+      const res = await fetch(`/api/garden-dashboard/history?days=${timeRange}&metric=${selectedMetric}`);
+      const h = await res.json();
+      setHistory(h);
+    } catch (err) { console.error(err); }
+  };
+
+  const handleExport = () => window.open('/api/garden-dashboard/report', '_blank');
+
+  if (loading) return <div className="gd-loading">Caricamento dashboard...</div>;
+  if (!data) return <div className="gd-error">Nessun dato disponibile</div>;
+
+  const cropChartData = {
+    labels: data.topCrops?.map(c => c.crop) || [],
+    datasets: [{
+      data: data.topCrops?.map(c => c.gardens) || [],
+      backgroundColor: ['#4CAF50','#66BB6A','#81C784','#A5D6A7','#C8E6C9','#388E3C','#2E7D32','#1B5E20','#8BC34A','#CDDC39']
+    }]
+  };
+
+  const historyChartData = history ? {
+    labels: history.history?.map(h => new Date(h.timestamp).toLocaleDateString('it-IT')) || [],
+    datasets: [{
+      label: selectedMetric,
+      data: history.history?.map(h => h.value) || [],
+      borderColor: '#4CAF50',
+      backgroundColor: 'rgba(76,175,80,0.1)',
+      fill: true, tension: 0.3
+    }]
+  } : null;
+
+  return (
+    <div className="garden-dashboard">
+      <div className="gd-header">
+        <h2>Dashboard Orti Urbani</h2>
+        <button onClick={handleExport} className="gd-export-btn">Esporta Report</button>
+      </div>
+
+      <div className="gd-summary-cards">
+        <div className="gd-card">
+          <span className="gd-card-label">Orti Attivi</span>
+          <span className="gd-card-value">{data.summary.totalGardens}</span>
+        </div>
+        <div className="gd-card">
+          <span className="gd-card-label">Area Totale</span>
+          <span className="gd-card-value">{data.summary.totalArea_sqm?.toLocaleString()} m²</span>
+        </div>
+        <div className="gd-card">
+          <span className="gd-card-label">Area Media</span>
+          <span className="gd-card-value">{data.summary.avgArea_sqm?.toFixed(0)} m²</span>
+        </div>
+      </div>
+
+      <div className="gd-charts">
+        <div className="gd-chart-panel">
+          <h3>Top 10 Colture</h3>
+          <div className="gd-chart-body">
+            <Doughnut data={cropChartData} options={{ responsive: true, maintainAspectRatio: false }} />
+          </div>
+        </div>
+
+        <div className="gd-chart-panel">
+          <h3>Andamento Metriche</h3>
+          <div className="gd-chart-controls">
+            <select value={selectedMetric} onChange={e => setSelectedMetric(e.target.value)}>
+              {['temperature','humidity','soil_moisture','soil_ph','light_level','water_usage','harvest_yield'].map(m => (
+                <option key={m} value={m}>{m.replace(/_/g,' ')}</option>
+              ))}
+            </select>
+            <select value={timeRange} onChange={e => setTimeRange(parseInt(e.target.value))}>
+              <option value={7}>7 giorni</option><option value={30}>30 giorni</option><option value={90}>90 giorni</option>
+            </select>
+          </div>
+          <div className="gd-chart-body">
+            {historyChartData && <Line data={historyChartData} options={{ responsive: true, maintainAspectRatio: false }} />}
+          </div>
+        </div>
+      </div>
+
+      <div className="gd-recent-metrics">
+        <h3>Metriche Recenti</h3>
+        <table><thead><tr><th>Timestamp</th><th>Metrica</th><th>Valore</th></tr></thead>
+        <tbody>
+          {data.recentMetrics?.slice(0,20).map((m,i) => (
+            <tr key={i}><td>{new Date(m.timestamp).toLocaleString('it-IT')}</td><td>{m.metric}</td><td>{m.value} {m.unit}</td></tr>
+          ))}
+        </tbody></table>
+      </div>
+
+      <div className="gd-footer">Generato: {new Date(data.generatedAt).toLocaleString('it-IT')}</div>
+    </div>
+  );
+}
+
+export default GardenDashboard;

--- a/models/GardenMetric.js
+++ b/models/GardenMetric.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const gardenMetricSchema = new mongoose.Schema({
+  gardenId: { type: mongoose.Schema.Types.ObjectId, ref: 'Garden', index: true },
+  metric: {
+    type: String,
+    required: true,
+    enum: ['temperature', 'humidity', 'soil_moisture', 'soil_ph', 'light_level', 'water_usage', 'harvest_yield']
+  },
+  value: { type: Number, required: true },
+  unit: { type: String, default: '' },
+  timestamp: { type: Date, default: Date.now, index: true }
+});
+
+gardenMetricSchema.index({ gardenId: 1, metric: 1, timestamp: -1 });
+gardenMetricSchema.index({ timestamp: -1 });
+
+module.exports = mongoose.model('GardenMetric', gardenMetricSchema);

--- a/routes/gardenDashboard.js
+++ b/routes/gardenDashboard.js
@@ -1,0 +1,99 @@
+const express = require('express');
+const router = express.Router();
+const Garden = require('../models/Garden');
+const GardenMetric = require('../models/GardenMetric');
+
+// Real-time dashboard data
+router.get('/', async (req, res) => {
+  try {
+    const [totalGardens, totalArea, cropCounts, recentMetrics] = await Promise.all([
+      Garden.countDocuments({ isActive: true }),
+      Garden.aggregate([
+        { $match: { isActive: true } },
+        { $group: { _id: null, total: { $sum: '$area_sqm' } } }
+      ]),
+      Garden.aggregate([
+        { $unwind: '$crops' },
+        { $group: { _id: '$crops', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: 10 }
+      ]),
+      GardenMetric.find()
+        .sort({ timestamp: -1 })
+        .limit(50)
+        .lean()
+    ]);
+
+    res.json({
+      summary: {
+        totalGardens,
+        totalArea_sqm: totalArea[0]?.total || 0,
+        avgArea_sqm: totalGardens > 0 ? (totalArea[0]?.total || 0) / totalGardens : 0
+      },
+      topCrops: cropCounts.map(c => ({ crop: c._id, gardens: c.count })),
+      recentMetrics,
+      generatedAt: new Date().toISOString()
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Historical data
+router.get('/history', async (req, res) => {
+  try {
+    const { days = 30, metric } = req.query;
+    const since = new Date(Date.now() - parseInt(days) * 86400000);
+    
+    const filter = { timestamp: { $gte: since } };
+    if (metric) filter.metric = metric;
+    
+    const history = await GardenMetric.find(filter)
+      .sort({ timestamp: 1 })
+      .lean();
+    
+    res.json({ history, days: parseInt(days), count: history.length });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Record a metric
+router.post('/metrics', async (req, res) => {
+  try {
+    const { gardenId, metric, value, unit } = req.body;
+    const record = new GardenMetric({ gardenId, metric, value, unit });
+    await record.save();
+    res.status(201).json(record);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Export report
+router.get('/report', async (req, res) => {
+  try {
+    const [gardens, metrics] = await Promise.all([
+      Garden.find({ isActive: true }).select('name area_sqm crops location').lean(),
+      GardenMetric.aggregate([
+        { $group: { _id: '$metric', avg: { $avg: '$value' }, min: { $min: '$value' }, max: { $max: '$value' }, count: { $sum: 1 } } }
+      ])
+    ]);
+
+    res.json({
+      reportType: 'garden_dashboard',
+      generatedAt: new Date().toISOString(),
+      gardens: {
+        total: gardens.length,
+        items: gardens
+      },
+      metrics: {
+        aggregated: metrics
+      }
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Descrizione
Dashboard per visualizzare dati degli orti urbani con grafici, metriche e export report.

## Criteri soddisfatti
- [x] Dati in tempo reale — riepilogo orti attivi, area totale/media, top colture
- [x] Grafici e metriche — Chart.js: Doughnut (top colture), Line (andamento metriche)
- [x] Storico dati — endpoint history con filtro giorni e metrica
- [x] Export report — endpoint /api/garden-dashboard/report
- [x] Responsive design — grid layout adattivo

## File
| File | Descrizione |
|------|-------------|
| routes/gardenDashboard.js | Route Express: GET dashboard, GET history, POST metrics, GET report |
| models/GardenMetric.js | Modello Mongoose: 7 tipi di metrica |
| client/src/components/GardenDashboard.jsx | React + Chart.js: cards, charts, table |
| client/src/components/GardenDashboard.css | Stili responsive |

Closes #744