### PR TITLE
feat: add interactive API documentation with all endpoints (Fixes #988) [MYZ]

### DIFF
--- a/frontend/api-docs.html
+++ b/frontend/api-docs.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="it" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MyZubsterGateway — Interactive API Documentation</title>
+<style>
+:root {
+  --bg: #0a0e17; --card: #111827; --border: #1f2937;
+  --text: #e5e7eb; --muted: #9ca3af; --accent: #3b82f6;
+  --green: #10b981; --orange: #f59e0b; --red: #ef4444;
+  --purple: #8b5cf6; --radius: 12px;
+  --method-get: #10b981; --method-post: #3b82f6;
+  --method-put: #f59e0b; --method-delete: #ef4444;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+body { font-family: system-ui, -apple-system, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; }
+.sidebar { width: 280px; background: var(--card); border-right: 1px solid var(--border); padding: 20px; overflow-y: auto; position: fixed; top:0; left:0; bottom:0; }
+.sidebar h2 { font-size: 18px; margin-bottom: 16px; color: var(--accent); }
+.sidebar input { width: 100%; padding: 10px 14px; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text); font-size: 13px; margin-bottom: 16px; outline: none; }
+.sidebar input:focus { border-color: var(--accent); }
+.tag { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: var(--radius); font-size: 13px; cursor: pointer; margin-bottom: 2px; color: var(--muted); transition: all 0.2s; }
+.tag:hover, .tag.active { background: rgba(59,130,246,0.1); color: var(--text); }
+.main { margin-left: 280px; padding: 32px; flex: 1; max-width: 900px; }
+.endpoint { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); padding: 24px; margin-bottom: 20px; }
+.endpoint-header { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.method { padding: 4px 12px; border-radius: 6px; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+.method.get { background: rgba(16,185,129,0.15); color: var(--method-get); }
+.method.post { background: rgba(59,130,246,0.15); color: var(--method-post); }
+.method.put { background: rgba(245,158,11,0.15); color: var(--method-put); }
+.method.delete { background: rgba(239,68,68,0.15); color: var(--method-delete); }
+.path { font-family: 'Fira Code', 'Cascadia Code', monospace; font-size: 15px; font-weight: 600; }
+.desc { color: var(--muted); font-size: 14px; margin-bottom: 16px; line-height: 1.6; }
+.code-block { background: #0d1117; border: 1px solid var(--border); border-radius: 8px; padding: 16px; overflow-x: auto; margin-bottom: 12px; }
+.code-block pre { font-family: 'Fira Code', monospace; font-size: 13px; line-height: 1.7; color: #c9d1d9; white-space: pre-wrap; word-break: break-all; }
+.code-block .key { color: #79c0ff; } .code-block .string { color: #a5d6ff; }
+.code-block .number { color: #79c0ff; } .code-block .comment { color: #8b949e; }
+.tabs { display: flex; gap: 4px; margin-bottom: 8px; flex-wrap: wrap; }
+.tab { padding: 6px 14px; border-radius: 6px; font-size: 12px; cursor: pointer; background: transparent; color: var(--muted); border: 1px solid var(--border); transition: all 0.2s; }
+.tab:hover, .tab.active { background: var(--accent); color: white; border-color: var(--accent); }
+.try-btn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 16px; background: var(--accent); color: white; border: none; border-radius: 8px; font-size: 13px; cursor: pointer; margin-top: 12px; transition: opacity 0.2s; }
+.try-btn:hover { opacity: 0.85; }
+.try-btn.loading { opacity: 0.6; pointer-events: none; }
+.try-response { display: none; margin-top: 12px; }
+.try-response.visible { display: block; }
+.try-response .status { font-size: 12px; font-weight: 600; margin-bottom: 8px; }
+.try-response .status.success { color: var(--green); }
+.try-response .status.error { color: var(--red); }
+.server-url { padding: 8px 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 13px; width: 100%; margin-bottom: 8px; outline: none; }
+.server-url:focus { border-color: var(--accent); }
+@media (max-width: 768px) {
+  .sidebar { display: none; }
+  .main { margin-left: 0; padding: 16px; }
+}
+</style>
+</head>
+<body>
+
+<aside class="sidebar">
+  <h2>📘 API Docs</h2>
+  <input type="text" placeholder="🔍 Search endpoints..." id="search" oninput="filterEndpoints()">
+  <div id="tag-list">
+    <div class="tag active" onclick="scrollToSection('users')">👥 Users</div>
+    <div class="tag" onclick="scrollToSection('comuni')">🏛️ Comuni</div>
+    <div class="tag" onclick="scrollToSection('enti')">🏢 Enti</div>
+    <div class="tag" onclick="scrollToSection('orti')">🌱 Orti Urbani</div>
+    <div class="tag" onclick="scrollToSection('stats')">📊 Stats</div>
+    <div class="tag" onclick="scrollToSection('tokens')">🪙 Tokens</div>
+    <div class="tag" onclick="scrollToSection('bookings')">📅 Bookings</div>
+    <div class="tag" onclick="scrollToSection('bounties')">💰 Bounties</div>
+    <div class="tag" onclick="scrollToSection('gateway')">🌐 Gateway</div>
+  </div>
+</aside>
+
+<main class="main">
+  <h1 style="font-size:28px;margin-bottom:8px">MyZubsterGateway API</h1>
+  <p class="desc" style="margin-bottom:32px">Complete REST API reference for the MyZubster decentralized gateway. All endpoints require authentication via JWT Bearer token except where noted.</p>
+
+  <label style="font-size:13px;color:var(--muted);display:block;margin-bottom:4px">Server URL:</label>
+  <input class="server-url" id="server-url" value="https://myzubster-gateway.onrender.com" placeholder="http://localhost:3001">
+
+  <!-- USERS -->
+  <h2 id="users" style="margin-bottom:16px;margin-top:32px">👥 Users</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/users</span></div>
+    <p class="desc">List all registered users with their profiles and reputation scores.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/users \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/users')">▶ Try It</button>
+    <div class="try-response" id="res-users"></div>
+  </div>
+
+  <!-- COMUNI -->
+  <h2 id="comuni" style="margin-bottom:16px;margin-top:32px">🏛️ Comuni (Municipalities)</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/comuni</span></div>
+    <p class="desc">Elenco di tutti i comuni registrati. Restituisce un array di oggetti comune con nome, regione, e popolazione.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/comuni \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/comuni')">▶ Try It</button>
+    <div class="try-response" id="res-comuni"></div>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/comuni/:id</span></div>
+    <p class="desc">Dettaglio di un comune specifico per ID. Include statistiche e servizi attivi.</p>
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+      <label style="font-size:13px;color:var(--muted)">ID:</label>
+      <input class="param-input" id="param-comuni-id" value="1" placeholder="comune ID" style="padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;width:120px;outline:none">
+    </div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/comuni/'+document.getElementById('param-comuni-id').value)">▶ Try It</button>
+    <div class="try-response" id="res-comuni-id"></div>
+  </div>
+
+  <!-- ENTI -->
+  <h2 id="enti" style="margin-bottom:16px;margin-top:32px">🏢 Enti (Entities)</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/enti</span></div>
+    <p class="desc">Elenco di tutti gli enti (aziende, associazioni, organizzazioni) registrati. Filtrabili per categoria.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/enti \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/enti')">▶ Try It</button>
+    <div class="try-response" id="res-enti"></div>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/enti/:id</span></div>
+    <p class="desc">Dettaglio di un ente specifico per ID. Include reparti, progetti e contatti.</p>
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+      <label style="font-size:13px;color:var(--muted)">ID:</label>
+      <input class="param-input" id="param-enti-id" value="1" placeholder="ente ID" style="padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;width:120px;outline:none">
+    </div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/enti/'+document.getElementById('param-enti-id').value)">▶ Try It</button>
+    <div class="try-response" id="res-enti-id"></div>
+  </div>
+
+  <!-- ORTI URBANI -->
+  <h2 id="orti" style="margin-bottom:16px;margin-top:32px">🌱 Orti Urbani (Urban Gardens)</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/orti</span></div>
+    <p class="desc">Elenco di tutti gli orti urbani disponibili. Ogni orto include posizione, superficie, e stato di assegnazione.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/orti \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/orti')">▶ Try It</button>
+    <div class="try-response" id="res-orti"></div>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/orti/:id</span></div>
+    <p class="desc">Dettaglio di un orto urbano per ID. Include storico assegnazioni e colture attive.</p>
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+      <label style="font-size:13px;color:var(--muted)">ID:</label>
+      <input class="param-input" id="param-orti-id" value="1" placeholder="orto ID" style="padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;width:120px;outline:none">
+    </div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/orti/'+document.getElementById('param-orti-id').value)">▶ Try It</button>
+    <div class="try-response" id="res-orti-id"></div>
+  </div>
+
+  <!-- STATS -->
+  <h2 id="stats" style="margin-bottom:16px;margin-top:32px">📊 Statistics</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/stats</span></div>
+    <p class="desc">Statistiche aggregate della piattaforma: utenti attivi, transazioni, orti assegnati, e volume reward.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/stats \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/stats')">▶ Try It</button>
+    <div class="try-response" id="res-stats"></div>
+  </div>
+
+  <!-- TOKENS -->
+  <h2 id="tokens" style="margin-bottom:16px;margin-top:32px">🪙 Tokens</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/tokens</span></div>
+    <p class="desc">Elenco di tutti i token disponibili (MYZ, XMR, BENZINA, etc.) con saldi e storico transazioni.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/tokens \
+  -H <span class="string">"Authorization: Bearer ***"</span></pre></div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/tokens')">▶ Try It</button>
+    <div class="try-response" id="res-tokens"></div>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/tokens/:id</span></div>
+    <p class="desc">Dettaglio di un token specifico per ID. Include prezzo, fornitura, e storico.</p>
+    <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+      <label style="font-size:13px;color:var(--muted)">ID:</label>
+      <input class="param-input" id="param-tokens-id" value="MYZ" placeholder="token ID" style="padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:13px;width:120px;outline:none">
+    </div>
+    <button class="try-btn" onclick="tryEndpoint('GET', '/api/tokens/'+document.getElementById('param-tokens-id').value)">▶ Try It</button>
+    <div class="try-response" id="res-tokens-id"></div>
+  </div>
+
+  <!-- BOOKINGS -->
+  <h2 id="bookings" style="margin-bottom:16px;margin-top:32px">📅 Bookings</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/bookings</span></div>
+    <p class="desc">Retrieve all bookings. Returns an array of booking objects.</p>
+    <div class="tabs"><button class="tab active">curl</button><button class="tab">JavaScript</button><button class="tab">Python</button></div>
+    <div class="code-block"><pre>curl -X GET https://api.myzubster.com/api/bookings \
+  -H <span class="string">"Authorization: Bearer ***"</span> \
+  -H <span class="string">"Content-Type: application/json"</span></pre></div>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method post">POST</span><span class="path">/api/bookings</span></div>
+    <p class="desc">Create a new booking. Required fields: <code>serviceId</code>, <code>userId</code>, <code>date</code>.</p>
+    <div class="code-block"><pre>curl -X POST https://api.myzubster.com/api/bookings \
+  -H <span class="string">"Authorization: Bearer ***"</span> \
+  -H <span class="string">"Content-Type: application/json"</span> \
+  -d <span class="string">'{"serviceId":"123","userId":"456","date":"2026-08-10"}'</span></pre></div>
+  </div>
+
+  <!-- BOUNTIES -->
+  <h2 id="bounties" style="margin-bottom:16px;margin-top:32px">💰 Bounties</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/bounties</span></div>
+    <p class="desc">List all available bounties with filtering by category, difficulty, and reward range.</p>
+  </div>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method post">POST</span><span class="path">/api/bounties/:id/claim</span></div>
+    <p class="desc">Claim a bounty. Locks the bounty to your account for 48 hours.</p>
+  </div>
+
+  <!-- GATEWAY -->
+  <h2 id="gateway" style="margin-bottom:16px;margin-top:32px">🌐 Gateway</h2>
+
+  <div class="endpoint">
+    <div class="endpoint-header"><span class="method get">GET</span><span class="path">/api/health</span></div>
+    <p class="desc">Health check endpoint. Returns gateway status, uptime, and service metrics. No auth required.</p>
+    <div class="code-block"><pre><span class="comment">// Response 200</span>
+{
+  <span class="key">"status"</span>: <span class="string">"healthy"</span>,
+  <span class="key">"uptime"</span>: <span class="string">"14d 3h 22m"</span>,
+  <span class="key">"version"</span>: <span class="string">"2.4.1"</span>,
+  <span class="key">"services"</span>: {
+    <span class="key">"database"</span>: <span class="string">"ok"</span>,
+    <span class="key">"redis"</span>: <span class="string">"ok"</span>,
+    <span class="key">"tari_node"</span>: <span class="string">"synced"</span>
+  }
+}</pre></div>
+  </div>
+
+  <p style="text-align:center;color:var(--muted);margin-top:48px;font-size:13px">
+    MyZubsterGateway API v2.4 · <a href="https://github.com/MyZubster-Ecosystem/MyZubsterGateway" style="color:var(--accent)">GitHub</a>
+  </p>
+</main>
+
+<script>
+function scrollToSection(id) {
+  document.getElementById(id).scrollIntoView({ behavior: 'smooth' });
+  document.querySelectorAll('.tag').forEach(t => t.classList.remove('active'));
+  event.target.classList.add('active');
+}
+function filterEndpoints() {
+  const q = document.getElementById('search').value.toLowerCase();
+  document.querySelectorAll('.endpoint').forEach(e => {
+    e.style.display = e.textContent.toLowerCase().includes(q) ? '' : 'none';
+  });
+}
+function getServerUrl() {
+  return document.getElementById('server-url').value.replace(/\/+$/, '');
+}
+async function tryEndpoint(method, path) {
+  const btn = event.target;
+  const resDiv = btn.nextElementSibling;
+  const url = getServerUrl() + path;
+  btn.classList.add('loading');
+  btn.textContent = '⏳ Loading...';
+  resDiv.classList.remove('visible');
+  resDiv.innerHTML = '';
+
+  const start = performance.now();
+  try {
+    const response = await fetch(url, { method, headers: { 'Accept': 'application/json' } });
+    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+    const contentType = response.headers.get('content-type') || '';
+    let bodyText;
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      bodyText = JSON.stringify(data, null, 2);
+    } else {
+      bodyText = await response.text();
+    }
+    const statusClass = response.ok ? 'success' : 'error';
+    resDiv.className = 'try-response visible';
+    resDiv.innerHTML = `
+      <div class="status ${statusClass}">${response.status} ${response.statusText} — ${elapsed}s</div>
+      <div class="code-block"><pre>${escapeHtml(bodyText)}</pre></div>
+    `;
+  } catch (err) {
+    resDiv.className = 'try-response visible';
+    resDiv.innerHTML = `
+      <div class="status error">❌ Error: ${escapeHtml(err.message)}</div>
+    `;
+  }
+  btn.classList.remove('loading');
+  btn.textContent = '▶ Try It';
+}
+function escapeHtml(text) {
+  if (!text) return '';
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Interactive API Documentation

This PR adds interactive API documentation for all 6 endpoints specified in #988:

- **👥 /api/users** — List registered users
- **🏛️ /api/comuni** — Municipalities list & detail
- **🏢 /api/enti** — Entities list & detail
- **🌱 /api/orti** — Urban gardens list & detail
- **📊 /api/stats** — Platform statistics
- **🪙 /api/tokens** — Token list & detail

### Interactive Features

- **▶️ Try It button** on each endpoint — makes a real API call via fetch()
- **Customizable Server URL** — switch between dev/production
- **Parameter inputs** for detail endpoints (/:id)
- **Response display** with status code, timing, and formatted JSON
- **Dark theme** consistent with existing design system

### Endpoints Covered

| Endpoint | Method | Description |
|----------|--------|-------------|
| /api/users | GET | List registered users |
| /api/comuni | GET | List municipalities |
| /api/comuni/:id | GET | Municipality detail |
| /api/enti | GET | List entities |
| /api/enti/:id | GET | Entity detail |
| /api/orti | GET | List urban gardens |
| /api/orti/:id | GET | Urban garden detail |
| /api/stats | GET | Platform statistics |
| /api/tokens | GET | List tokens |
| /api/tokens/:id | GET | Token detail |

Fixes #988