### PR TITLE
feat: add Kubernetes deployment for Gateway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+.git
+.env
+.env.*
+coverage
+frontend/node_modules
+frontend/dist
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+
+deploy/kubernetes/secret.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS dependencies
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY . .
+RUN addgroup -S gateway && adduser -S gateway -G gateway && chown -R gateway:gateway /app
+USER gateway
+EXPOSE 10000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:10000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+CMD ["node", "server.js"]

--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -1,0 +1,2 @@
+FROM moneroexamples/onion-monero-blockchain-explorer:latest
+EXPOSE 8081

--- a/Dockerfile.rpc
+++ b/Dockerfile.rpc
@@ -1,0 +1,3 @@
+FROM monero-project/monero:latest
+EXPOSE 18081
+ENTRYPOINT ["monero-wallet-rpc"]

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,38 @@
+# Kubernetes deployment
+
+This directory deploys the Gateway, a wallet RPC service, and a blockchain explorer in the `myzubster` namespace.
+
+## Build and publish images
+
+```sh
+docker build -t ghcr.io/myzubster-ecosystem/gateway:TAG .
+docker build -f Dockerfile.rpc -t ghcr.io/myzubster-ecosystem/monero-rpc:TAG .
+docker build -f Dockerfile.explorer -t ghcr.io/myzubster-ecosystem/monero-explorer:TAG .
+docker push ghcr.io/myzubster-ecosystem/gateway:TAG
+docker push ghcr.io/myzubster-ecosystem/monero-rpc:TAG
+docker push ghcr.io/myzubster-ecosystem/monero-explorer:TAG
+```
+
+Replace `latest` in the manifests with an immutable image tag before production use.
+
+## Configure and deploy
+
+```sh
+kubectl apply -f namespace.yaml
+cp secret.template.yaml secret.yaml
+# Edit secret.yaml locally with the production MongoDB and RPC credentials.
+kubectl apply -f secret.yaml
+kubectl apply -k .
+```
+
+`secret.yaml` is deliberately not included in `kustomization.yaml` and must remain untracked. Update the Ingress hostname and select a cluster storage class if the default is unsuitable.
+
+## Verify and roll back
+
+```sh
+kubectl -n myzubster rollout status deployment/gateway
+kubectl -n myzubster get pods,svc,hpa,ingress
+kubectl -n myzubster port-forward service/gateway 10000:80
+curl http://127.0.0.1:10000/health
+kubectl -n myzubster rollout undo deployment/gateway
+```

--- a/deploy/kubernetes/autoscaling.yaml
+++ b/deploy/kubernetes/autoscaling.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway
+  namespace: myzubster
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gateway
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-config
+  namespace: myzubster
+data:
+  NODE_ENV: production
+  PORT: "10000"

--- a/deploy/kubernetes/explorer.yaml
+++ b/deploy/kubernetes/explorer.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monero-explorer
+  namespace: myzubster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: monero-explorer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: monero-explorer
+    spec:
+      containers:
+        - name: explorer
+          image: ghcr.io/myzubster-ecosystem/monero-explorer:latest
+          ports:
+            - name: http
+              containerPort: 8081
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monero-explorer
+  namespace: myzubster
+spec:
+  selector:
+    app.kubernetes.io/name: monero-explorer
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kubernetes/gateway.yaml
+++ b/deploy/kubernetes/gateway.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: myzubster
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: ghcr.io/myzubster-ecosystem/gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 10000
+          envFrom:
+            - configMapRef:
+                name: gateway-config
+            - secretRef:
+                name: gateway-secrets
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: myzubster
+spec:
+  selector:
+    app.kubernetes.io/name: gateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: myzubster
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 2m
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: gateway.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  name: http

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - gateway.yaml
+  - monero-rpc.yaml
+  - explorer.yaml
+  - autoscaling.yaml
+  - ingress.yaml

--- a/deploy/kubernetes/monero-rpc.yaml
+++ b/deploy/kubernetes/monero-rpc.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: monero-rpc-data
+  namespace: myzubster
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monero-rpc
+  namespace: myzubster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: monero-rpc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: monero-rpc
+    spec:
+      containers:
+        - name: monero-rpc
+          image: ghcr.io/myzubster-ecosystem/monero-rpc:latest
+          ports:
+            - name: rpc
+              containerPort: 18081
+          command: ["/bin/sh", "-ec"]
+          args:
+            - >-
+              exec monero-wallet-rpc --rpc-bind-ip=0.0.0.0 --rpc-bind-port=18081
+              --wallet-file=/data/wallet
+              --rpc-login="${MONERO_RPC_USERNAME}:${MONERO_RPC_PASSWORD}"
+          env:
+            - name: MONERO_RPC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: gateway-secrets
+                  key: MONERO_RPC_USERNAME
+            - name: MONERO_RPC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: gateway-secrets
+                  key: MONERO_RPC_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: rpc
+            initialDelaySeconds: 20
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: monero-rpc-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monero-rpc
+  namespace: myzubster
+spec:
+  selector:
+    app.kubernetes.io/name: monero-rpc
+  ports:
+    - name: rpc
+      port: 18081
+      targetPort: rpc

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: myzubster

--- a/deploy/kubernetes/secret.template.yaml
+++ b/deploy/kubernetes/secret.template.yaml
@@ -1,0 +1,11 @@
+# Copy this file to secret.yaml, set real values, then apply it. Never commit secret.yaml.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gateway-secrets
+  namespace: myzubster
+type: Opaque
+stringData:
+  MONGODB_URI: mongodb://replace-me:27017/myzubster
+  MONERO_RPC_USERNAME: replace-me
+  MONERO_RPC_PASSWORD: replace-me


### PR DESCRIPTION
Closes #1098\n\nAdds production-oriented Dockerfiles for the Gateway, Monero wallet RPC, and explorer; Kubernetes deployments, services, PVC, probes, HPA, Ingress, secret template, and deployment documentation.\n\nValidation: `node --test tests/*.test.js` (11 passing) and `kubectl kustomize deploy/kubernetes`.