### PR TITLE
[B8 — Jest Tests] feat: Jest test framework con configurazione e script (Closes #261)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.js', '**/*.test.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/.netlify/'],
+  verbose: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/tests/setup.js'],
+  testTimeout: 30000,
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "start:prod": "NODE_ENV=production node server.js"
+    "start:prod": "NODE_ENV=production node server.js",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }


### PR DESCRIPTION
Jest framework setup.

- package.json: jest + supertest devDeps, test scripts
- jest.config.js: config with coverage, 30s timeout
- Tests in tests/ are already Jest-compatible

```bash
npm install && npm test
```

Closes #261