### PR TITLE
feat: [SPORT — 15000 MYZ] Tokenizzazione SPORT con NFT minting (Closes #1225)

### DIFF
--- a/routes/sportRoutes.js
+++ b/routes/sportRoutes.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const router = express.Router();
+const sport = require('../sport/sport-tokenization');
+
+// ---- GET endpoints ----
+router.get('/stats', (req, res) => {
+  res.json({ success: true, stats: sport.getStats() });
+});
+
+router.get('/all', (req, res) => {
+  res.json({ success: true, data: sport });
+});
+
+router.get('/teams', (req, res) => {
+  res.json({ success: true, teams: sport.teams });
+});
+router.get('/athletes', (req, res) => {
+  res.json({ success: true, athletes: sport.athletes });
+});
+router.get('/stadia', (req, res) => {
+  res.json({ success: true, stadia: sport.stadia });
+});
+router.get('/events', (req, res) => {
+  res.json({ success: true, events: sport.events });
+});
+
+// ---- NFT Minting endpoints ----
+router.post('/mint/:type/:id', (req, res) => {
+  const { type, id } = req.params;
+  const itemId = parseInt(id, 10);
+  if (isNaN(itemId)) {
+    return res.status(400).json({ success: false, error: 'Invalid item ID' });
+  }
+  const result = sport.mintNFT(type, itemId);
+  if (result.success) {
+    res.status(201).json(result);
+  } else {
+    res.status(404).json(result);
+  }
+});
+
+router.get('/nfts', (req, res) => {
+  res.json(sport.getAllNFTs());
+});
+
+router.get('/nft/:nftId', (req, res) => {
+  const result = sport.getNFT(req.params.nftId);
+  if (result.success) {
+    res.json(result);
+  } else {
+    res.status(404).json(result);
+  }
+});
+
+module.exports = router;

--- a/sport/sport-tokenization.js
+++ b/sport/sport-tokenization.js
@@ -1,19 +1,98 @@
-class SportTokenization {
-  constructor() {
-    this.teams = []; this.athletes = []; this.stadia = []; this.events = [];
-    ['Juventus','Milan','Inter','Roma','Napoli','Fiorentina','Lazio','Atalanta'].forEach(t =>
-      this.teams.push({ name: t, sport: 'Calcio', country: 'Italia', tokenId: `NFT-SPORT-TEAM-${String(this.teams.length+1).padStart(3,'0')}` })
-    );
-    ['Messi','Ronaldo','Neymar','Mbappé','Haaland','Lewandowski','Salah','Vinicius'].forEach(a =>
-      this.athletes.push({ name: a, sport: 'Calcio', country: 'Mondo', tokenId: `NFT-SPORT-ATHLETE-${String(this.athletes.length+1).padStart(3,'0')}` })
-    );
-    ['San Siro','Allianz Stadium','Olimpico','Maradona','Wembley','Camp Nou','Bernabeu'].forEach(s =>
-      this.stadia.push({ name: s, capacity: Math.floor(Math.random()*50000+30000), tokenId: `NFT-SPORT-STADIUM-${String(this.stadia.length+1).padStart(3,'0')}` })
-    );
-    ['Mondiale 2026','Europei 2024','Champions League Finale','Coppa Italia'].forEach(e =>
-      this.events.push({ name: e, year: 2026, tokenId: `NFT-SPORT-EVENT-${String(this.events.length+1).padStart(3,'0')}` })
-    );
-  }
-  getStats() { return { teams: this.teams.length, athletes: this.athletes.length, stadia: this.stadia.length, events: this.events.length, total: this.teams.length+this.athletes.length+this.stadia.length+this.events.length }; }
+// SPORT Tokenization Module — Bounty #1225
+// Tokenizzazione SPORT su MyZubster Chain con NFT minting
+
+const crypto = require('crypto');
+
+// NFT minting store (in-memory; production would use DB/blockchain)
+const mintedNFTs = [];
+
+function generateNFTId() {
+  return 'NFT-SPORT-' + crypto.randomBytes(8).toString('hex');
 }
-module.exports = new SportTokenization();
+
+// ===== DATA =====
+
+const teams = [
+  {"id": 1, "name": "Juventus", "league": "Serie A", "country": "Italia", "rarity": "Legendary"},
+  {"id": 2, "name": "Milan", "league": "Serie A", "country": "Italia", "rarity": "Legendary"},
+  {"id": 3, "name": "Inter", "league": "Serie A", "country": "Italia", "rarity": "Legendary"},
+  {"id": 4, "name": "Roma", "league": "Serie A", "country": "Italia", "rarity": "Rare"},
+  {"id": 5, "name": "Napoli", "league": "Serie A", "country": "Italia", "rarity": "Rare"},
+  {"id": 6, "name": "Fiorentina", "league": "Serie A", "country": "Italia", "rarity": "Uncommon"},
+  {"id": 7, "name": "Lazio", "league": "Serie A", "country": "Italia", "rarity": "Uncommon"},
+  {"id": 8, "name": "Atalanta", "league": "Serie A", "country": "Italia", "rarity": "Uncommon"}
+];
+
+const athletes = [
+  {"id": 1, "name": "Messi", "sport": "Calcio", "country": "Argentina", "rarity": "Legendary"},
+  {"id": 2, "name": "Ronaldo", "sport": "Calcio", "country": "Portogallo", "rarity": "Legendary"},
+  {"id": 3, "name": "Neymar", "sport": "Calcio", "country": "Brasile", "rarity": "Legendary"},
+  {"id": 4, "name": "Mbappé", "sport": "Calcio", "country": "Francia", "rarity": "Rare"},
+  {"id": 5, "name": "Haaland", "sport": "Calcio", "country": "Norvegia", "rarity": "Rare"},
+  {"id": 6, "name": "Lewandowski", "sport": "Calcio", "country": "Polonia", "rarity": "Rare"},
+  {"id": 7, "name": "Salah", "sport": "Calcio", "country": "Egitto", "rarity": "Rare"},
+  {"id": 8, "name": "Vinicius", "sport": "Calcio", "country": "Brasile", "rarity": "Uncommon"}
+];
+
+const stadia = [
+  {"id": 1, "name": "San Siro", "city": "Milano", "capacity": 80018, "rarity": "Legendary"},
+  {"id": 2, "name": "Olimpico", "city": "Roma", "capacity": 70634, "rarity": "Legendary"},
+  {"id": 3, "name": "Maracanã", "city": "Rio de Janeiro", "capacity": 78838, "rarity": "Legendary"},
+  {"id": 4, "name": "Camp Nou", "city": "Barcellona", "capacity": 99354, "rarity": "Legendary"},
+  {"id": 5, "name": "Wembley", "city": "Londra", "capacity": 90000, "rarity": "Legendary"},
+  {"id": 6, "name": "Allianz Arena", "city": "Monaco", "capacity": 75000, "rarity": "Rare"},
+  {"id": 7, "name": "Santiago Bernabeu", "city": "Madrid", "capacity": 81044, "rarity": "Legendary"}
+];
+
+const events = [
+  {"id": 1, "name": "Mondiali FIFA", "year": 2026, "host": "USA/Messico/Canada", "rarity": "Legendary"},
+  {"id": 2, "name": "Champions League", "season": "2025-26", "rarity": "Legendary"},
+  {"id": 3, "name": "Olimpiadi", "year": 2028, "host": "Los Angeles", "rarity": "Legendary"},
+  {"id": 4, "name": "Europei UEFA", "year": 2028, "host": "UK/Irlanda", "rarity": "Rare"}
+];
+
+// ===== FUNCTIONS =====
+
+function getStats() {
+  const stats = { totalNFTs: mintedNFTs.length, totalObjects: 0 };
+  stats.teams = teams.length; stats.totalObjects += teams.length;
+  stats.athletes = athletes.length; stats.totalObjects += athletes.length;
+  stats.stadia = stadia.length; stats.totalObjects += stadia.length;
+  stats.events = events.length; stats.totalObjects += events.length;
+  return stats;
+}
+
+function mintNFT(type, itemId) {
+  const collections = { teams: teams, athletes: athletes, stadia: stadia, events: events };
+  const collection = collections[type];
+  if (!collection) return { success: false, error: `Unknown type: ${type}` };
+  
+  const item = collection.find(i => i.id === itemId);
+  if (!item) return { success: false, error: `Item not found: ${type}/${itemId}` };
+  
+  const nft = {
+    tokenId: generateNFTId(),
+    type,
+    itemId: item.id,
+    name: item.name,
+    rarity: item.rarity || 'Common',
+    mintedAt: new Date().toISOString(),
+    ...item
+  };
+  
+  mintedNFTs.push(nft);
+  return { success: true, tokenId: nft.tokenId, nft };
+}
+
+function getNFT(nftId) {
+  const nft = mintedNFTs.find(n => n.tokenId === nftId);
+  if (!nft) return { success: false, error: 'NFT not found' };
+  return { success: true, nft };
+}
+
+function getAllNFTs() {
+  return { success: true, count: mintedNFTs.length, nfts: mintedNFTs };
+}
+
+module.exports = { getStats, mintNFT, getNFT, getAllNFTs, 
+  teams, athletes, stadia, events };


### PR DESCRIPTION
## SPORT Tokenization — Bounty #1225

### Implementation
- **SPORT NFT Minting Engine** (`sport/sport-tokenization.js`): complete module with 27 tokenizable objects
  - 8 Squadre
  - 8 Atleti
  - 7 Stadi
  - 4 Eventi

- **API Endpoints** (`routes/sportRoutes.js`):
  - `GET /api/sport/teams` — list all Squadre
  - `GET /api/sport/athletes` — list all Atleti
  - `GET /api/sport/stadia` — list all Stadi
  - `GET /api/sport/events` — list all Eventi
  - `POST /api/sport/mint/:type/:id` — mint NFT for an item
  - `GET /api/sport/nfts` — list all minted NFTs
  - `GET /api/sport/nft/:nftId` — get specific NFT by token ID
  - `GET /api/sport/stats` — collection statistics

### Bounty Details
- **Issue**: #1225
- **Reward**: 15000 MYZ
- **Status**: Ready for review

Ciao @DanielIoni-creator! 🚀