### PR TITLE
feat: add human robots tokenization for issue #1277

### DIFF
--- a/docs/robots/human-robots.md
+++ b/docs/robots/human-robots.md
@@ -1,0 +1,70 @@
+# 🤖 Human Robots Tokenization
+
+Bounty #1277 — Tokenizzazione Robot Umani su MyZubster Chain.
+
+## Categorie
+
+### Androidi (8)
+- Sophia
+- Ameca
+- Atlas
+- ASIMO
+- Pepper
+- Nao
+- RoboCop
+- T-800
+
+### Cyborg (6)
+- Neuralink
+- Cyborg Soldier
+- Cyberpunk
+- Ghost in the Shell
+- Deus Ex
+- Altered Carbon
+
+### Protesi Intelligenti (6)
+- Bionic Leg
+- Smart Arm
+- Neural Interface
+- Exoskeleton
+- Bionic Eye
+- Smart Heart
+
+### AI Avatar (5)
+- DeepSeek Avatar
+- GPT-5 Humanoid
+- Claude 4
+- Gemini Avatar
+- Meta Human
+
+### Aziende Produttrici (8)
+- Boston Dynamics
+- Hanson Robotics
+- Tesla Bot
+- SoftBank
+- Samsung
+- Xiaomi
+- OpenAI
+- Google DeepMind
+
+## API
+
+```
+GET /api/human-robots/stats
+GET /api/human-robots/all
+GET /api/human-robots/androids
+GET /api/human-robots/cyborgs
+GET /api/human-robots/prosthetics
+GET /api/human-robots/ai-avatars
+GET /api/human-robots/companies
+```
+
+## Minting
+
+```bash
+node scripts/mint-human-robots.js
+```
+
+## Payout Address
+
+XMR: `83nAhuys6Mx1aHE6kJBWsSLsGBPKFZb12ApfkgehJnxoC246aAT6xwVRJNoE3ZfbPi7Cfmxsu6F4zGTNnYa48q5T11VUo1n`

--- a/human-robots/human-robots-tokenization.js
+++ b/human-robots/human-robots-tokenization.js
@@ -1,0 +1,92 @@
+class HumanRobotsTokenization {
+  constructor() {
+    this.androids = [];
+    this.cyborgs = [];
+    this.prosthetics = [];
+    this.aiAvatars = [];
+    this.companies = [];
+
+    this.initializeHumanRobots();
+  }
+
+  initializeHumanRobots() {
+    const androids = [
+      'Sophia', 'Ameca', 'Atlas', 'ASIMO', 'Pepper', 'Nao', 'RoboCop', 'T-800'
+    ];
+    androids.forEach(name =>
+      this.androids.push({
+        name,
+        type: 'Android',
+        tokenId: `NFT-HUMAN-ROBOT-ANDROID-${String(this.androids.length).padStart(3, '0')}`
+      })
+    );
+
+    const cyborgs = [
+      'Neuralink', 'Cyborg Soldier', 'Cyberpunk', 'Ghost in the Shell', 'Deus Ex', 'Altered Carbon'
+    ];
+    cyborgs.forEach(name =>
+      this.cyborgs.push({
+        name,
+        type: 'Cyborg',
+        tokenId: `NFT-HUMAN-ROBOT-CYBORG-${String(this.cyborgs.length).padStart(3, '0')}`
+      })
+    );
+
+    const prosthetics = [
+      'Bionic Leg', 'Smart Arm', 'Neural Interface', 'Exoskeleton', 'Bionic Eye', 'Smart Heart'
+    ];
+    prosthetics.forEach(name =>
+      this.prosthetics.push({
+        name,
+        type: 'Protesi Intelligente',
+        tokenId: `NFT-HUMAN-ROBOT-PROSTHETIC-${String(this.prosthetics.length).padStart(3, '0')}`
+      })
+    );
+
+    const aiAvatars = [
+      'DeepSeek Avatar', 'GPT-5 Humanoid', 'Claude 4', 'Gemini Avatar', 'Meta Human'
+    ];
+    aiAvatars.forEach(name =>
+      this.aiAvatars.push({
+        name,
+        type: 'AI Avatar',
+        tokenId: `NFT-HUMAN-ROBOT-AI-AVATAR-${String(this.aiAvatars.length).padStart(3, '0')}`
+      })
+    );
+
+    const companies = [
+      'Boston Dynamics', 'Hanson Robotics', 'Tesla Bot', 'SoftBank', 'Samsung', 'Xiaomi', 'OpenAI', 'Google DeepMind'
+    ];
+    companies.forEach(name =>
+      this.companies.push({
+        name,
+        type: 'Azienda Produttrice',
+        tokenId: `NFT-HUMAN-ROBOT-COMPANY-${String(this.companies.length).padStart(3, '0')}`
+      })
+    );
+  }
+
+  getStats() {
+    return {
+      androids: this.androids.length,
+      cyborgs: this.cyborgs.length,
+      prosthetics: this.prosthetics.length,
+      aiAvatars: this.aiAvatars.length,
+      companies: this.companies.length,
+      total: this.androids.length + this.cyborgs.length + this.prosthetics.length + this.aiAvatars.length + this.companies.length
+    };
+  }
+
+  generateReport() {
+    return {
+      stats: this.getStats(),
+      androids: this.androids,
+      cyborgs: this.cyborgs,
+      prosthetics: this.prosthetics,
+      aiAvatars: this.aiAvatars,
+      companies: this.companies
+    };
+  }
+}
+
+module.exports = new HumanRobotsTokenization();

--- a/routes/humanRobotsRoutes.js
+++ b/routes/humanRobotsRoutes.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const humanRobots = require('../human-robots/human-robots-tokenization');
+
+router.get('/stats', (req, res) => {
+  res.json({ success: true, stats: humanRobots.getStats() });
+});
+
+router.get('/all', (req, res) => {
+  res.json({ success: true, humanRobots: humanRobots.generateReport() });
+});
+
+router.get('/androids', (req, res) => {
+  res.json({ success: true, androids: humanRobots.androids });
+});
+
+router.get('/cyborgs', (req, res) => {
+  res.json({ success: true, cyborgs: humanRobots.cyborgs });
+});
+
+router.get('/prosthetics', (req, res) => {
+  res.json({ success: true, prosthetics: humanRobots.prosthetics });
+});
+
+router.get('/ai-avatars', (req, res) => {
+  res.json({ success: true, aiAvatars: humanRobots.aiAvatars });
+});
+
+router.get('/companies', (req, res) => {
+  res.json({ success: true, companies: humanRobots.companies });
+});
+
+module.exports = router;

--- a/routes/nftRoutes.js
+++ b/routes/nftRoutes.js
@@ -115,7 +115,7 @@ router.post('/mint', authMiddleware, (req, res) => {
 // ============ GET STATS ============
 router.get('/stats', (req, res) => {
   try {
-    const types = ['hera_robot', 'waste_robot', 'resource', 'galaxy', 'star', 'planet', 'constellation', 'nebula', 'element', 'molecule', 'bounty', 'test'];
+    const types = ['hera_robot', 'waste_robot', 'resource', 'galaxy', 'star', 'planet', 'constellation', 'nebula', 'element', 'molecule', 'bounty', 'test', 'human_robot'];
     const stats = {};
     let total = 0;
     

--- a/scripts/mint-human-robots.js
+++ b/scripts/mint-human-robots.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const axios = require('axios');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+const GATEWAY_URL = process.env.API_URL || 'http://localhost:5002';
+const JWT_SECRET = process.env.JWT_SECRET || 'myzubster-secret';
+
+const token = jwt.sign(
+  { userId: 'admin', role: 'admin' },
+  JWT_SECRET,
+  { expiresIn: '24h' }
+);
+
+const humanRobots = require('../human-robots/human-robots-tokenization');
+const report = humanRobots.generateReport();
+
+const categories = [
+  { key: 'androids', label: 'Androidi' },
+  { key: 'cyborgs', label: 'Cyborg' },
+  { key: 'prosthetics', label: 'Protesi Intelligenti' },
+  { key: 'aiAvatars', label: 'AI Avatar' },
+  { key: 'companies', label: 'Aziende Produttrici' }
+];
+
+async function mintNFT(item, category, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await axios.post(
+        `${GATEWAY_URL}/api/nft/mint`,
+        { type: 'human_robot', name: item.name, metadata: { category, type: item.type, tokenId: item.tokenId } },
+        {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          timeout: 10000
+        }
+      );
+      console.log(`  ✅ ${item.name} → ${response.data.nft.tokenId}`);
+      return response.data;
+    } catch (error) {
+      if (i === retries - 1) {
+        console.error(`  ❌ Errore per ${item.name} (tentativo ${i + 1}/${retries}):`, error.response?.data?.error || error.message);
+      } else {
+        console.log(`  ⏳ ${item.name}: riprovo... (${i + 1}/${retries})`);
+        await new Promise(r => setTimeout(r, 1000));
+      }
+    }
+  }
+  return null;
+}
+
+async function main() {
+  console.log('🤖 MINTING ROBOT UMANI — 33 NFT');
+  console.log('===================================');
+
+  let total = 0;
+  let errors = 0;
+
+  for (const cat of categories) {
+    const items = report[cat.key];
+    console.log(`\n${cat.label} (${items.length})...`);
+    for (const item of items) {
+      const result = await mintNFT(item, cat.key);
+      if (result) total++;
+      else errors++;
+    }
+  }
+
+  console.log('\n📊 RIEPILOGO');
+  console.log('===================================');
+  console.log(`✅ NFT mintati: ${total}`);
+  console.log(`❌ Errori: ${errors}`);
+  console.log(`📦 Totale: ${total + errors}`);
+}
+
+main().catch(console.error);

--- a/server.js
+++ b/server.js
@@ -184,6 +184,10 @@ app.use('/api/universe', universeRoutes);
 const tvRoutes = require('./routes/tvRoutes');
 app.use('/api/tv', tvRoutes);
 
+// 🤖 Route Tokenizzazione Robot Umani
+const humanRobotsRoutes = require('./routes/humanRobotsRoutes');
+app.use('/api/human-robots', humanRobotsRoutes);
+
 // 🏛️ Route Tokenizzazione Politica
 const politicsRoutes = require('./routes/politicsRoutes');
 app.use('/api/politics', politicsRoutes);


### PR DESCRIPTION
Closes #1277

## 🤖 Human Robots Tokenization

This PR adds tokenization for 33 human robots across 5 categories on MyZubster Chain.

### Categories
- **Androidi (8):** Sophia, Ameca, Atlas, ASIMO, Pepper, Nao, RoboCop, T-800
- **Cyborg (6):** Neuralink, Cyborg Soldier, Cyberpunk, Ghost in the Shell, Deus Ex, Altered Carbon
- **Protesi Intelligenti (6):** Bionic Leg, Smart Arm, Neural Interface, Exoskeleton, Bionic Eye, Smart Heart
- **AI Avatar (5):** DeepSeek Avatar, GPT-5 Humanoid, Claude 4, Gemini Avatar, Meta Human
- **Aziende Produttrici (8):** Boston Dynamics, Hanson Robotics, Tesla Bot, SoftBank, Samsung, Xiaomi, OpenAI, Google DeepMind

### Files Changed
- `human-robots/human-robots-tokenization.js` — Core tokenization module
- `routes/humanRobotsRoutes.js` — REST API endpoints
- `server.js` — Mount /api/human-robots routes
- `routes/nftRoutes.js` — Include human_robot in stats
- `scripts/mint-human-robots.js` — Minting script for all 33 NFTs
- `docs/robots/human-robots.md` — Documentation

### Payout Address (XMR)
`83nAhuys6Mx1aHE6kJBWsSLsGBPKFZb12ApfkgehJnxoC246aAT6xwVRJNoE3ZfbPi7Cfmxsu6F4zGTNnYa48q5T11VUo1n`