### PR TITLE
feat: Seed Exchange CSV + GeoJSON export endpoints (Closes #109)

### DIFF
--- a/models/SeedExchange.js
+++ b/models/SeedExchange.js
@@ -1,0 +1,82 @@
+const mongoose = require('mongoose');
+
+const SeedExchangeSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    plantName: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 120,
+      index: true,
+    },
+    variety: {
+      type: String,
+      trim: true,
+      maxlength: 120,
+      default: '',
+    },
+    type: {
+      type: String,
+      required: true,
+      enum: ['seeds', 'cuttings', 'seedlings', 'bulbs'],
+      index: true,
+    },
+    quantity: {
+      type: Number,
+      required: true,
+      min: 1,
+      max: 1000000,
+      validate: {
+        validator: Number.isInteger,
+        message: 'quantity must be an integer',
+      },
+    },
+    location: {
+      type: String,
+      trim: true,
+      maxlength: 200,
+      default: '',
+      index: true,
+    },
+    // Optional coordinates so GeoJSON export can place listings on a map.
+    latitude: {
+      type: Number,
+      min: -90,
+      max: 90,
+    },
+    longitude: {
+      type: Number,
+      min: -180,
+      max: 180,
+    },
+    availability: {
+      type: String,
+      enum: ['immediate', 'seasonal'],
+      default: 'immediate',
+      index: true,
+    },
+    exchangeType: {
+      type: String,
+      enum: ['free', 'barter', 'donation'],
+      default: 'free',
+      index: true,
+    },
+    description: {
+      type: String,
+      trim: true,
+      maxlength: 2000,
+      default: '',
+    },
+  },
+  { timestamps: true }
+);
+
+SeedExchangeSchema.index({ plantName: 1, type: 1, location: 1, createdAt: -1 });
+
+module.exports = mongoose.models.SeedExchange || mongoose.model('SeedExchange', SeedExchangeSchema);

--- a/routes/seedExchangeExport.js
+++ b/routes/seedExchangeExport.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const express = require('express');
+const {
+  buildFilters,
+  toCsv,
+  toGeoJSON,
+} = require('../utils/seedExchangeExport');
+
+// The Seed Exchange model ships with the listing API (PR #104 / #107). Load it
+// lazily so this router still registers cleanly when the model is not present
+// yet, and answer with a clear 503 in that case.
+let SeedExchange = null;
+try {
+  SeedExchange = require('../models/SeedExchange');
+} catch (err) {
+  SeedExchange = null;
+}
+
+const router = express.Router();
+
+function modelUnavailable(res) {
+  return res.status(503).json({
+    success: false,
+    error: 'Seed Exchange data model is not available yet (requires the Seed Exchange listing API).',
+  });
+}
+
+async function fetchListings(query) {
+  const { filter, error } = buildFilters(query || {});
+  if (error) return { error };
+  if (!SeedExchange) return { unavailable: true };
+  const listings = await SeedExchange.find(filter).sort({ createdAt: -1 }).lean();
+  return { listings };
+}
+
+// GET /api/seed-exchange/export/csv
+router.get('/csv', async (req, res) => {
+  try {
+    const result = await fetchListings(req.query);
+    if (result.error) {
+      return res.status(400).json({ success: false, error: result.error });
+    }
+    if (result.unavailable) return modelUnavailable(res);
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', 'attachment; filename="seed-exchange-listings.csv"');
+    return res.send(toCsv(result.listings));
+  } catch (error) {
+    console.error('Seed exchange CSV export error:', error);
+    return res.status(500).json({ success: false, error: 'unable to export seed exchange listings' });
+  }
+});
+
+// GET /api/seed-exchange/export/geojson
+router.get('/geojson', async (req, res) => {
+  try {
+    const result = await fetchListings(req.query);
+    if (result.error) {
+      return res.status(400).json({ success: false, error: result.error });
+    }
+    if (result.unavailable) return modelUnavailable(res);
+
+    res.setHeader('Content-Type', 'application/geo+json; charset=utf-8');
+    res.setHeader('Content-Disposition', 'attachment; filename="seed-exchange-listings.geojson"');
+    return res.json(toGeoJSON(result.listings));
+  } catch (error) {
+    console.error('Seed exchange GeoJSON export error:', error);
+    return res.status(500).json({ success: false, error: 'unable to export seed exchange listings' });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -115,6 +115,9 @@ try { const routes = require("./routes/webhookRoutes"); app.use("/webhook", rout
 // Benzina XMR
 try { const routes = require("./routes/benzinaXmr"); app.use("/api/benzina-xmr", routes); } catch(e) {}
 
+// Seed Exchange export (CSV + GeoJSON) #109
+try { const routes = require("./routes/seedExchangeExport"); app.use("/api/seed-exchange/export", routes); } catch(e) {}
+
 // Mass Bounty 990-999
 try { const routes = require("./routes/massBounty990"); app.use("/api/bounty-990", routes); } catch(e) {}
 try { const routes = require("./routes/massBounty991"); app.use("/api/bounty-991", routes); } catch(e) {}

--- a/tests/seedExchangeExport.test.js
+++ b/tests/seedExchangeExport.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const {
+  buildFilters,
+  toCsv,
+  toGeoJSON,
+  toPublicListing,
+  csvEscape,
+  extractCoordinates,
+} = require('../utils/seedExchangeExport');
+
+describe('seed exchange export utilities', () => {
+  const listing = {
+    _id: '507f1f77bcf86cd799439011',
+    userId: '507f1f77bcf86cd799439012',
+    plantName: 'Tomato',
+    variety: 'San Marzano',
+    type: 'seeds',
+    quantity: 25,
+    availability: 'immediate',
+    exchangeType: 'barter',
+    location: 'Rome, IT',
+    latitude: 41.9028,
+    longitude: 12.4964,
+    description: 'Heirloom, organic',
+    createdAt: new Date('2026-08-01T10:00:00Z'),
+    updatedAt: new Date('2026-08-01T10:00:00Z'),
+  };
+
+  describe('buildFilters', () => {
+    test('builds plant, location and type filters like the listing API', () => {
+      const { filter, error } = buildFilters({ plant: 'tomato', location: 'rome', type: 'seed' });
+      expect(error).toBeUndefined();
+      expect(filter.plantName).toEqual({ $regex: 'tomato', $options: 'i' });
+      expect(filter.location).toEqual({ $regex: 'rome', $options: 'i' });
+      expect(filter.type).toBe('seeds');
+    });
+
+    test('normalizes type aliases', () => {
+      expect(buildFilters({ type: 'TALEA' }).filter.type).toBe('cuttings');
+      expect(buildFilters({ type: 'piantine' }).filter.type).toBe('seedlings');
+      expect(buildFilters({ type: 'bulbo' }).filter.type).toBe('bulbs');
+    });
+
+    test('escapes regex special characters', () => {
+      const { filter } = buildFilters({ plant: 'a+b' });
+      expect(filter.plantName.$regex).toBe('a\\+b');
+    });
+
+    test('rejects unknown type values', () => {
+      const { error } = buildFilters({ type: 'nope' });
+      expect(error).toMatch(/seeds, cuttings, seedlings, or bulbs/);
+    });
+  });
+
+  describe('csvEscape', () => {
+    test('quotes fields and doubles embedded quotes', () => {
+      expect(csvEscape('a,b')).toBe('"a,b"');
+      expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+      expect(csvEscape(42)).toBe('"42"');
+      expect(csvEscape(null)).toBe('""');
+      expect(csvEscape(undefined)).toBe('""');
+    });
+  });
+
+  describe('toCsv', () => {
+    test('emits a header row and one row per listing', () => {
+      const csv = toCsv([listing]);
+      const lines = csv.split('\r\n');
+      expect(lines[0]).toContain('plantName');
+      expect(lines[0]).toContain('exchangeType');
+      expect(lines[0]).toContain('latitude');
+      expect(lines[1]).toContain('San Marzano');
+      expect(lines[1]).toContain('"41.9028"');
+      expect(lines[1]).toContain('"12.4964"');
+    });
+  });
+
+  describe('extractCoordinates', () => {
+    test('reads latitude/longitude as [lng, lat]', () => {
+      expect(extractCoordinates(listing)).toEqual([12.4964, 41.9028]);
+    });
+
+    test('returns null without coordinates', () => {
+      const { latitude, longitude, ...rest } = listing;
+      expect(extractCoordinates(rest)).toBeNull();
+    });
+  });
+
+  describe('toGeoJSON', () => {
+    test('builds a FeatureCollection with Point geometry', () => {
+      const gj = toGeoJSON([listing]);
+      expect(gj.type).toBe('FeatureCollection');
+      expect(gj.features).toHaveLength(1);
+      expect(gj.features[0].geometry).toEqual({ type: 'Point', coordinates: [12.4964, 41.9028] });
+      expect(gj.features[0].properties.plantName).toBe('Tomato');
+      expect(gj.features[0].properties.exchangeType).toBe('barter');
+      expect(gj.features[0].properties.id).toBe('507f1f77bcf86cd799439011');
+    });
+
+    test('uses a null geometry when coordinates are missing', () => {
+      const { latitude, longitude, ...rest } = listing;
+      const gj = toGeoJSON([rest]);
+      expect(gj.features[0].geometry).toBeNull();
+      expect(gj.features[0].properties.location).toBe('Rome, IT');
+    });
+  });
+
+  describe('toPublicListing', () => {
+    test('stringifies ids and dates', () => {
+      const pub = toPublicListing(listing);
+      expect(pub.id).toBe('507f1f77bcf86cd799439011');
+      expect(pub.userId).toBe('507f1f77bcf86cd799439012');
+      expect(pub.createdAt).toBe('2026-08-01T10:00:00.000Z');
+    });
+  });
+});

--- a/utils/seedExchangeExport.js
+++ b/utils/seedExchangeExport.js
@@ -1,0 +1,220 @@
+'use strict';
+
+// Pure serialization + filtering helpers for the Seed Exchange export endpoints.
+//
+// These helpers intentionally mirror the field contract and filter semantics of
+// the Seed Exchange listing API (see PR #104 / #107):
+//   * plant   -> case-insensitive regex on plantName
+//   * type    -> canonical enum (seeds / cuttings / seedlings / bulbs)
+//   * location-> case-insensitive regex on location
+//
+// They are kept free of any runtime dependency (no express, no mongoose) so they
+// can be unit-tested and reused without a database connection.
+
+const TYPE_ALIASES = new Map([
+  ['seed', 'seeds'],
+  ['seeds', 'seeds'],
+  ['seme', 'seeds'],
+  ['semi', 'seeds'],
+  ['cutting', 'cuttings'],
+  ['cuttings', 'cuttings'],
+  ['talea', 'cuttings'],
+  ['talee', 'cuttings'],
+  ['seedling', 'seedlings'],
+  ['seedlings', 'seedlings'],
+  ['piantina', 'seedlings'],
+  ['piantine', 'seedlings'],
+  ['bulb', 'bulbs'],
+  ['bulbs', 'bulbs'],
+  ['bulbo', 'bulbs'],
+  ['bulbi', 'bulbs'],
+]);
+
+const CSV_COLUMNS = [
+  'id',
+  'userId',
+  'plantName',
+  'variety',
+  'type',
+  'quantity',
+  'availability',
+  'exchangeType',
+  'location',
+  'latitude',
+  'longitude',
+  'description',
+  'createdAt',
+  'updatedAt',
+];
+
+function firstDefined(source, keys) {
+  for (const key of keys) {
+    if (source && Object.prototype.hasOwnProperty.call(source, key)) {
+      return source[key];
+    }
+  }
+  return undefined;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeEnum(value, aliases) {
+  const key = normalizeText(value).toLowerCase();
+  return aliases.get(key) || null;
+}
+
+function queryText(query, keys) {
+  return normalizeText(firstDefined(query, keys));
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Builds the Mongo filter for the export endpoints. This is the exact same
+ * filter contract used by the listing API so the exports honour the same
+ * `plant`, `type` and `location` query parameters.
+ */
+function buildFilters(query) {
+  const filter = {};
+  const plant = queryText(query, ['plantName', 'plant', 'pianta']);
+  const location = queryText(query, ['location', 'posizione']);
+  const rawType = queryText(query, ['type', 'tipo']);
+
+  if (plant) filter.plantName = { $regex: escapeRegex(plant), $options: 'i' };
+  if (location) filter.location = { $regex: escapeRegex(location), $options: 'i' };
+
+  if (rawType) {
+    const type = normalizeEnum(rawType, TYPE_ALIASES);
+    if (!type) {
+      return { error: 'type must be seeds, cuttings, seedlings, or bulbs' };
+    }
+    filter.type = type;
+  }
+
+  return { filter };
+}
+
+function toNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Returns GeoJSON coordinates `[longitude, latitude]` when the listing exposes
+ * a location, otherwise `null`. Coordinates may come from `latitude`/`longitude`
+ * fields or from a `coordinates` value ([lng, lat] or {lat, lng}).
+ */
+function extractCoordinates(listing) {
+  if (!listing) return null;
+
+  const lat = toNumber(listing.latitude);
+  const lng = toNumber(listing.longitude);
+  if (lat !== null && lng !== null && Math.abs(lat) <= 90 && Math.abs(lng) <= 180) {
+    return [lng, lat];
+  }
+
+  const coords = listing.coordinates;
+  if (Array.isArray(coords) && coords.length >= 2) {
+    const c0 = toNumber(coords[0]);
+    const c1 = toNumber(coords[1]);
+    if (c0 !== null && c1 !== null && Math.abs(c1) <= 90 && Math.abs(c0) <= 180) {
+      return [c0, c1];
+    }
+  } else if (coords && typeof coords === 'object') {
+    const clat = toNumber(coords.latitude != null ? coords.latitude : coords.lat);
+    const clng = toNumber(coords.longitude != null ? coords.longitude : coords.lng);
+    if (clat !== null && clng !== null && Math.abs(clat) <= 90 && Math.abs(clng) <= 180) {
+      return [clng, clat];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes a listing document (mongoose doc or plain/lean object) into the
+ * public flat shape used by both CSV and GeoJSON exports.
+ */
+function toPublicListing(listing) {
+  const value =
+    listing && typeof listing.toObject === 'function' ? listing.toObject() : listing || {};
+  const coords = extractCoordinates(value);
+
+  return {
+    id: value._id != null ? String(value._id) : '',
+    userId: value.userId != null ? String(value.userId) : '',
+    plantName: value.plantName || '',
+    variety: value.variety || '',
+    type: value.type || '',
+    quantity: value.quantity != null ? value.quantity : '',
+    availability: value.availability || '',
+    exchangeType: value.exchangeType || '',
+    location: value.location || '',
+    latitude: coords ? coords[1] : '',
+    longitude: coords ? coords[0] : '',
+    description: value.description || '',
+    createdAt: value.createdAt ? new Date(value.createdAt).toISOString() : '',
+    updatedAt: value.updatedAt ? new Date(value.updatedAt).toISOString() : '',
+  };
+}
+
+/**
+ * RFC 4180 CSV field escaping: every field is quoted and embedded quotes are
+ * doubled.
+ */
+function csvEscape(value) {
+  if (value === null || value === undefined) value = '';
+  return '"' + String(value).replace(/"/g, '""') + '"';
+}
+
+/**
+ * Serializes listings into a CSV document (header + one row per listing).
+ */
+function toCsv(listings) {
+  const rows = [CSV_COLUMNS.join(',')];
+  for (const listing of listings || []) {
+    const pub = toPublicListing(listing);
+    rows.push(CSV_COLUMNS.map((column) => csvEscape(pub[column])).join(','));
+  }
+  return rows.join('\r\n') + '\r\n';
+}
+
+/**
+ * Serializes listings into a GeoJSON FeatureCollection. Listings with usable
+ * coordinates become Point features; listings without coordinates are emitted
+ * with a `null` geometry (valid GeoJSON) so their properties remain exportable.
+ */
+function toGeoJSON(listings) {
+  const features = (listings || []).map((listing) => {
+    const coords = extractCoordinates(listing);
+    return {
+      type: 'Feature',
+      geometry: coords ? { type: 'Point', coordinates: coords } : null,
+      properties: toPublicListing(listing),
+    };
+  });
+
+  return {
+    type: 'FeatureCollection',
+    features,
+  };
+}
+
+module.exports = {
+  TYPE_ALIASES,
+  CSV_COLUMNS,
+  buildFilters,
+  toPublicListing,
+  toCsv,
+  toGeoJSON,
+  csvEscape,
+  extractCoordinates,
+};


### PR DESCRIPTION
## Summary

Adds CSV and GeoJSON export endpoints for the Seed Exchange listings, closing #109.

### Endpoints
- GET /api/seed-exchange/export/csv (RFC 4180 CSV)
- GET /api/seed-exchange/export/geojson (GeoJSON FeatureCollection for maps)

Both honour the same filters as the listing API: plant, type, location.

### Changes
- utils/seedExchangeExport.js - serialization + filter helpers
- routes/seedExchangeExport.js - Express router
- models/SeedExchange.js - model with optional latitude/longitude
- tests/seedExchangeExport.test.js - unit tests
- server.js - mounts router at /api/seed-exchange/export

Signed-off-by: laurentketterle-hub <laurentketterle-hub@users.noreply.github.com>