### PR TITLE
feat: dark mode toggle with persistence (Closes #200)

### DIFF
--- a/frontend/css/dark-mode.css
+++ b/frontend/css/dark-mode.css
@@ -1,0 +1,197 @@
+/* ============================================================================
+   MyZubsterGateway - Dark Mode theme (issue #200)
+   ----------------------------------------------------------------------------
+   Self-contained dark theme. To enable it on a page add to <head>:
+
+     <link rel="stylesheet" href="frontend/css/dark-mode.css">
+     <script src="frontend/js/dark-mode.js" defer></script>
+
+   How it works
+   -------------
+   * Light palette lives in :root (the default).
+   * [data-theme="dark"] overrides it with the dark palette.
+   * @media (prefers-color-scheme: dark) applies the dark palette
+     automatically when the visitor's OS is in dark mode AND they have not
+     chosen a theme yet (i.e. <html> has no data-theme attribute).
+   * The companion script (frontend/js/dark-mode.js) sets/removes the
+     data-theme attribute on <html>, persists the choice in localStorage and
+     injects a floating toggle button (bottom-right).
+   ========================================================================== */
+
+:root {
+  --mz-bg: #ffffff;
+  --mz-bg-soft: #f4f6fb;
+  --mz-surface: #ffffff;
+  --mz-surface-hover: #eef1f7;
+  --mz-text: #1e2430;
+  --mz-text-muted: #5b6577;
+  --mz-border: #e2e6ef;
+  --mz-accent: #4f46e5;
+  --mz-accent-contrast: #ffffff;
+  --mz-accent-hover: #4338ca;
+  --mz-success: #16a34a;
+  --mz-warning: #d97706;
+  --mz-error: #dc2626;
+  --mz-link: #4f46e5;
+  --mz-shadow: 0 1px 3px rgba(16, 24, 40, 0.10);
+  --mz-shadow-lg: 0 12px 32px rgba(16, 24, 40, 0.14);
+  --mz-code-bg: #f1f3f8;
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --mz-bg: #0b1220;
+  --mz-bg-soft: #101a2e;
+  --mz-surface: #141f36;
+  --mz-surface-hover: #1c2a47;
+  --mz-text: #e7ecf6;
+  --mz-text-muted: #9aa6bd;
+  --mz-border: #27334f;
+  --mz-accent: #818cf8;
+  --mz-accent-contrast: #0b1220;
+  --mz-accent-hover: #a5b4fc;
+  --mz-success: #34d399;
+  --mz-warning: #fbbf24;
+  --mz-error: #f87171;
+  --mz-link: #a5b4fc;
+  --mz-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+  --mz-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.65);
+  --mz-code-bg: #1c2a47;
+  color-scheme: dark;
+}
+
+/* Follow the OS dark-mode preference for first-time visitors who have not
+   yet picked a theme. The JS removes data-theme for "light", so this only
+   matches the unset state and never fights an explicit user choice. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --mz-bg: #0b1220;
+    --mz-bg-soft: #101a2e;
+    --mz-surface: #141f36;
+    --mz-surface-hover: #1c2a47;
+    --mz-text: #e7ecf6;
+    --mz-text-muted: #9aa6bd;
+    --mz-border: #27334f;
+    --mz-accent: #818cf8;
+    --mz-accent-contrast: #0b1220;
+    --mz-accent-hover: #a5b4fc;
+    --mz-success: #34d399;
+    --mz-warning: #fbbf24;
+    --mz-error: #f87171;
+    --mz-link: #a5b4fc;
+    --mz-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+    --mz-shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.65);
+    --mz-code-bg: #1c2a47;
+    color-scheme: dark;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Base page
+   ------------------------------------------------------------------------- */
+body {
+  background-color: var(--mz-bg);
+  color: var(--mz-text);
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+/* Generic surfaces */
+.card, .panel, .box, article, section, aside,
+.modal, .dialog, .popover, .dropdown-menu,
+nav, header, footer, .navbar, .sidebar {
+  background-color: var(--mz-surface);
+  color: var(--mz-text);
+  border-color: var(--mz-border);
+  transition: background-color 0.25s ease, color 0.25s ease,
+              border-color 0.25s ease;
+}
+
+/* Tables */
+table {
+  background-color: var(--mz-surface);
+  color: var(--mz-text);
+}
+th, td {
+  border-color: var(--mz-border);
+}
+thead th,
+tbody tr:nth-child(even) {
+  background-color: var(--mz-surface-hover);
+}
+
+/* Forms */
+input, select, textarea, button {
+  background-color: var(--mz-surface);
+  color: var(--mz-text);
+  border: 1px solid var(--mz-border);
+}
+input::placeholder, textarea::placeholder {
+  color: var(--mz-text-muted);
+}
+input:focus, select:focus, textarea:focus {
+  border-color: var(--mz-accent);
+  outline: 2px solid var(--mz-accent);
+  outline-offset: 1px;
+}
+
+/* Links and text helpers */
+a {
+  color: var(--mz-link);
+}
+.text-muted, .muted, small {
+  color: var(--mz-text-muted);
+}
+code, pre, kbd, samp {
+  background-color: var(--mz-code-bg);
+  color: var(--mz-text);
+}
+
+/* Status colours */
+.success, .text-success { color: var(--mz-success); }
+.warning, .text-warning { color: var(--mz-warning); }
+.error, .text-error   { color: var(--mz-error); }
+
+/* Soften bright media in dark mode */
+[data-theme="dark"] img:not([src*=".svg"]),
+[data-theme="dark"] video {
+  filter: brightness(0.88) contrast(1.05);
+}
+
+/* Themed scrollbars (Firefox) */
+html {
+  scrollbar-color: var(--mz-border) var(--mz-bg-soft);
+}
+
+/* ---------------------------------------------------------------------------
+   Floating theme toggle button (injected by frontend/js/dark-mode.js)
+   ------------------------------------------------------------------------- */
+.mz-theme-toggle {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 2147483000;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid var(--mz-border);
+  background-color: var(--mz-surface);
+  color: var(--mz-text);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--mz-shadow-lg);
+  transition: transform 0.2s ease, background-color 0.2s ease,
+              color 0.2s ease;
+}
+.mz-theme-toggle:hover {
+  transform: scale(1.1);
+  background-color: var(--mz-accent);
+  color: var(--mz-accent-contrast);
+}
+.mz-theme-toggle:focus-visible {
+  outline: 2px solid var(--mz-accent);
+  outline-offset: 2px;
+}

--- a/frontend/js/dark-mode.js
+++ b/frontend/js/dark-mode.js
@@ -1,0 +1,147 @@
+/* ============================================================================
+   MyZubsterGateway - Dark Mode toggle + persistence (issue #200)
+   ----------------------------------------------------------------------------
+   Drop-in script. Add alongside the theme stylesheet:
+
+     <link rel="stylesheet" href="frontend/css/dark-mode.css">
+     <script src="frontend/js/dark-mode.js" defer></script>
+
+   Behaviour
+   ----------
+   * On first visit the OS preference is read via matchMedia and, if dark,
+     data-theme="dark" is applied to <html>.
+   * A floating toggle button (bottom-right) is injected automatically.
+   * The chosen theme is applied as data-theme="dark" on <html> (removed for
+     light) and persisted in localStorage under the "myz-theme" key.
+   * A MutationObserver re-injects the button if the page replaces <body>
+     (single-page-app navigations), so the script stays drop-in.
+   ========================================================================== */
+
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'myz-theme';
+
+  /* Unicode escapes keep this file pure ASCII:
+     \u263E = last-quarter moon, \u2600 = sun. */
+  var GLYPH_DARK = '\u263E';
+  var GLYPH_LIGHT = '\u2600';
+
+  function readStoredTheme() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function writeStoredTheme(theme) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch (err) {
+      /* storage unavailable (private mode) - fall back to session only */
+    }
+  }
+
+  function prefersDark() {
+    return !!(window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+
+  function resolveInitialTheme() {
+    var stored = readStoredTheme();
+    if (stored === 'dark' || stored === 'light') {
+      return stored;
+    }
+    return prefersDark() ? 'dark' : 'light';
+  }
+
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') === 'dark'
+      ? 'dark'
+      : 'light';
+  }
+
+  function buttonGlyph(theme) {
+    return theme === 'dark' ? GLYPH_DARK : GLYPH_LIGHT;
+  }
+
+  function syncButtons(theme) {
+    var buttons = document.querySelectorAll('.mz-theme-toggle');
+    var isDark = theme === 'dark';
+    for (var i = 0; i < buttons.length; i += 1) {
+      var btn = buttons[i];
+      btn.textContent = buttonGlyph(theme);
+      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+      btn.setAttribute(
+        'aria-label',
+        isDark ? 'Switch to light mode' : 'Switch to dark mode'
+      );
+      btn.title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+    }
+  }
+
+  function applyTheme(theme) {
+    var root = document.documentElement;
+    if (theme === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+    } else {
+      root.removeAttribute('data-theme');
+    }
+    syncButtons(theme);
+  }
+
+  function setTheme(theme) {
+    writeStoredTheme(theme);
+    applyTheme(theme);
+  }
+
+  function toggleTheme() {
+    setTheme(currentTheme() === 'dark' ? 'light' : 'dark');
+  }
+
+  function createToggleButton() {
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mz-theme-toggle';
+    btn.setAttribute('aria-label', 'Toggle dark mode');
+    btn.setAttribute('title', 'Toggle dark mode');
+    btn.addEventListener('click', toggleTheme);
+    return btn;
+  }
+
+  function injectToggle() {
+    if (!document.body || document.querySelector('.mz-theme-toggle')) {
+      return;
+    }
+    document.body.appendChild(createToggleButton());
+    syncButtons(currentTheme());
+  }
+
+  function watchBody() {
+    if (typeof MutationObserver === 'undefined') {
+      return;
+    }
+    var observer = new MutationObserver(function () {
+      injectToggle();
+    });
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function init() {
+    applyTheme(resolveInitialTheme());
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', injectToggle);
+    } else {
+      injectToggle();
+    }
+
+    watchBody();
+  }
+
+  init();
+})();


### PR DESCRIPTION
## Summary
Adds a self-contained, drop-in dark mode to the MyZubsterGateway frontend.

## What's included
- `frontend/css/dark-mode.css` - light/dark design tokens (CSS custom properties), a `[data-theme="dark"]` override, automatic OS preference via `@media (prefers-color-scheme: dark)` (only when no explicit theme is set), themed surfaces/forms/tables/scrollbars, and styling for the floating toggle button.
- `frontend/js/dark-mode.js` - injects the floating toggle, applies `data-theme` to `<html>`, persists the choice in `localStorage` (`myz-theme`), auto-detects the OS preference on first load, and re-injects the button on SPA navigations via a MutationObserver.

## Usage
Add to any page head:
```html
<link rel="stylesheet" href="frontend/css/dark-mode.css">
<script src="frontend/js/dark-mode.js" defer></script>
```

This PR delivers the #200 MYZ bounty (UI: dark mode for the site). Fixes #200.
