### PR TITLE
test: Cypress end-to-end specs (Closes #209)

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,11 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3002',
+    supportFile: false,
+    defaultCommandTimeout: 10000,
+    video: false,
+    screenshotOnRunFailure: false,
+  },
+});

--- a/cypress/e2e/api-sensors.cy.js
+++ b/cypress/e2e/api-sensors.cy.js
@@ -1,0 +1,18 @@
+// Focused end-to-end coverage for the Arduino sensor ingestion endpoint.
+describe('POST /api/sensors', () => {
+  const base = { deviceId: 'arduino-e2e-02', pH: 7.0, ec: 1.0, temperature: 21.0, humidity: 55 };
+
+  it('returns a success class for a complete payload', () => {
+    cy.request({ method: 'POST', url: '/api/sensors', body: base, failOnStatusCode: false })
+      .then((res) => {
+        expect([200, 201, 202]).to.include(res.status);
+      });
+  });
+
+  it('returns a client error class for an empty body', () => {
+    cy.request({ method: 'POST', url: '/api/sensors', body: {}, failOnStatusCode: false })
+      .then((res) => {
+        expect(res.status).to.be.at.least(400);
+      });
+  });
+});

--- a/cypress/e2e/gateway.cy.js
+++ b/cypress/e2e/gateway.cy.js
@@ -1,0 +1,37 @@
+// End-to-end smoke tests for the MyZubster Gateway web app + sensor ingestion API.
+describe('Gateway web app', () => {
+  it('serves the homepage', () => {
+    cy.request({ url: '/', failOnStatusCode: false }).then((res) => {
+      expect([200, 301, 302, 304]).to.include(res.status);
+    });
+  });
+
+  it('renders a page body', () => {
+    cy.visit('/');
+    cy.get('body').should('exist');
+  });
+});
+
+describe('Arduino sensor ingestion API', () => {
+  const validPayload = {
+    deviceId: 'arduino-e2e-01',
+    pH: 6.8,
+    ec: 1.2,
+    temperature: 22.5,
+    humidity: 60,
+  };
+
+  it('accepts a well-formed sensor payload', () => {
+    cy.request({ method: 'POST', url: '/api/sensors', body: validPayload, failOnStatusCode: false })
+      .then((res) => {
+        expect([200, 201, 202]).to.include(res.status);
+      });
+  });
+
+  it('rejects a malformed sensor payload', () => {
+    cy.request({ method: 'POST', url: '/api/sensors', body: { unexpected: true }, failOnStatusCode: false })
+      .then((res) => {
+        expect(res.status).to.be.at.least(400);
+      });
+  });
+});


### PR DESCRIPTION
## Cypress end-to-end tests (#209)

Adds Cypress config + two e2e specs (homepage smoke, sensor ingestion API).

Run with: npx cypress run (against a running gateway on :3002).

Delivers the #209 MYZ bounty.