### PR TITLE
feat: add global jurisdiction capability engine

### DIFF
--- a/.github/workflows/jurisdiction-policy.yml
+++ b/.github/workflows/jurisdiction-policy.yml
@@ -1,0 +1,32 @@
+name: Jurisdiction policy
+
+on:
+  pull_request:
+    paths:
+      - "data/jurisdictions/**"
+      - "services/jurisdictionCapabilityService.js"
+      - "routes/jurisdictionCapabilities.js"
+      - "tests/jurisdiction*.test.js"
+      - ".github/workflows/jurisdiction-policy.yml"
+  push:
+    branches: [main]
+    paths:
+      - "data/jurisdictions/**"
+      - "services/jurisdictionCapabilityService.js"
+      - "routes/jurisdictionCapabilities.js"
+      - "tests/jurisdiction*.test.js"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: node --test tests/jurisdiction*.test.js

--- a/api/public/v1/routes.js
+++ b/api/public/v1/routes.js
@@ -8,11 +8,13 @@ const { apiLimiter, strictLimiter, validateApiKey, apiLogger } = require('../mid
 const { Product } = require('../../../marketplace/models/marketplace.model');
 const { Bounty } = require('../../../bounty/models/bounty.model');
 const { SocketManager } = require('../../../notifications/websocket/socket.manager');
+const { createJurisdictionCapabilitiesRouter } = require('../../../routes/jurisdictionCapabilities');
 
 // Applica middleware a tutte le route
 router.use(apiLogger);
 router.use(validateApiKey);
 router.use(apiLimiter);
+router.use('/jurisdictions', createJurisdictionCapabilitiesRouter());
 
 // ============================================
 // 🌿 API PIANTE

--- a/data/jurisdictions/v1.json
+++ b/data/jurisdictions/v1.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "1.0.0",
+  "policyVersion": "2026-08-19.1",
+  "regulatedCapabilities": [
+    "payments",
+    "crypto",
+    "custody",
+    "exchange",
+    "settlement",
+    "token_rwa"
+  ],
+  "defaultPolicy": {
+    "regulated": "BLOCKED",
+    "nonRegulated": "REVIEW_REQUIRED"
+  },
+  "aliases": {
+    "CN_MAINLAND": "CN"
+  },
+  "jurisdictions": {
+    "CN": {
+      "name": "China (Mainland)",
+      "capabilities": {
+        "gardens": { "state": "PILOT_ONLY", "approval": "CN-GARDENS-PILOT", "evidence": ["issue:1369"] },
+        "sensors": { "state": "PILOT_ONLY", "approval": "CN-SENSORS-PILOT", "evidence": ["issue:1369"] },
+        "payments": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358", "issue:1369"] },
+        "crypto": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358", "issue:1369"] },
+        "custody": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "exchange": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "settlement": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "token_rwa": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1369"] }
+      }
+    },
+    "SG": {
+      "name": "Singapore",
+      "capabilities": {
+        "gardens": { "state": "PILOT_ONLY", "approval": "SG-GARDENS-PILOT", "evidence": ["issue:1370"] },
+        "sensors": { "state": "PILOT_ONLY", "approval": "SG-SENSORS-PILOT", "evidence": ["issue:1370"] },
+        "payments": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358", "issue:1370"] },
+        "crypto": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358", "issue:1370"] },
+        "custody": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "exchange": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "settlement": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358"] },
+        "token_rwa": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1370"] }
+      }
+    },
+    "US": {
+      "name": "United States",
+      "capabilities": {
+        "gardens": { "state": "PILOT_ONLY", "approval": "US-GARDENS-PILOT", "evidence": ["issue:1371"] },
+        "sensors": { "state": "PILOT_ONLY", "approval": "US-SENSORS-PILOT", "evidence": ["issue:1371"] },
+        "payments": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358", "issue:1371"] },
+        "crypto": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358", "issue:1371"] },
+        "custody": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "exchange": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1358"] },
+        "settlement": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1358"] },
+        "token_rwa": { "state": "REVIEW_REQUIRED", "approval": null, "evidence": ["issue:1371"] }
+      },
+      "subdivisions": {
+        "US-CA": {
+          "name": "California",
+          "capabilities": {
+            "token_rwa": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1371", "state-review:pending"] }
+          }
+        },
+        "US-NY": {
+          "name": "New York",
+          "capabilities": {
+            "crypto": { "state": "RESTRICTED", "approval": null, "evidence": ["issue:1371", "state-review:pending"] },
+            "exchange": { "state": "BLOCKED", "approval": null, "evidence": ["issue:1371"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/JURISDICTION_CAPABILITIES.md
+++ b/docs/JURISDICTION_CAPABILITIES.md
@@ -1,0 +1,35 @@
+# Jurisdiction capability registry
+
+The Gateway resolves legal jurisdiction independently from language or locale. Business routes
+must ask the capability service for a decision and must not add country-specific allow lists.
+
+## API
+
+- `GET /api/jurisdictions/:countryCode/capabilities?subdivision=US-CA` returns the effective
+  country and subdivision profile.
+- `POST /api/jurisdictions/decision` evaluates one capability. The request accepts
+  `countryCode`, optional `subdivisionCode`, `capability`, and `environment`.
+
+Only `SUPPORTED` is allowed in production. `PILOT_ONLY` is allowed in `pilot`, `sandbox`, or
+`test`. `RESTRICTED`, `BLOCKED`, and `REVIEW_REQUIRED` deny execution. Missing regulated
+capabilities always use the global `BLOCKED` default.
+
+Every decision includes the schema version, policy version, resolved jurisdiction, evidence,
+approval reference, and allow/deny reason. The default router writes this audit record as
+structured JSON; production deployments should send it to the normal audit sink.
+
+## Add a jurisdiction
+
+1. Add the ISO 3166-1 alpha-2 key under `jurisdictions` in
+   `data/jurisdictions/v1.json`.
+2. Add subdivisions as ISO 3166-2 keys only when regional policy differs.
+3. Give every configured capability a valid `state`, an `evidence` array, and an approval
+   reference when the state is `SUPPORTED`.
+4. Never mark a regulated capability supported from locale, IP address, or self-declared
+   country alone. The caller remains responsible for trusted jurisdiction resolution.
+5. Add regression tests for the profile and run
+   `node --test tests/jurisdiction*.test.js`.
+6. Increment `policyVersion` for policy-only changes. Create a new schema file and update the
+   loader deliberately for incompatible structural changes.
+
+Adding a profile requires no changes to normal business routes.

--- a/routes/jurisdictionCapabilities.js
+++ b/routes/jurisdictionCapabilities.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const {
+  JurisdictionCapabilityService
+} = require('../services/jurisdictionCapabilityService');
+
+function createJurisdictionCapabilitiesRouter({ service, audit } = {}) {
+  const router = express.Router();
+  const capabilityService = service || new JurisdictionCapabilityService({
+    audit: audit || ((event) => console.info('[JurisdictionPolicy]', JSON.stringify(event)))
+  });
+
+  router.get('/:countryCode', (req, res, next) => {
+    try {
+      res.json(capabilityService.discover(req.params.countryCode, req.query.subdivision));
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/decision', (req, res, next) => {
+    try {
+      const decision = capabilityService.decide(req.body || {});
+      res.status(decision.allowed ? 200 : 403).json(decision);
+    } catch (error) {
+      error.status = 400;
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createJurisdictionCapabilitiesRouter };

--- a/services/jurisdictionCapabilityService.js
+++ b/services/jurisdictionCapabilityService.js
@@ -1,0 +1,173 @@
+const fs = require('fs');
+const path = require('path');
+
+const STATES = new Set([
+  'SUPPORTED',
+  'PILOT_ONLY',
+  'RESTRICTED',
+  'BLOCKED',
+  'REVIEW_REQUIRED'
+]);
+
+const DEFAULT_REGISTRY_PATH = path.join(
+  __dirname,
+  '..',
+  'data',
+  'jurisdictions',
+  'v1.json'
+);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function validateCapabilityRecord(record, location) {
+  if (!record || !STATES.has(record.state)) {
+    throw new Error(`${location} has an invalid capability state`);
+  }
+  if (!Array.isArray(record.evidence)) {
+    throw new Error(`${location} must provide an evidence array`);
+  }
+  if (record.state === 'SUPPORTED' && !record.approval) {
+    throw new Error(`${location} cannot be SUPPORTED without approval`);
+  }
+}
+
+function validateRegistry(registry) {
+  if (!registry || !/^\d+\.\d+\.\d+$/.test(registry.schemaVersion || '')) {
+    throw new Error('registry schemaVersion must use semantic versioning');
+  }
+  if (!registry.policyVersion || !registry.jurisdictions) {
+    throw new Error('registry must include policyVersion and jurisdictions');
+  }
+  if (!Array.isArray(registry.regulatedCapabilities)) {
+    throw new Error('registry must list regulatedCapabilities');
+  }
+  if (!STATES.has(registry.defaultPolicy?.regulated) ||
+      !STATES.has(registry.defaultPolicy?.nonRegulated)) {
+    throw new Error('registry defaultPolicy contains an invalid state');
+  }
+
+  for (const [countryCode, profile] of Object.entries(registry.jurisdictions)) {
+    if (!/^[A-Z]{2}$/.test(countryCode)) {
+      throw new Error(`invalid ISO 3166-1 country code: ${countryCode}`);
+    }
+    for (const [capability, record] of Object.entries(profile.capabilities || {})) {
+      validateCapabilityRecord(record, `${countryCode}.${capability}`);
+    }
+    for (const [subdivisionCode, subdivision] of Object.entries(profile.subdivisions || {})) {
+      if (!subdivisionCode.startsWith(`${countryCode}-`)) {
+        throw new Error(`${subdivisionCode} is not a subdivision of ${countryCode}`);
+      }
+      for (const [capability, record] of Object.entries(subdivision.capabilities || {})) {
+        validateCapabilityRecord(record, `${subdivisionCode}.${capability}`);
+      }
+    }
+  }
+  return registry;
+}
+
+function loadRegistry(registryPath = DEFAULT_REGISTRY_PATH) {
+  return validateRegistry(JSON.parse(fs.readFileSync(registryPath, 'utf8')));
+}
+
+class JurisdictionCapabilityService {
+  constructor({ registry = loadRegistry(), audit = () => {} } = {}) {
+    this.registry = validateRegistry(clone(registry));
+    this.audit = audit;
+    this.regulated = new Set(this.registry.regulatedCapabilities);
+  }
+
+  resolve(countryCode, subdivisionCode) {
+    const requestedCountry = String(countryCode || '').trim().toUpperCase();
+    const canonicalCountry = this.registry.aliases?.[requestedCountry] || requestedCountry;
+    const requestedSubdivision = subdivisionCode
+      ? String(subdivisionCode).trim().toUpperCase()
+      : null;
+    const profile = this.registry.jurisdictions[canonicalCountry];
+    const subdivision = profile?.subdivisions?.[requestedSubdivision] || null;
+
+    return {
+      requestedCountry,
+      countryCode: profile ? canonicalCountry : null,
+      countryName: profile?.name || null,
+      requestedSubdivision,
+      subdivisionCode: subdivision ? requestedSubdivision : null,
+      subdivisionName: subdivision?.name || null,
+      known: Boolean(profile),
+      subdivisionKnown: requestedSubdivision ? Boolean(subdivision) : null,
+      profile,
+      subdivision
+    };
+  }
+
+  discover(countryCode, subdivisionCode) {
+    const resolution = this.resolve(countryCode, subdivisionCode);
+    const capabilities = {
+      ...(resolution.profile?.capabilities || {}),
+      ...(resolution.subdivision?.capabilities || {})
+    };
+
+    return {
+      schemaVersion: this.registry.schemaVersion,
+      policyVersion: this.registry.policyVersion,
+      jurisdiction: {
+        requestedCountry: resolution.requestedCountry,
+        countryCode: resolution.countryCode,
+        countryName: resolution.countryName,
+        requestedSubdivision: resolution.requestedSubdivision,
+        subdivisionCode: resolution.subdivisionCode,
+        subdivisionName: resolution.subdivisionName,
+        known: resolution.known,
+        subdivisionKnown: resolution.subdivisionKnown
+      },
+      defaults: clone(this.registry.defaultPolicy),
+      regulatedCapabilities: [...this.regulated],
+      capabilities: clone(capabilities)
+    };
+  }
+
+  decide({ countryCode, subdivisionCode, capability, environment = 'production' }) {
+    const discovery = this.discover(countryCode, subdivisionCode);
+    const normalizedCapability = String(capability || '').trim().toLowerCase();
+    if (!normalizedCapability) {
+      throw new Error('capability is required');
+    }
+
+    const regulated = this.regulated.has(normalizedCapability);
+    const configured = discovery.capabilities[normalizedCapability] || null;
+    const state = configured?.state || (
+      regulated ? discovery.defaults.regulated : discovery.defaults.nonRegulated
+    );
+    const pilotEnvironment = ['pilot', 'sandbox', 'test'].includes(
+      String(environment).toLowerCase()
+    );
+    const allowed = state === 'SUPPORTED' || (state === 'PILOT_ONLY' && pilotEnvironment);
+    const decision = {
+      timestamp: new Date().toISOString(),
+      schemaVersion: discovery.schemaVersion,
+      policyVersion: discovery.policyVersion,
+      jurisdiction: discovery.jurisdiction,
+      capability: normalizedCapability,
+      regulated,
+      environment,
+      state,
+      allowed,
+      approval: configured?.approval || null,
+      evidence: clone(configured?.evidence || []),
+      reason: configured
+        ? (allowed ? 'explicit_policy_allows' : 'explicit_policy_denies')
+        : (regulated ? 'missing_regulated_approval' : 'missing_capability_policy')
+    };
+
+    this.audit(clone(decision));
+    return decision;
+  }
+}
+
+module.exports = {
+  STATES,
+  JurisdictionCapabilityService,
+  loadRegistry,
+  validateRegistry
+};

--- a/tests/jurisdictionCapabilitiesRoutes.test.js
+++ b/tests/jurisdictionCapabilitiesRoutes.test.js
@@ -1,0 +1,70 @@
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const test = require('node:test');
+const express = require('express');
+
+const {
+  createJurisdictionCapabilitiesRouter
+} = require('../routes/jurisdictionCapabilities');
+
+function request(app, { method = 'GET', path, body }) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const payload = body ? JSON.stringify(body) : null;
+      const req = http.request({
+        hostname: '127.0.0.1',
+        port: server.address().port,
+        method,
+        path,
+        headers: payload ? {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload)
+        } : {}
+      }, (res) => {
+        let responseBody = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => { responseBody += chunk; });
+        res.on('end', () => {
+          server.close(() => resolve({
+            status: res.statusCode,
+            body: JSON.parse(responseBody)
+          }));
+        });
+      });
+      req.on('error', (error) => server.close(() => reject(error)));
+      if (payload) req.write(payload);
+      req.end();
+    });
+  });
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/jurisdictions', createJurisdictionCapabilitiesRouter({ audit: () => {} }));
+  app.use((error, _req, res, _next) => {
+    res.status(error.status || 500).json({ error: error.message });
+  });
+  return app;
+}
+
+test('capability discovery exposes an effective subdivision profile', async () => {
+  const response = await request(createApp(), {
+    path: '/api/jurisdictions/US?subdivision=US-NY'
+  });
+  assert.equal(response.status, 200);
+  assert.equal(response.body.jurisdiction.subdivisionCode, 'US-NY');
+  assert.equal(response.body.capabilities.crypto.state, 'RESTRICTED');
+  assert.equal(response.body.policyVersion, '2026-08-19.1');
+});
+
+test('decision endpoint returns 403 for an unknown regulated jurisdiction', async () => {
+  const response = await request(createApp(), {
+    method: 'POST',
+    path: '/api/jurisdictions/decision',
+    body: { countryCode: 'ZZ', capability: 'settlement' }
+  });
+  assert.equal(response.status, 403);
+  assert.equal(response.body.allowed, false);
+  assert.equal(response.body.reason, 'missing_regulated_approval');
+});

--- a/tests/jurisdictionCapabilityService.test.js
+++ b/tests/jurisdictionCapabilityService.test.js
@@ -1,0 +1,83 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  JurisdictionCapabilityService,
+  loadRegistry,
+  validateRegistry
+} = require('../services/jurisdictionCapabilityService');
+
+test('loads and validates the versioned registry', () => {
+  const registry = loadRegistry();
+  assert.equal(registry.schemaVersion, '1.0.0');
+  assert.ok(registry.jurisdictions.CN);
+  assert.ok(registry.jurisdictions.SG);
+  assert.ok(registry.jurisdictions.US.subdivisions['US-CA']);
+});
+
+test('rejects malformed profiles during CI validation', () => {
+  const invalid = loadRegistry();
+  invalid.jurisdictions.SG.capabilities.payments.state = 'MAYBE';
+  assert.throws(() => validateRegistry(invalid), /invalid capability state/);
+});
+
+test('resolves CN_MAINLAND without route-specific logic', () => {
+  const service = new JurisdictionCapabilityService();
+  const result = service.discover('CN_MAINLAND');
+  assert.equal(result.jurisdiction.countryCode, 'CN');
+  assert.equal(result.capabilities.payments.state, 'BLOCKED');
+});
+
+test('keeps SG regulated capabilities fail-closed without approval', () => {
+  const service = new JurisdictionCapabilityService();
+  const result = service.decide({ countryCode: 'SG', capability: 'payments' });
+  assert.equal(result.allowed, false);
+  assert.equal(result.state, 'REVIEW_REQUIRED');
+});
+
+test('applies a US subdivision override over the country profile', () => {
+  const service = new JurisdictionCapabilityService();
+  const result = service.decide({
+    countryCode: 'US',
+    subdivisionCode: 'US-CA',
+    capability: 'token_rwa'
+  });
+  assert.equal(result.jurisdiction.subdivisionCode, 'US-CA');
+  assert.equal(result.state, 'BLOCKED');
+  assert.equal(result.allowed, false);
+});
+
+test('allows pilot-only software capabilities only outside production', () => {
+  const service = new JurisdictionCapabilityService();
+  const production = service.decide({ countryCode: 'US', capability: 'gardens' });
+  const pilot = service.decide({
+    countryCode: 'US',
+    capability: 'gardens',
+    environment: 'pilot'
+  });
+  assert.equal(production.allowed, false);
+  assert.equal(pilot.allowed, true);
+});
+
+test('defaults unknown jurisdictions to deny for regulated capabilities', () => {
+  const audit = [];
+  const service = new JurisdictionCapabilityService({ audit: (event) => audit.push(event) });
+  const result = service.decide({ countryCode: 'ZZ', capability: 'custody' });
+  assert.equal(result.jurisdiction.known, false);
+  assert.equal(result.allowed, false);
+  assert.equal(result.state, 'BLOCKED');
+  assert.equal(result.reason, 'missing_regulated_approval');
+  assert.equal(audit.length, 1);
+  assert.equal(audit[0].policyVersion, result.policyVersion);
+});
+
+test('unknown subdivisions do not inherit a fabricated approval', () => {
+  const service = new JurisdictionCapabilityService();
+  const result = service.decide({
+    countryCode: 'US',
+    subdivisionCode: 'US-XX',
+    capability: 'exchange'
+  });
+  assert.equal(result.jurisdiction.subdivisionKnown, false);
+  assert.equal(result.allowed, false);
+});


### PR DESCRIPTION
## Summary
- add a versioned, data-driven jurisdiction registry with CN, SG, US, and subdivision overrides
- expose capability discovery and decision APIs with fail-closed regulated defaults
- emit auditable policy decisions and document profile onboarding without country logic in business routes
- cover schema validation, aliases, pilot gates, subdivision overrides, unknown jurisdictions, and HTTP behavior

## Verification
- `npm ci` (0 vulnerabilities)
- `npm test` (18 passing locally)
- dedicated jurisdiction workflow (10 passing)
- `git diff --check`

Closes #1372
Closes #1373