### PR TITLE
feat: add optional Tor transport with multi-instance failover

### DIFF
--- a/.github/workflows/tor-gateway.yml
+++ b/.github/workflows/tor-gateway.yml
@@ -1,0 +1,25 @@
+name: Tor gateway checks
+
+on:
+  pull_request:
+    paths:
+      - "deploy/tor/**"
+      - "docs/TOR_*.md"
+      - "services/torInstanceRegistry.js"
+      - "tor/**"
+      - "tests/tor*.test.js"
+      - ".github/workflows/tor-gateway.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node --test tests/tor*.test.js
+      - run: touch .env && docker compose -f docker-compose.yml -f deploy/tor/docker-compose.tor.yml config --quiet

--- a/deploy/tor/Dockerfile
+++ b/deploy/tor/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ca-certificates curl gosu tor \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY torrc /etc/tor/torrc
+COPY healthcheck.sh /usr/local/bin/tor-healthcheck
+COPY entrypoint.sh /usr/local/bin/tor-entrypoint
+RUN chmod 0755 /usr/local/bin/tor-healthcheck /usr/local/bin/tor-entrypoint \
+    && chown -R debian-tor:debian-tor /var/lib/tor
+
+ENTRYPOINT ["/usr/local/bin/tor-entrypoint"]

--- a/deploy/tor/docker-compose.tor.yml
+++ b/deploy/tor/docker-compose.tor.yml
@@ -1,0 +1,61 @@
+services:
+  tor-primary:
+    profiles: ["tor"]
+    build: ./deploy/tor
+    restart: unless-stopped
+    depends_on:
+      gateway:
+        condition: service_healthy
+    environment:
+      TOR_INSTANCE_ID: primary
+    volumes:
+      - tor_primary_data:/var/lib/tor
+      - tor_status:/run/myzubster-tor/status
+    networks: [myzubster-network]
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/tor-healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  tor-secondary:
+    profiles: ["tor"]
+    build: ./deploy/tor
+    restart: unless-stopped
+    depends_on:
+      gateway:
+        condition: service_healthy
+    environment:
+      TOR_INSTANCE_ID: secondary
+    volumes:
+      - tor_secondary_data:/var/lib/tor
+      - tor_status:/run/myzubster-tor/status
+    networks: [myzubster-network]
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/tor-healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  tor-metadata:
+    profiles: ["tor"]
+    image: node:20-bookworm-slim
+    restart: unless-stopped
+    working_dir: /app
+    command: ["node", "tor/metadataServer.js"]
+    environment:
+      TOR_METADATA_HOST: 0.0.0.0
+      TOR_METADATA_PORT: 9080
+      TOR_INSTANCES_CONFIG: /run/myzubster-tor/instances.json
+    volumes:
+      - ./:/app:ro
+      - ./deploy/tor/instances.json:/run/myzubster-tor/instances.json:ro
+      - tor_status:/run/myzubster-tor/status:ro
+    ports:
+      - "127.0.0.1:${TOR_METADATA_PORT:-9080}:9080"
+    networks: [myzubster-network]
+
+volumes:
+  tor_primary_data:
+  tor_secondary_data:
+  tor_status:

--- a/deploy/tor/entrypoint.sh
+++ b/deploy/tor/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+install -d -o debian-tor -g debian-tor -m 0700 /var/lib/tor
+install -d -o debian-tor -g debian-tor -m 0750 "${TOR_STATUS_DIR:-/run/myzubster-tor/status}"
+exec gosu debian-tor tor -f /etc/tor/torrc

--- a/deploy/tor/healthcheck.sh
+++ b/deploy/tor/healthcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+instance="${TOR_INSTANCE_ID:?TOR_INSTANCE_ID is required}"
+status_dir="${TOR_STATUS_DIR:-/run/myzubster-tor/status}"
+status_file="${status_dir}/${instance}.json"
+checked_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mkdir -p "$status_dir"
+
+if test -s /var/lib/tor/hidden_service/hostname \
+  && curl --fail --silent --show-error --max-time 5 http://gateway:10000/health >/dev/null; then
+  printf '{"healthy":true,"checkedAt":"%s"}\n' "$checked_at" >"$status_file"
+  exit 0
+fi
+
+printf '{"healthy":false,"checkedAt":"%s","reason":"tor-or-upstream-unavailable"}\n' "$checked_at" >"$status_file"
+exit 1

--- a/deploy/tor/instances.example.json
+++ b/deploy/tor/instances.example.json
@@ -1,0 +1,20 @@
+{
+  "enabled": false,
+  "directHttpsUrl": "https://gateway.example.invalid",
+  "instances": [
+    {
+      "id": "primary",
+      "publicUrl": "http://primaryexampleaddress.onion",
+      "region": "operator-zone-a",
+      "priority": 10,
+      "statusFile": "/run/myzubster-tor/status/primary.json"
+    },
+    {
+      "id": "secondary",
+      "publicUrl": "http://secondaryexampleaddress.onion",
+      "region": "operator-zone-b",
+      "priority": 20,
+      "statusFile": "/run/myzubster-tor/status/secondary.json"
+    }
+  ]
+}

--- a/deploy/tor/torrc
+++ b/deploy/tor/torrc
@@ -1,0 +1,7 @@
+SocksPort 0
+ControlPort 0
+DataDirectory /var/lib/tor
+HiddenServiceDir /var/lib/tor/hidden_service
+HiddenServiceVersion 3
+HiddenServicePort 80 gateway:10000
+Log notice stdout

--- a/docs/TOR_GATEWAY.md
+++ b/docs/TOR_GATEWAY.md
@@ -1,0 +1,48 @@
+# Optional Tor gateway transport
+
+Tor is an optional transport for operators who need an onion-service endpoint. It
+does not replace, disable, or alter the normal HTTPS listener. The deployment is
+disabled unless the `tor` Compose profile is explicitly selected.
+
+## Local deployment
+
+1. Copy `deploy/tor/instances.example.json` to `deploy/tor/instances.json`.
+2. Keep `enabled` set to `false` until each generated onion hostname has been
+   placed in the operator-owned configuration.
+3. Start the normal gateway first and verify its HTTPS health endpoint.
+4. Run `docker compose -f docker-compose.yml -f deploy/tor/docker-compose.tor.yml
+   --profile tor up -d --build`.
+5. Read local-only discovery metadata from
+   `http://127.0.0.1:9080/v1/tor/instances`.
+
+The example runs two isolated Tor processes with separate persistent data
+volumes. Increase or reduce the instance services as required, giving each one a
+unique volume, `TOR_INSTANCE_ID`, priority, and public onion hostname. Never copy
+an onion private-key directory between simultaneously running instances.
+
+## Health and failover
+
+Each Tor container checks that its hostname exists and that the upstream Gateway
+health endpoint responds. It writes only `healthy`, `checkedAt`, and a generic
+failure reason to a shared status volume. The metadata service sorts healthy
+instances by numeric priority and publishes `selectedInstance`; it never reads
+the Tor data volumes or private keys. Missing, malformed, and stale status inputs
+fail closed as unavailable. Direct HTTPS remains independently advertised.
+
+The metadata listener binds to loopback on the host by default. Put authentication
+and TLS in front of it before exposing it outside the operator network. Consumers
+must treat discovery as advisory and retain their normal HTTPS fallback.
+
+## Rotation and recovery
+
+1. Add a fresh Tor instance with a new data volume and lower precedence.
+2. Wait for a healthy status and publish its onion hostname in configuration.
+3. Move the new instance to the preferred priority and monitor both transports.
+4. Remove the old hostname from discovery, then stop its container.
+5. Back up or destroy its private-key volume according to the operator policy.
+
+If a key is lost or suspected compromised, do not restore it onto another live
+instance. Remove the endpoint from discovery, create a new volume and hostname,
+and publish the replacement after health verification. Logs and support bundles
+must exclude `/var/lib/tor`, Docker volume exports, control cookies, and client
+authorization material.

--- a/docs/TOR_THREAT_MODEL.md
+++ b/docs/TOR_THREAT_MODEL.md
@@ -1,0 +1,25 @@
+# Tor transport threat model
+
+## Security goals
+
+- Keep onion private keys isolated per Tor process and out of application logs.
+- Preserve the direct HTTPS path when Tor is disabled, degraded, or unavailable.
+- Publish only public endpoint and coarse health metadata.
+- Avoid using Tor as an authentication, authorization, or jurisdiction bypass.
+
+## Threats and mitigations
+
+| Threat | Mitigation |
+| --- | --- |
+| Private-key disclosure | Separate data volumes; the metadata service mounts only status data; secret-shaped configuration fields are rejected. |
+| Malicious discovery data | Strict onion URL and instance ID validation; loopback binding; `no-store` responses; operators add TLS/auth before external exposure. |
+| Failed or partitioned instance | Health status fails closed; deterministic priority selection; independent HTTPS fallback remains available. |
+| Correlation and traffic analysis | No anonymity guarantee is claimed; operators should avoid identifying logs and use normal data-minimization controls. |
+| Stale/compromised onion key | Staged rotation with a new volume and explicit endpoint withdrawal; never clone one key across active instances. |
+| Policy bypass | Gateway authentication and jurisdiction controls are unchanged and execute behind both transports. |
+
+## Out of scope
+
+This profile does not promise censorship resistance, user anonymity, protection
+from a global traffic observer, or automatic key escrow. It does not modify
+Gateway authorization and must not be used to evade legal or platform controls.

--- a/services/torInstanceRegistry.js
+++ b/services/torInstanceRegistry.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const fs = require('fs');
+
+const SECRET_KEYS = new Set([
+  'privateKey',
+  'secretKey',
+  'clientAuth',
+  'controlPassword',
+  'cookie',
+]);
+
+function assertPublicOnionUrl(value, id) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`Tor instance ${id} has an invalid publicUrl`);
+  }
+  if (url.protocol !== 'http:' || !url.hostname.endsWith('.onion')) {
+    throw new Error(`Tor instance ${id} publicUrl must be an http://*.onion URL`);
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+function normalizeInstance(instance, index) {
+  if (!instance || typeof instance !== 'object' || Array.isArray(instance)) {
+    throw new Error(`Tor instance at index ${index} must be an object`);
+  }
+  for (const key of Object.keys(instance)) {
+    if (SECRET_KEYS.has(key)) {
+      throw new Error(`Tor instance ${instance.id || index} includes forbidden secret field ${key}`);
+    }
+  }
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(instance.id || '')) {
+    throw new Error(`Tor instance at index ${index} has an invalid id`);
+  }
+
+  return {
+    id: instance.id,
+    publicUrl: assertPublicOnionUrl(instance.publicUrl, instance.id),
+    region: String(instance.region || 'unspecified'),
+    priority: Number.isInteger(instance.priority) && instance.priority >= 0
+      ? instance.priority
+      : 100,
+    statusFile: instance.statusFile ? String(instance.statusFile) : null,
+  };
+}
+
+function readStatus(instance, readFile = fs.readFileSync, now = Date.now, maxStatusAgeMs = 120000) {
+  if (!instance.statusFile) {
+    return { healthy: false, checkedAt: null, reason: 'status-unavailable' };
+  }
+  try {
+    const status = JSON.parse(readFile(instance.statusFile, 'utf8'));
+    const checkedAt = typeof status.checkedAt === 'string' ? status.checkedAt : null;
+    const checkedAtMs = checkedAt ? Date.parse(checkedAt) : Number.NaN;
+    if (!Number.isFinite(checkedAtMs) || now() - checkedAtMs > maxStatusAgeMs) {
+      return { healthy: false, checkedAt, reason: 'status-stale' };
+    }
+    const healthy = status.healthy === true;
+    return {
+      healthy,
+      checkedAt,
+      reason: healthy ? null : String(status.reason || 'health-check-failed'),
+    };
+  } catch {
+    return { healthy: false, checkedAt: null, reason: 'status-unavailable' };
+  }
+}
+
+class TorInstanceRegistry {
+  constructor(config, options = {}) {
+    if (!config || config.enabled !== true) {
+      this.enabled = false;
+      this.instances = [];
+      this.directHttpsUrl = config && config.directHttpsUrl ? String(config.directHttpsUrl) : null;
+      this.readFile = options.readFile;
+      return;
+    }
+    if (!Array.isArray(config.instances) || config.instances.length === 0) {
+      throw new Error('At least one Tor instance is required when Tor is enabled');
+    }
+    this.enabled = true;
+    this.directHttpsUrl = config.directHttpsUrl ? String(config.directHttpsUrl) : null;
+    this.instances = config.instances.map(normalizeInstance);
+    this.readFile = options.readFile;
+    this.now = options.now;
+    this.maxStatusAgeMs = Number.isFinite(options.maxStatusAgeMs)
+      ? options.maxStatusAgeMs
+      : 120000;
+  }
+
+  snapshot() {
+    const instances = this.instances
+      .map((instance) => ({
+        ...instance,
+        ...readStatus(instance, this.readFile, this.now, this.maxStatusAgeMs),
+      }))
+      .sort((left, right) => left.priority - right.priority || left.id.localeCompare(right.id))
+      .map(({ statusFile, ...publicInstance }) => publicInstance);
+
+    const selected = instances.find((instance) => instance.healthy) || null;
+    return {
+      enabled: this.enabled,
+      selectedInstance: selected ? selected.id : null,
+      directHttpsAvailable: Boolean(this.directHttpsUrl),
+      instances,
+    };
+  }
+}
+
+function loadRegistry(configPath, options) {
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  return new TorInstanceRegistry(config, options);
+}
+
+module.exports = { TorInstanceRegistry, loadRegistry };

--- a/tests/torInstanceRegistry.test.js
+++ b/tests/torInstanceRegistry.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { TorInstanceRegistry } = require('../services/torInstanceRegistry');
+
+const config = {
+  enabled: true,
+  directHttpsUrl: 'https://gateway.example.invalid',
+  instances: [
+    {
+      id: 'secondary',
+      publicUrl: 'http://secondaryexampleaddress.onion',
+      region: 'zone-b',
+      priority: 20,
+      statusFile: '/status/secondary.json',
+    },
+    {
+      id: 'primary',
+      publicUrl: 'http://primaryexampleaddress.onion',
+      region: 'zone-a',
+      priority: 10,
+      statusFile: '/status/primary.json',
+    },
+  ],
+};
+
+test('Tor stays disabled by default and keeps direct HTTPS independent', () => {
+  const registry = new TorInstanceRegistry({
+    directHttpsUrl: 'https://gateway.example.invalid',
+  });
+  assert.deepEqual(registry.snapshot(), {
+    enabled: false,
+    selectedInstance: null,
+    directHttpsAvailable: true,
+    instances: [],
+  });
+});
+
+test('selects the healthiest instance with the lowest priority', () => {
+  const statuses = {
+    '/status/primary.json': JSON.stringify({ healthy: false, reason: 'probe-failed' }),
+    '/status/secondary.json': JSON.stringify({
+      healthy: true,
+      checkedAt: '2026-08-19T00:00:00Z',
+    }),
+  };
+  const registry = new TorInstanceRegistry(config, {
+    readFile: (path) => statuses[path],
+    now: () => Date.parse('2026-08-19T00:01:00Z'),
+  });
+  const snapshot = registry.snapshot();
+  assert.equal(snapshot.selectedInstance, 'secondary');
+  assert.equal(snapshot.directHttpsAvailable, true);
+  assert.equal(snapshot.instances[0].id, 'primary');
+  assert.equal('statusFile' in snapshot.instances[0], false);
+});
+
+test('fails closed when health status is unavailable', () => {
+  const registry = new TorInstanceRegistry(config, {
+    readFile: () => { throw new Error('missing'); },
+  });
+  const snapshot = registry.snapshot();
+  assert.equal(snapshot.selectedInstance, null);
+  assert.ok(snapshot.instances.every((instance) => instance.healthy === false));
+  assert.ok(snapshot.instances.every((instance) => instance.reason === 'status-unavailable'));
+});
+
+test('does not select an instance with stale health status', () => {
+  const registry = new TorInstanceRegistry(config, {
+    readFile: () => JSON.stringify({ healthy: true, checkedAt: '2026-08-19T00:00:00Z' }),
+    now: () => Date.parse('2026-08-19T00:03:00Z'),
+  });
+  const snapshot = registry.snapshot();
+  assert.equal(snapshot.selectedInstance, null);
+  assert.ok(snapshot.instances.every((instance) => instance.reason === 'status-stale'));
+});
+
+test('rejects secret fields and non-onion discovery URLs', () => {
+  assert.throws(() => new TorInstanceRegistry({
+    enabled: true,
+    instances: [{
+      id: 'bad',
+      publicUrl: 'https://example.com',
+      privateKey: 'must-not-be-here',
+    }],
+  }), /forbidden secret field/);
+
+  assert.throws(() => new TorInstanceRegistry({
+    enabled: true,
+    instances: [{ id: 'bad', publicUrl: 'https://example.com' }],
+  }), /must be an http:\/\/\*\.onion URL/);
+});

--- a/tests/torMetadataServer.test.js
+++ b/tests/torMetadataServer.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { TorInstanceRegistry } = require('../services/torInstanceRegistry');
+const { createMetadataServer } = require('../tor/metadataServer');
+
+async function withServer(registry, callback) {
+  const server = createMetadataServer(registry);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('serves health and sanitized discovery metadata', async () => {
+  const registry = new TorInstanceRegistry({
+    enabled: true,
+    directHttpsUrl: 'https://gateway.example.invalid',
+    instances: [{
+      id: 'primary',
+      publicUrl: 'http://primaryexampleaddress.onion',
+      priority: 10,
+      statusFile: '/status/primary.json',
+    }],
+  }, {
+    readFile: () => JSON.stringify({ healthy: true, checkedAt: '2026-08-19T00:00:00Z' }),
+    now: () => Date.parse('2026-08-19T00:01:00Z'),
+  });
+
+  await withServer(registry, async (baseUrl) => {
+    const health = await fetch(`${baseUrl}/healthz`);
+    assert.equal(health.status, 200);
+    assert.deepEqual(await health.json(), { status: 'ok', torEnabled: true });
+
+    const discovery = await fetch(`${baseUrl}/v1/tor/instances`);
+    assert.equal(discovery.headers.get('cache-control'), 'no-store');
+    const body = await discovery.json();
+    assert.equal(body.selectedInstance, 'primary');
+    assert.equal(JSON.stringify(body).includes('statusFile'), false);
+  });
+});
+
+test('rejects writes and unknown routes', async () => {
+  const registry = new TorInstanceRegistry({ enabled: false });
+  await withServer(registry, async (baseUrl) => {
+    assert.equal((await fetch(`${baseUrl}/healthz`, { method: 'POST' })).status, 405);
+    assert.equal((await fetch(`${baseUrl}/missing`)).status, 404);
+  });
+});

--- a/tor/metadataServer.js
+++ b/tor/metadataServer.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const http = require('http');
+const { loadRegistry } = require('../services/torInstanceRegistry');
+
+const configPath = process.env.TOR_INSTANCES_CONFIG || '/run/myzubster-tor/instances.json';
+const host = process.env.TOR_METADATA_HOST || '127.0.0.1';
+const port = Number(process.env.TOR_METADATA_PORT || 9080);
+
+function sendJson(response, status, body) {
+  response.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  response.end(`${JSON.stringify(body)}\n`);
+}
+
+function createMetadataServer(registry) {
+  return http.createServer((request, response) => {
+    if (request.method !== 'GET') {
+      return sendJson(response, 405, { error: 'method_not_allowed' });
+    }
+    if (request.url === '/healthz') {
+      return sendJson(response, 200, { status: 'ok', torEnabled: registry.enabled });
+    }
+    if (request.url === '/v1/tor/instances') {
+      return sendJson(response, 200, registry.snapshot());
+    }
+    return sendJson(response, 404, { error: 'not_found' });
+  });
+}
+
+if (require.main === module) {
+  const registry = loadRegistry(configPath);
+  createMetadataServer(registry).listen(port, host, () => {
+    console.log(`Tor metadata listening on ${host}:${port}`);
+  });
+}
+
+module.exports = { createMetadataServer };


### PR DESCRIPTION
Closes #1374

## Summary
- add an opt-in 	or Compose profile with isolated primary/secondary onion-service instances
- add sanitized, loopback-bound discovery metadata with deterministic priority failover
- fail closed on missing/stale health status while keeping direct HTTPS independent
- document deployment, key rotation/recovery, and the Tor transport threat model
- add focused Node tests and a path-scoped CI workflow

## Validation
- 
ode --test tests/tor*.test.js (7/7 passing)
- docker compose -f docker-compose.yml -f deploy/tor/docker-compose.tor.yml config --quiet
- git diff --check
- image build was not run locally because the Docker Desktop Linux engine was unavailable

Tor remains disabled by default. This does not bypass Gateway authentication, authorization, jurisdiction policy, or platform controls, and makes no anonymity or censorship-resistance guarantee.