### PR TITLE
docs: audit legacy bounty settlement wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,80 +1,99 @@
-name: 🏆 Bounty Issue
-description: Proponi un nuovo bounty pagato in MYZ o XMR
-title: "[BOUNTY] "
-labels: ["bounty", "help wanted"]
+name: Bounty Issue
+description: Propose verifiable work under the MyZubster bounty policy
+title: "Bounty - "
+labels: ["type:bounty", "status:proposed", "evidence:required", "review:manual"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## 🏆 Nuova Bounty Issue
-        
-        Scegli la valuta per la ricompensa:
-        - **MYZ** (token Tari) → **illimitato**, puoi aprirne quante vuoi
-        - **XMR** (Monero) → **massimo 1 al giorno** per utente
+        ## Bounty proposal
+
+        A reward amount is not proof of funding or settlement. MYZ is an
+        internal reward/accounting unit unless a separately verified external
+        rail is documented.
 
   - type: dropdown
     id: currency
     attributes:
-      label: "💱 Valuta della ricompensa"
-      description: "Seleziona la valuta in cui verrà pagato il bounty"
+      label: "Reward asset or accounting unit"
+      description: "Select the proposed reward unit"
       options:
-        - "MYZ (illimitato)"
-        - "XMR (1 al giorno)"
+        - "MYZ (internal accounting)"
+        - "XMR"
+        - "Other / none"
     validations:
       required: true
 
   - type: input
     id: title
     attributes:
-      label: "📌 Titolo"
-      placeholder: "es. Aggiungere supporto per wallet X"
+      label: "Objective"
+      placeholder: "Describe the verifiable outcome"
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: "📋 Descrizione"
-      placeholder: "Spiega cosa deve essere fatto..."
+      label: "Scope and deliverable"
+      placeholder: "Describe what must be delivered and what is out of scope"
     validations:
       required: true
 
   - type: input
     id: reward
     attributes:
-      label: "💰 Ricompensa"
-      placeholder: "es. 80 (MYZ) o 0.1 (XMR)"
+      label: "Proposed reward amount"
+      placeholder: "For example: 80 MYZ or 0.1 XMR"
     validations:
       required: true
 
   - type: textarea
     id: acceptance
     attributes:
-      label: "✅ Criteri di accettazione"
-      placeholder: "- [ ] Criterio 1\n- [ ] Criterio 2"
+      label: "Acceptance criteria"
+      placeholder: "- [ ] Criterion 1\n- [ ] Criterion 2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: funding
+    attributes:
+      label: "Funding state"
+      options:
+        - "PROPOSED"
+        - "VALIDATED"
+        - "APPROVED"
+        - "FUNDED"
     validations:
       required: true
 
   - type: textarea
-    id: technical
+    id: evidence
     attributes:
-      label: "🛠️ Dettagli tecnici"
-      placeholder: "Informazioni utili per chi lavora sul bounty"
+      label: "Verification evidence"
+      description: "Specify tests, reports, screenshots, hashes, or transaction evidence required"
+    validations:
+      required: true
+
+  - type: textarea
+    id: settlement
+    attributes:
+      label: "Settlement conditions"
+      description: "Define the rail, verifier, and evidence required before PAID may be recorded"
+    validations:
+      required: true
 
   - type: markdown
     attributes:
       value: |
         ---
-        📌 **Regole**
-        - **MYZ**: illimitato
-        - **XMR**: max 1 al giorno per utente
-        - **Un bounty alla volta** per contributor
-        - **PR entro 48h**, altrimenti l'issue viene riaperta
-        - Pagamento via gateway dopo il merge
+        **Settlement rule**
 
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        💡 **Nota:** Le issue free hanno un reward minimo di 1 MYZ.  
-        Se vuoi una ricompensa più alta, usa questo template **Bounty Issue** (senza limiti).
+        Issue closure, assignment, PR approval, merge, a gateway response,
+        screenshot, simulation, or internal ledger entry is not external
+        payment proof. `PAID` requires independently verifiable settlement
+        evidence.
+
+        Canonical policy: https://github.com/MyZubster-Ecosystem/myzubster/blob/main/BOUNTIES.md
+        Canonical ledger: https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,7 +1,7 @@
 name: Bounty Issue
 description: Propose verifiable work under the MyZubster bounty policy
 title: "Bounty - "
-labels: ["type:bounty", "status:proposed", "evidence:required", "review:manual"]
+labels: ["bounty", "help wanted"]
 body:
   - type: markdown
     attributes:

--- a/docs/LEGACY_BOUNTY_WORDING_AUDIT.md
+++ b/docs/LEGACY_BOUNTY_WORDING_AUDIT.md
@@ -1,0 +1,96 @@
+# Legacy bounty wording audit
+
+Snapshot date: 2026-08-23
+
+This audit covers the historical Gateway bounty issues named in #1380. It
+does not assert that any reward was funded, recorded, settled, or paid.
+Historical amounts are retained only as the amounts originally advertised.
+
+## Result
+
+- 38 issues inspected through the GitHub API.
+- 36 closed issues still say that payment follows a merge.
+- #257 and #389 already contain settlement clarification.
+- No issue in this audit may be treated as `PAID` without independently
+  verifiable settlement evidence.
+
+The canonical rules are [BOUNTIES.md](../BOUNTIES.md) and the ecosystem
+[rewards ledger](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md).
+An issue, PR, merge, closure, gateway response, screenshot, simulated
+transaction, or internal ledger entry is not external payment proof.
+
+## Issue inventory
+
+`Legacy wording` means that the issue still includes the statement
+"Pagamento: via gateway dopo il merge" or an equivalent automatic-payment
+implication. Amounts below are historical advertisements, not debts or proof
+of funding.
+
+| Issue | State | Historical amount | Audit status |
+| --- | --- | ---: | --- |
+| #255 | closed | 100 MYZ | Legacy wording |
+| #257 | closed | 150 MYZ | Clarification present |
+| #259 | closed | 100 MYZ | Legacy wording |
+| #261 | closed | 120 MYZ | Legacy wording |
+| #268 | closed | 40 MYZ + 10 points | Legacy wording |
+| #271 | closed | 35 MYZ + 10 points | Legacy wording |
+| #274 | closed | 50 MYZ + 10 points | Legacy wording |
+| #276 | closed | 100 MYZ | Legacy wording |
+| #277 | closed | 120 MYZ | Legacy wording |
+| #278 | closed | 150 MYZ | Legacy wording |
+| #279 | closed | 80 MYZ | Legacy wording |
+| #280 | closed | 100 MYZ | Legacy wording |
+| #281 | closed | 120 MYZ | Legacy wording |
+| #282 | closed | 150 MYZ | Legacy wording |
+| #283 | closed | 100 MYZ | Legacy wording |
+| #284 | closed | 120 MYZ | Legacy wording |
+| #338 | closed | 120 MYZ | Legacy wording |
+| #339 | closed | 150 MYZ | Legacy wording |
+| #344 | closed | 60 MYZ | Legacy wording |
+| #345 | closed | 150 MYZ | Legacy wording |
+| #347 | closed | 180 MYZ | Legacy wording |
+| #358 | closed | 150 MYZ | Legacy wording |
+| #360 | closed | 200 MYZ | Legacy wording |
+| #361 | closed | 120 MYZ | Legacy wording |
+| #362 | closed | 160 MYZ | Legacy wording |
+| #363 | closed | 100 MYZ | Legacy wording |
+| #364 | closed | 170 MYZ | Legacy wording |
+| #365 | closed | 140 MYZ | Legacy wording |
+| #366 | closed | 190 MYZ | Legacy wording |
+| #367 | closed | 130 MYZ | Legacy wording |
+| #371 | closed | 140 MYZ | Legacy wording |
+| #372 | closed | 160 MYZ | Legacy wording |
+| #373 | closed | 130 MYZ | Legacy wording |
+| #374 | closed | 110 MYZ | Legacy wording |
+| #375 | closed | 150 MYZ | Legacy wording |
+| #376 | closed | 80 MYZ | Legacy wording |
+| #377 | closed | 100 MYZ | Legacy wording |
+| #389 | closed | 1,070 MYZ program total | Clarification present |
+
+## Recommended issue-body clarification
+
+Append this block to each issue marked `Legacy wording`; retain the original
+text as historical context rather than silently rewriting the advertised
+amount:
+
+> **Settlement clarification:** The amount above is the reward originally
+> advertised. Issue closure or PR merge does not prove that the reward was
+> funded, recorded, externally settled, or paid. Use the canonical bounty
+> policy and rewards ledger to determine the current funding and reward-record
+> state. Mark `PAID` only when independently verifiable settlement evidence is
+> linked.
+
+Apply the clarification to open issues before closed issues if more legacy
+issues are discovered. Maintainers must perform issue-body edits because a PR
+cannot update historical GitHub issue bodies.
+
+## Reproduction
+
+Run the audit from the repository root:
+
+```sh
+node scripts/audit-legacy-bounty-wording.mjs
+```
+
+Set `GITHUB_TOKEN` to avoid the unauthenticated API rate limit. The command
+prints one result per issue and exits non-zero if an issue cannot be inspected.

--- a/docs/LEGACY_BOUNTY_WORDING_AUDIT.md
+++ b/docs/LEGACY_BOUNTY_WORDING_AUDIT.md
@@ -14,7 +14,9 @@ Historical amounts are retained only as the amounts originally advertised.
 - No issue in this audit may be treated as `PAID` without independently
   verifiable settlement evidence.
 
-The canonical rules are [BOUNTIES.md](../BOUNTIES.md) and the ecosystem
+The canonical rules are the ecosystem
+[BOUNTIES.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/BOUNTIES.md)
+and
 [rewards ledger](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md).
 An issue, PR, merge, closure, gateway response, screenshot, simulated
 transaction, or internal ledger entry is not external payment proof.

--- a/scripts/audit-legacy-bounty-wording.mjs
+++ b/scripts/audit-legacy-bounty-wording.mjs
@@ -1,0 +1,62 @@
+const repository = "MyZubster-Ecosystem/MyZubsterGateway";
+const issueNumbers = [
+  255, 257, 259, 261, 268, 271, 274,
+  276, 277, 278, 279, 280, 281, 282, 283, 284,
+  338, 339, 344, 345, 347, 358,
+  360, 361, 362, 363, 364, 365, 366, 367,
+  371, 372, 373, 374, 375, 376, 377, 389,
+];
+
+const automaticPaymentPattern =
+  /(?:pagamento|payment).{0,80}(?:dopo|after).{0,30}(?:merge|merged)/is;
+const clarificationPattern =
+  /(?:does.{0,12}not|non).{0,140}(?:proof|prove|prova).{0,140}(?:payment|pagamento|settlement|settled|funding|funded)/is;
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "myzubster-legacy-bounty-audit",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+if (process.env.GITHUB_TOKEN) {
+  headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+}
+
+async function inspectIssue(number) {
+  const response = await fetch(`https://api.github.com/repos/${repository}/issues/${number}`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(`#${number}: GitHub API returned ${response.status}`);
+  }
+
+  const issue = await response.json();
+  const body = issue.body ?? "";
+
+  return {
+    issue: number,
+    state: issue.state,
+    automaticPaymentWording: automaticPaymentPattern.test(body),
+    settlementClarification: clarificationPattern.test(body),
+  };
+}
+
+const results = [];
+for (const number of issueNumbers) {
+  results.push(await inspectIssue(number));
+}
+
+for (const result of results) {
+  const status = result.settlementClarification
+    ? "clarification-present"
+    : result.automaticPaymentWording
+      ? "legacy-wording"
+      : "manual-review";
+  console.log(`#${result.issue}\t${result.state}\t${status}`);
+}
+
+const legacyCount = results.filter(
+  (result) => result.automaticPaymentWording && !result.settlementClarification,
+).length;
+console.log(`inspected=${results.length} legacy=${legacyCount}`);


### PR DESCRIPTION
## Summary
- audit all 38 legacy bounty issues named in #1380
- distinguish historical advertised amounts from funding, reward-record, settlement, and payment evidence
- add a reproducible GitHub API audit script
- replace automatic-payment wording with explicit funding, acceptance, evidence, and settlement fields while retaining existing Gateway labels

## Verification
- `node scripts/audit-legacy-bounty-wording.mjs` -> `inspected=38 legacy=36`
- `git diff --check`
- verified that the `bounty` and `help wanted` labels exist in Gateway

Historical issue-body edits require maintainer permissions; the audit includes a concise clarification block. Reward amount and rail for #1380 remain unspecified, so this PR makes no payment claim.

Closes #1380