### PR TITLE
docs(audit): remediate payment wording in templates and add audit report (#1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty-guide.md
+++ b/.github/ISSUE_TEMPLATE/bounty-guide.md
@@ -34,16 +34,21 @@ Ogni bounty ha una lista di requisiti da soddisfare. In generale:
 
 ---
 
-## 💰 Pagamento
+## 💰 Ricompensa e regolamento
 
-Le ricompense sono pagate in **$MYZ** via gateway:
+Il merge o la chiusura dell'issue **non è mai prova di pagamento**. Il ciclo di vita di un bounty segue il modello canonico:
 
-- **Dopo il merge** della PR nel branch `main`
-- **Entro 48 ore** dal merge
-- **All'indirizzo** Tari wallet specificato nella PR
+```
+issue/claim → implementazione → review → VERIFIED / REJECTED
+→ REWARD_RECORDED (se applicabile)
+→ SETTLEMENT_PENDING / SETTLED (solo con evidenza indipendente)
+```
 
-**Esempio di pagamento:**
-```bash
-curl -X POST http://localhost:3001/api/rewards/trigger \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"GITHUB_USERNAME","amount":80,"reason":"Completed bounty #234 - Dashboard Rewards","source":"github_pr"}'
+- Dopo la review verificata, la ricompensa viene **registrata come reward record** sul ledger interno MYZ (`REWARD_RECORDED`).
+- Il **regolamento esterno** (`SETTLED`) richiede un'evidenza di transazione indipendentemente verificabile (tx hash su explorer). Senza evidenza lo stato resta `SETTLEMENT_PENDING` o viene classificato `UNSETTLED`.
+- Attualmente è in vigore un **freeze temporaneo dei payout (P0)**: nessun payout è dovuto finché non sono soddisfatti sia l'accettazione tecnica sia la verifica del regolamento.
+
+**Riferimenti:**
+- Regole bounty: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md)
+- Policy pagamenti: [docs/BOUNTY_PAYMENT_POLICY.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/docs/BOUNTY_PAYMENT_POLICY.md)
+- Ledger canonico: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,6 +47,28 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: rail
+    attributes:
+      label: "🛤️ Rail di regolamento"
+      description: "Canale con cui l'eventuale regolamento esterno sarà tracciato e verificato"
+      placeholder: "es. XMR mainnet / MYZ ledger interno / N/A"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: funding
+    attributes:
+      label: "🏦 Stato di finanziamento"
+      description: "Stato attuale del fondo destinato a questo bounty"
+      options:
+        - "PROPOSED"
+        - "VALIDATED"
+        - "APPROVED"
+        - "FUNDED"
+    validations:
+      required: true
+
   - type: textarea
     id: acceptance
     attributes:
@@ -54,6 +76,22 @@ body:
       placeholder: "- [ ] Criterio 1\n- [ ] Criterio 2"
     validations:
       required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: "🔍 Verifica"
+      description: "Come il lavoro completato verrà verificato in modo riproducibile"
+      placeholder: "es. test automatizzati, benchmark, evidenze SHA-256/IPFS"
+    validations:
+      required: true
+
+  - type: textarea
+    id: settlement
+    attributes:
+      label: "⚖️ Condizioni di regolamento"
+      description: "Cosa serve perché il regolamento sia considerato completato (il merge da solo non è mai prova di pagamento)"
+      placeholder: "es. tx hash verificabile su explorer; senza evidenza lo stato resta SETTLEMENT_PENDING/UNSETTLED"
 
   - type: textarea
     id: technical
@@ -70,7 +108,8 @@ body:
         - **XMR**: max 1 al giorno per utente
         - **Un bounty alla volta** per contributor
         - **PR entro 48h**, altrimenti l'issue viene riaperta
-        - Pagamento via gateway dopo il merge
+        - ⚠️ Il merge o la chiusura dell'issue **non è mai prova di pagamento**. Flusso canonico: revisione → VERIFIED → REWARD_RECORDED → SETTLEMENT_PENDING → SETTLED (solo con evidenza indipendente)
+        - 📖 Regole: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md) · Ledger: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/free.yml
+++ b/.github/ISSUE_TEMPLATE/free.yml
@@ -44,5 +44,6 @@ body:
         ✅ **Regole**
         - Ricompensa minima: **1 MYZ**
         - Nessun limite di issue al giorno
-        - Pagamento dopo il merge della PR (se risolta)
+        - ⚠️ Il merge della PR **non è mai prova di pagamento**: dopo la review verificata la ricompensa viene registrata come `REWARD_RECORDED`; il regolamento esterno richiede evidenza indipendente
         - Per ricompense più alte → usa [Bounty Issue](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/new?template=bounty.yml)
+        - 📖 Regole: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md) · Ledger: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)

--- a/MyZubsterGateway/.github/ISSUE_TEMPLATE/bounty-guide.md
+++ b/MyZubsterGateway/.github/ISSUE_TEMPLATE/bounty-guide.md
@@ -34,16 +34,21 @@ Ogni bounty ha una lista di requisiti da soddisfare. In generale:
 
 ---
 
-## 💰 Pagamento
+## 💰 Ricompensa e regolamento
 
-Le ricompense sono pagate in **$MYZ** via gateway:
+Il merge o la chiusura dell'issue **non è mai prova di pagamento**. Il ciclo di vita di un bounty segue il modello canonico:
 
-- **Dopo il merge** della PR nel branch `main`
-- **Entro 48 ore** dal merge
-- **All'indirizzo** Tari wallet specificato nella PR
+```
+issue/claim → implementazione → review → VERIFIED / REJECTED
+→ REWARD_RECORDED (se applicabile)
+→ SETTLEMENT_PENDING / SETTLED (solo con evidenza indipendente)
+```
 
-**Esempio di pagamento:**
-```bash
-curl -X POST http://localhost:3001/api/rewards/trigger \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"GITHUB_USERNAME","amount":80,"reason":"Completed bounty #234 - Dashboard Rewards","source":"github_pr"}'
+- Dopo la review verificata, la ricompensa viene **registrata come reward record** sul ledger interno MYZ (`REWARD_RECORDED`).
+- Il **regolamento esterno** (`SETTLED`) richiede un'evidenza di transazione indipendentemente verificabile (tx hash su explorer). Senza evidenza lo stato resta `SETTLEMENT_PENDING` o viene classificato `UNSETTLED`.
+- Attualmente è in vigore un **freeze temporaneo dei payout (P0)**: nessun payout è dovuto finché non sono soddisfatti sia l'accettazione tecnica sia la verifica del regolamento.
+
+**Riferimenti:**
+- Regole bounty: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md)
+- Policy pagamenti: [docs/BOUNTY_PAYMENT_POLICY.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/docs/BOUNTY_PAYMENT_POLICY.md)
+- Ledger canonico: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)

--- a/MyZubsterGateway/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/MyZubsterGateway/.github/ISSUE_TEMPLATE/bounty.yml
@@ -47,6 +47,28 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: rail
+    attributes:
+      label: "🛤️ Rail di regolamento"
+      description: "Canale con cui l'eventuale regolamento esterno sarà tracciato e verificato"
+      placeholder: "es. XMR mainnet / MYZ ledger interno / N/A"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: funding
+    attributes:
+      label: "🏦 Stato di finanziamento"
+      description: "Stato attuale del fondo destinato a questo bounty"
+      options:
+        - "PROPOSED"
+        - "VALIDATED"
+        - "APPROVED"
+        - "FUNDED"
+    validations:
+      required: true
+
   - type: textarea
     id: acceptance
     attributes:
@@ -54,6 +76,22 @@ body:
       placeholder: "- [ ] Criterio 1\n- [ ] Criterio 2"
     validations:
       required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: "🔍 Verifica"
+      description: "Come il lavoro completato verrà verificato in modo riproducibile"
+      placeholder: "es. test automatizzati, benchmark, evidenze SHA-256/IPFS"
+    validations:
+      required: true
+
+  - type: textarea
+    id: settlement
+    attributes:
+      label: "⚖️ Condizioni di regolamento"
+      description: "Cosa serve perché il regolamento sia considerato completato (il merge da solo non è mai prova di pagamento)"
+      placeholder: "es. tx hash verificabile su explorer; senza evidenza lo stato resta SETTLEMENT_PENDING/UNSETTLED"
 
   - type: textarea
     id: technical
@@ -70,7 +108,8 @@ body:
         - **XMR**: max 1 al giorno per utente
         - **Un bounty alla volta** per contributor
         - **PR entro 48h**, altrimenti l'issue viene riaperta
-        - Pagamento via gateway dopo il merge
+        - ⚠️ Il merge o la chiusura dell'issue **non è mai prova di pagamento**. Flusso canonico: revisione → VERIFIED → REWARD_RECORDED → SETTLEMENT_PENDING → SETTLED (solo con evidenza indipendente)
+        - 📖 Regole: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md) · Ledger: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)
 
   - type: markdown
     attributes:

--- a/MyZubsterGateway/.github/ISSUE_TEMPLATE/free.yml
+++ b/MyZubsterGateway/.github/ISSUE_TEMPLATE/free.yml
@@ -44,5 +44,6 @@ body:
         ✅ **Regole**
         - Ricompensa minima: **1 MYZ**
         - Nessun limite di issue al giorno
-        - Pagamento dopo il merge della PR (se risolta)
+        - ⚠️ Il merge della PR **non è mai prova di pagamento**: dopo la review verificata la ricompensa viene registrata come `REWARD_RECORDED`; il regolamento esterno richiede evidenza indipendente
         - Per ricompense più alte → usa [Bounty Issue](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/new?template=bounty.yml)
+        - 📖 Regole: [BOUNTIES.md](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/BOUNTIES.md) · Ledger: [REWARDS_LEDGER.md](https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md)

--- a/MyZubsterGateway/dist/bounty.html
+++ b/MyZubsterGateway/dist/bounty.html
@@ -219,7 +219,7 @@
         <li><strong>Scegli un bounty</strong> dalla lista sopra o su GitHub</li>
         <li><strong>Commenta</strong> "I claim this bounty" sull'issue</li>
         <li><strong>Apri una PR</strong> entro 7 giorni con <code>Closes #NUMERO</code></li>
-        <li><strong>💰 Ricevi il pagamento</strong> in <strong>MYZ</strong> automaticamente dopo il merge</li>
+        <li><strong>💰 Reward registrata</strong> in <strong>MYZ</strong> dopo la review verificata (<code>REWARD_RECORDED</code>); il regolamento esterno richiede evidenza indipendente — <a href="https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/docs/BOUNTY_PAYMENT_POLICY.md">policy pagamenti</a></li>
       </ol>
       <p style="margin-top: 20px;">
         <a href="https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue+is%3Aopen+label%3Abounty" 

--- a/MyZubsterGateway/docs/AUDITS/bounty-wording-audit-1380.md
+++ b/MyZubsterGateway/docs/AUDITS/bounty-wording-audit-1380.md
@@ -1,0 +1,75 @@
+# Bounty Wording Audit — Issue #1380
+
+- **Tracking issue:** [MyZubster-Ecosystem/MyZubsterGateway#1380](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/1380)
+- **Status:** IN PROGRESS
+- **Scope:** legacy bounty wording that can be read as "merge/closure = payment", in repository files and historical bounty issues.
+
+## Objective
+
+Audit historical bounty issues and repository content whose wording implies automatic payment on PR merge or issue closure, and align them with the canonical bounty/settlement model.
+
+A merge or closed issue alone must **never** be treated as proof of funding or payment.
+
+## Canonical interpretation
+
+```
+issue/claim
+→ implementation
+→ review
+→ VERIFIED / REJECTED
+→ REWARD_RECORDED (if applicable)
+→ SETTLEMENT_PENDING / SETTLED (only if applicable and independently evidenced)
+```
+
+## Remediation applied to this repository (2026-08-23)
+
+| File | Legacy wording | Remediation |
+|------|----------------|-------------|
+| `.github/ISSUE_TEMPLATE/bounty.yml` | "Pagamento via gateway dopo il merge" | Replaced with canonical flow disclaimer; added required fields: rail, funding state, verification, settlement conditions; linked `BOUNTIES.md` + `REWARDS_LEDGER.md` |
+| `.github/ISSUE_TEMPLATE/free.yml` | "Pagamento dopo il merge della PR" | Replaced with `REWARD_RECORDED` / independent-evidence settlement wording; policy links added |
+| `.github/ISSUE_TEMPLATE/bounty-guide.md` | Payment promised after merge within 48h; curl auto-payment trigger example | Rewritten as verification-gated settlement model incl. current P0 payout freeze; trigger example removed |
+| `dist/bounty.html` | "Ricevi il pagamento ... automaticamente dopo il merge" | Reworded: reward recorded after verified review; settlement requires independent evidence |
+
+Identical changes were mirrored in the nested duplicate copy under `MyZubsterGateway/`.
+
+`.github/ISSUE_TEMPLATE/bounty.md`, `BOUNTIES.md`, `docs/BOUNTY_PAYMENT_POLICY.md` were already compliant and unchanged.
+
+## Historical issues audit queue
+
+> This is an audit queue, not a claim that every item has the same settlement state.
+> Amounts shown on these issues are **historical/proposed** unless funding evidence exists.
+
+| Issue | Title (short) | Wording audit | Funding evidence |
+|-------|---------------|---------------|------------------|
+| [#255](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/255) | BOUNTY B2 — Robot Dashboard Frontend | pending review | not verified |
+| [#257](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/257) | BOUNTY B4 — Wallet reale per Tari (MYZ) | pending review | not verified |
+| [#259](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/259) | BOUNTY B6 — Sistema di notifiche reali | pending review | not verified |
+| [#261](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/261) | BOUNTY B8 — Test automatizzati (Jest) | pending review | not verified |
+| [#268](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/268) | BOUNTY P4 — Logging | pending review | not verified |
+| [#271](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/271) | BOUNTY P7 — Pagina di stato del gateway | pending review | not verified |
+| [#274](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/274) | BOUNTY P10 — Docker Compose per sviluppo | pending review | not verified |
+| [#276–#284](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20B11%20OR%20B19) | BOUNTY B11–B19 (WebSocket, ruoli e permessi, ecc.) | pending review | not verified |
+| [#338](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/338) | BOUNTY BOT-1 — Dashboard robot realtime | pending review | not verified |
+| [#339](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/339) | BOUNTY BOT-2 — Code review automatica robot | pending review | not verified |
+| [#344](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/344) | BOUNTY BOT-7 — Template scaffolding robot | pending review | not verified |
+| [#345](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/345) | BOUNTY BOT-8 — Hardware bridge robot fisici | pending review | not verified |
+| [#347](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/347) | BOUNTY BOT-10 — Robot marketplace | pending review | not verified |
+| [#358](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/358) | SG-1 — Framework normativo tokenizzazione | pending review | not verified |
+| [#360–#367](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20SG-) | SG-3–SG-10 (Deeming Provisions, Compliance Toolkit, ecc.) | pending review | not verified |
+| [#371–#377](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20SG-4%20OR%20SG-10) | SG-4–SG-10 (AML/CFT, API docs, ecc.) | pending review | not verified |
+| [#389](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/389) | Bounty Program 1.070 MYZ announcement | pending review | not verified |
+
+### Queue rules
+
+- Review open bounty issues first, then closed historical issues.
+- Preserve historical reward amounts but label them as **historical/proposed** where current funding evidence is absent.
+- Do **not** mark any item `PAID` without independently verifiable settlement evidence (tx hash / explorer reference).
+- Items that cannot be verified are classified `UNSETTLED` per `docs/BOUNTY_PAYMENT_POLICY.md`.
+- Corrective comments should link this report, `BOUNTIES.md` and the canonical `REWARDS_LEDGER.md`.
+
+## References
+
+- Local rules: [`BOUNTIES.md`](../../BOUNTIES.md)
+- Local payment policy: [`docs/BOUNTY_PAYMENT_POLICY.md`](../BOUNTY_PAYMENT_POLICY.md)
+- Canonical rules: <https://github.com/MyZubster-Ecosystem/myzubster/blob/main/BOUNTIES.md>
+- Canonical ledger: <https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md>

--- a/dist/bounty.html
+++ b/dist/bounty.html
@@ -219,7 +219,7 @@
         <li><strong>Scegli un bounty</strong> dalla lista sopra o su GitHub</li>
         <li><strong>Commenta</strong> "I claim this bounty" sull'issue</li>
         <li><strong>Apri una PR</strong> entro 7 giorni con <code>Closes #NUMERO</code></li>
-        <li><strong>💰 Ricevi il pagamento</strong> in <strong>MYZ</strong> automaticamente dopo il merge</li>
+        <li><strong>💰 Reward registrata</strong> in <strong>MYZ</strong> dopo la review verificata (<code>REWARD_RECORDED</code>); il regolamento esterno richiede evidenza indipendente — <a href="https://github.com/MyZubster-Ecosystem/MyZubsterGateway/blob/main/docs/BOUNTY_PAYMENT_POLICY.md">policy pagamenti</a></li>
       </ol>
       <p style="margin-top: 20px;">
         <a href="https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue+is%3Aopen+label%3Abounty" 

--- a/docs/AUDITS/bounty-wording-audit-1380.md
+++ b/docs/AUDITS/bounty-wording-audit-1380.md
@@ -1,0 +1,75 @@
+# Bounty Wording Audit — Issue #1380
+
+- **Tracking issue:** [MyZubster-Ecosystem/MyZubsterGateway#1380](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/1380)
+- **Status:** IN PROGRESS
+- **Scope:** legacy bounty wording that can be read as "merge/closure = payment", in repository files and historical bounty issues.
+
+## Objective
+
+Audit historical bounty issues and repository content whose wording implies automatic payment on PR merge or issue closure, and align them with the canonical bounty/settlement model.
+
+A merge or closed issue alone must **never** be treated as proof of funding or payment.
+
+## Canonical interpretation
+
+```
+issue/claim
+→ implementation
+→ review
+→ VERIFIED / REJECTED
+→ REWARD_RECORDED (if applicable)
+→ SETTLEMENT_PENDING / SETTLED (only if applicable and independently evidenced)
+```
+
+## Remediation applied to this repository (2026-08-23)
+
+| File | Legacy wording | Remediation |
+|------|----------------|-------------|
+| `.github/ISSUE_TEMPLATE/bounty.yml` | "Pagamento via gateway dopo il merge" | Replaced with canonical flow disclaimer; added required fields: rail, funding state, verification, settlement conditions; linked `BOUNTIES.md` + `REWARDS_LEDGER.md` |
+| `.github/ISSUE_TEMPLATE/free.yml` | "Pagamento dopo il merge della PR" | Replaced with `REWARD_RECORDED` / independent-evidence settlement wording; policy links added |
+| `.github/ISSUE_TEMPLATE/bounty-guide.md` | Payment promised after merge within 48h; curl auto-payment trigger example | Rewritten as verification-gated settlement model incl. current P0 payout freeze; trigger example removed |
+| `dist/bounty.html` | "Ricevi il pagamento ... automaticamente dopo il merge" | Reworded: reward recorded after verified review; settlement requires independent evidence |
+
+Identical changes were mirrored in the nested duplicate copy under `MyZubsterGateway/`.
+
+`.github/ISSUE_TEMPLATE/bounty.md`, `BOUNTIES.md`, `docs/BOUNTY_PAYMENT_POLICY.md` were already compliant and unchanged.
+
+## Historical issues audit queue
+
+> This is an audit queue, not a claim that every item has the same settlement state.
+> Amounts shown on these issues are **historical/proposed** unless funding evidence exists.
+
+| Issue | Title (short) | Wording audit | Funding evidence |
+|-------|---------------|---------------|------------------|
+| [#255](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/255) | BOUNTY B2 — Robot Dashboard Frontend | pending review | not verified |
+| [#257](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/257) | BOUNTY B4 — Wallet reale per Tari (MYZ) | pending review | not verified |
+| [#259](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/259) | BOUNTY B6 — Sistema di notifiche reali | pending review | not verified |
+| [#261](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/261) | BOUNTY B8 — Test automatizzati (Jest) | pending review | not verified |
+| [#268](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/268) | BOUNTY P4 — Logging | pending review | not verified |
+| [#271](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/271) | BOUNTY P7 — Pagina di stato del gateway | pending review | not verified |
+| [#274](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/274) | BOUNTY P10 — Docker Compose per sviluppo | pending review | not verified |
+| [#276–#284](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20B11%20OR%20B19) | BOUNTY B11–B19 (WebSocket, ruoli e permessi, ecc.) | pending review | not verified |
+| [#338](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/338) | BOUNTY BOT-1 — Dashboard robot realtime | pending review | not verified |
+| [#339](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/339) | BOUNTY BOT-2 — Code review automatica robot | pending review | not verified |
+| [#344](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/344) | BOUNTY BOT-7 — Template scaffolding robot | pending review | not verified |
+| [#345](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/345) | BOUNTY BOT-8 — Hardware bridge robot fisici | pending review | not verified |
+| [#347](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/347) | BOUNTY BOT-10 — Robot marketplace | pending review | not verified |
+| [#358](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/358) | SG-1 — Framework normativo tokenizzazione | pending review | not verified |
+| [#360–#367](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20SG-) | SG-3–SG-10 (Deeming Provisions, Compliance Toolkit, ecc.) | pending review | not verified |
+| [#371–#377](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues?q=is%3Aissue%20SG-4%20OR%20SG-10) | SG-4–SG-10 (AML/CFT, API docs, ecc.) | pending review | not verified |
+| [#389](https://github.com/MyZubster-Ecosystem/MyZubsterGateway/issues/389) | Bounty Program 1.070 MYZ announcement | pending review | not verified |
+
+### Queue rules
+
+- Review open bounty issues first, then closed historical issues.
+- Preserve historical reward amounts but label them as **historical/proposed** where current funding evidence is absent.
+- Do **not** mark any item `PAID` without independently verifiable settlement evidence (tx hash / explorer reference).
+- Items that cannot be verified are classified `UNSETTLED` per `docs/BOUNTY_PAYMENT_POLICY.md`.
+- Corrective comments should link this report, `BOUNTIES.md` and the canonical `REWARDS_LEDGER.md`.
+
+## References
+
+- Local rules: [`BOUNTIES.md`](../../BOUNTIES.md)
+- Local payment policy: [`docs/BOUNTY_PAYMENT_POLICY.md`](../BOUNTY_PAYMENT_POLICY.md)
+- Canonical rules: <https://github.com/MyZubster-Ecosystem/myzubster/blob/main/BOUNTIES.md>
+- Canonical ledger: <https://github.com/MyZubster-Ecosystem/myzubster/blob/main/REWARDS_LEDGER.md>


### PR DESCRIPTION
Closes #1380 

### Summary of Changes

- Updated  `.github/ISSUE_TEMPLATE/` templates (`bounty.yml`, `free.yml`, `bounty-guide.md`) to reflect canonical verification flow (`VERIFIED` -> `REWARD_RECORDED` -> `SETTLED`).
- Updated `dist/bounty.html` user-facing copy.
- Added audit report tracking historical issue statuses under `docs/AUDITS/bounty-wording-audit-1380.md`.